### PR TITLE
Add OpenXR extension wrappers for fb_scene, fb_spatial_entity, fb_spatial_entity_query, fb_spatial_entity_container

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,3 +10,4 @@ This plugin has been developed by or received contributions from:
 - [Daniel Castellanos](https://github.com/decacis)
 - [Rodolphe Houdas](https://github.com/rodolpheh)
 - [Tiago Zaccaro](https://github.com/tiagozaccaro)
+- [Mauricio Narvaez](https://github.com/maunvz)

--- a/common/src/main/cpp/util.h
+++ b/common/src/main/cpp/util.h
@@ -118,4 +118,6 @@
 		return (*func_name##_ptr)(p_##arg1, p_##arg2, p_##arg3, p_##arg4, p_##arg5, p_##arg6);                                                                                                                         \
 	}
 
+#define SESSION  (XrSession) get_openxr_api()->get_session()
+
 #endif // UTIL_H

--- a/godotopenxrmeta/src/main/cpp/export/meta_export_plugin.cpp
+++ b/godotopenxrmeta/src/main/cpp/export/meta_export_plugin.cpp
@@ -104,6 +104,16 @@ MetaEditorExportPlugin::MetaEditorExportPlugin() {
 			false,
 			false
 	);
+	_use_scene_api_option = _generate_export_option(
+			"meta_xr_features/use_scene_api",
+			"",
+			Variant::Type::BOOL,
+			PROPERTY_HINT_NONE,
+			"",
+			PROPERTY_USAGE_DEFAULT,
+			false,
+			false
+	);
 	_support_quest_1_option = _generate_export_option(
 			"meta_xr_features/quest_1_support",
 			"",
@@ -160,6 +170,7 @@ TypedArray<Dictionary> MetaEditorExportPlugin::_get_export_options(const Ref<Edi
 	export_options.append(_hand_tracking_frequency_option);
 	export_options.append(_passthrough_option);
 	export_options.append(_use_anchor_api_option);
+	export_options.append(_use_scene_api_option);
 	export_options.append(_support_quest_1_option);
 	export_options.append(_support_quest_2_option);
 	export_options.append(_support_quest_3_option);
@@ -238,6 +249,10 @@ String MetaEditorExportPlugin::_get_export_option_warning(const Ref<EditorExport
 		if (!openxr_enabled && _get_bool_option(option)) {
 			return "\"Use anchor API\" is only valid when \"XR Mode\" is \"OpenXR\".\n";
 		}
+	} else if (option == "meta_xr_features/use_scene_api") {
+		if (!openxr_enabled && _get_bool_option(option)) {
+			return "\"Use scene API\" is only valid when \"XR Mode\" is \"OpenXR\".\n";
+		}
 	}
 
 	return OpenXREditorExportPlugin::_get_export_option_warning(platform, option);
@@ -285,6 +300,12 @@ String MetaEditorExportPlugin::_get_android_manifest_element_contents(const Ref<
 	bool use_anchor_api = _get_bool_option("meta_xr_features/use_anchor_api");
 	if (use_anchor_api) {
 		contents += "    <uses-permission android:name=\"com.oculus.permission.USE_ANCHOR_API\" />\n";
+	}
+
+	// Check for scene api
+	bool use_scene_api = _get_bool_option("meta_xr_features/use_scene_api");
+	if (use_scene_api) {
+		contents += "    <uses-permission android:name=\"com.oculus.permission.USE_SCENE\" />\n";
 	}
 
 	return contents;

--- a/godotopenxrmeta/src/main/cpp/export/meta_export_plugin.h
+++ b/godotopenxrmeta/src/main/cpp/export/meta_export_plugin.h
@@ -83,6 +83,7 @@ private:
 	Dictionary _hand_tracking_frequency_option;
 	Dictionary _passthrough_option;
 	Dictionary _use_anchor_api_option;
+	Dictionary _use_scene_api_option;
 	Dictionary _support_quest_1_option;
 	Dictionary _support_quest_2_option;
 	Dictionary _support_quest_3_option;

--- a/godotopenxrmeta/src/main/cpp/include/openxr_fb_scene_extension_wrapper.h
+++ b/godotopenxrmeta/src/main/cpp/include/openxr_fb_scene_extension_wrapper.h
@@ -1,0 +1,121 @@
+/**************************************************************************/
+/*  openxr_fb_scene_extension_wrapper.h                                   */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
+#include <openxr/openxr.h>
+#include <openxr/fb_scene.h>
+#include <godot_cpp/templates/hash_map.hpp>
+#include <godot_cpp/templates/vector.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+#include "util.h"
+
+#include <optional>
+#include <map>
+
+using namespace godot;
+
+struct XrSceneObjectInternal {
+	XrUuidEXT uuid;
+	XrSpace space;
+	std::optional<String> label;
+
+	// Vertices and lines on a plane, probably use this for a floor / ceiling as they are irregularly shaped
+	// We store a std::vector instead of XrBoundary2DFB to own the vertex memory
+	std::optional<Vector<XrVector2f>> boundary2D;
+	// A rectangle containing the whole thing, perfect for desks / tables / play surfaces
+	std::optional<XrRect2Df> boundingBox2D;
+	// 3D box for the whole thing, better for obstacles and other objects not used as a surface
+	std::optional<XrRect3DfFB> boundingBox3D;
+};
+
+// Wrapper for the set of Facebook XR scene extension.
+class OpenXRFbSceneExtensionWrapper : public OpenXRExtensionWrapperExtension {
+	GDCLASS(OpenXRFbSceneExtensionWrapper, OpenXRExtensionWrapperExtension);
+
+public:
+	Dictionary _get_requested_extensions() override;
+
+	void _on_instance_created(uint64_t instance) override;
+
+	void _on_instance_destroyed() override;
+
+	bool is_scene_supported() {
+		return fb_scene_ext;
+	}
+
+	static OpenXRFbSceneExtensionWrapper *get_singleton();
+
+	OpenXRFbSceneExtensionWrapper();
+	~OpenXRFbSceneExtensionWrapper();
+
+	std::optional<String> get_semantic_labels(const XrSpace& space);
+	void get_shapes(const XrSpace& space, XrSceneObjectInternal& object);
+
+protected:
+	static void _bind_methods();
+
+private:
+	EXT_PROTO_XRRESULT_FUNC3(xrGetSpaceBoundingBox2DFB,
+			(XrSession), session,
+			(XrSpace), space,
+			(XrRect2Df *), boundingBox2DOutput)
+
+	EXT_PROTO_XRRESULT_FUNC3(xrGetSpaceBoundingBox3DFB,
+			(XrSession), session,
+			(XrSpace), space,
+			(XrRect3DfFB *), boundingBox3DOutput)
+
+	EXT_PROTO_XRRESULT_FUNC3(xrGetSpaceSemanticLabelsFB,
+			(XrSession), session,
+			(XrSpace), space,
+			(XrSemanticLabelsFB *), semanticLabelsOutput)
+
+	EXT_PROTO_XRRESULT_FUNC3(xrGetSpaceBoundary2DFB,
+			(XrSession), session,
+			(XrSpace), space,
+			(XrBoundary2DFB *), boundary2DOutput)
+
+	EXT_PROTO_XRRESULT_FUNC3(xrGetSpaceRoomLayoutFB,
+			(XrSession), session,
+			(XrSpace), space,
+			(XrRoomLayoutFB *), roomLayoutOutput)
+
+	bool initialize_fb_scene_extension(const XrInstance instance);
+
+	HashMap<String, bool *> request_extensions;
+
+	void cleanup();
+
+	static OpenXRFbSceneExtensionWrapper *singleton;
+
+	bool fb_scene_ext = false;
+};

--- a/godotopenxrmeta/src/main/cpp/include/openxr_fb_spatial_entity_container_extension_wrapper.h
+++ b/godotopenxrmeta/src/main/cpp/include/openxr_fb_spatial_entity_container_extension_wrapper.h
@@ -1,0 +1,86 @@
+/**************************************************************************/
+/*  openxr_fb_spatial_entity_container_extension_wrapper.h                */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
+#include <openxr/openxr.h>
+#include <openxr/fb_spatial_entity_container.h>
+#include <godot_cpp/templates/hash_map.hpp>
+#include <godot_cpp/templates/vector.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+#include "util.h"
+
+#include <functional>
+#include <map>
+
+using namespace godot;
+
+// Wrapper for the set of Facebook XR spatial entity container extension.
+class OpenXRFbSpatialEntityContainerExtensionWrapper : public OpenXRExtensionWrapperExtension {
+	GDCLASS(OpenXRFbSpatialEntityContainerExtensionWrapper, OpenXRExtensionWrapperExtension);
+
+public:
+	Dictionary _get_requested_extensions() override;
+
+	void _on_instance_created(uint64_t instance) override;
+
+	void _on_instance_destroyed() override;
+
+	bool is_spatial_entity_container_supported() {
+		return fb_spatial_entity_container_ext;
+	}
+
+	static OpenXRFbSpatialEntityContainerExtensionWrapper *get_singleton();
+
+	Vector<XrUuidEXT> get_contained_uuids(const XrSpace& space);
+
+	OpenXRFbSpatialEntityContainerExtensionWrapper();
+	~OpenXRFbSpatialEntityContainerExtensionWrapper();
+
+protected:
+	static void _bind_methods();
+
+private:
+	EXT_PROTO_XRRESULT_FUNC3(xrGetSpaceContainerFB,
+			(XrSession), session,
+			(XrSpace), space,
+			(XrSpaceContainerFB *), spaceContainerOutput)
+
+	bool initialize_fb_spatial_entity_container_extension(const XrInstance& instance);
+
+	HashMap<String, bool *> request_extensions;
+
+	void cleanup();
+
+	static OpenXRFbSpatialEntityContainerExtensionWrapper *singleton;
+
+	bool fb_spatial_entity_container_ext = false;
+};

--- a/godotopenxrmeta/src/main/cpp/include/openxr_fb_spatial_entity_extension_wrapper.h
+++ b/godotopenxrmeta/src/main/cpp/include/openxr_fb_spatial_entity_extension_wrapper.h
@@ -1,0 +1,124 @@
+/**************************************************************************/
+/*  openxr_fb_spatial_entity_extension_wrapper.h                          */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
+#include <openxr/openxr.h>
+#include <openxr/fb_spatial_entity.h>
+#include <godot_cpp/templates/hash_map.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+#include "util.h"
+
+#include <functional>
+#include <map>
+#include <optional>
+
+using namespace godot;
+
+typedef std::function<void(const XrEventDataSpaceSetStatusCompleteFB* eventData)> SetSpaceComponentStatusCallback_t;
+
+// Wrapper for the set of Facebook XR spatial entity extension.
+class OpenXRFbSpatialEntityExtensionWrapper : public OpenXRExtensionWrapperExtension {
+	GDCLASS(OpenXRFbSpatialEntityExtensionWrapper, OpenXRExtensionWrapperExtension);
+
+public:
+	Dictionary _get_requested_extensions() override;
+
+	void _on_instance_created(uint64_t instance) override;
+
+	void _on_instance_destroyed() override;
+
+	bool is_spatial_entity_supported() {
+		return fb_spatial_entity_ext;
+	}
+
+	bool is_component_supported(const XrSpace& space, XrSpaceComponentTypeFB type);
+	bool is_component_enabled(const XrSpace& space, XrSpaceComponentTypeFB type);
+
+	// Attempts to set the enabled status for the given component of an XrSpace. The callback will
+	// run to deliver results, with an arg of either:
+	// - nullptr on immediate failure
+	// - A valid XrEventDataSpaceSetStatusCompleteFB* delivered by the runtime later on
+	// Both cases should be handled, and the second may still indicate an error depending on the
+	// contained XrResult.
+	void set_component_enabled(
+		const XrSpace& space,
+		XrSpaceComponentTypeFB type,
+		bool status,
+		std::optional<SetSpaceComponentStatusCallback_t> callback = std::nullopt);
+
+	virtual bool _on_event_polled(const void *event) override;
+
+	static OpenXRFbSpatialEntityExtensionWrapper *get_singleton();
+
+	OpenXRFbSpatialEntityExtensionWrapper();
+	~OpenXRFbSpatialEntityExtensionWrapper();
+
+protected:
+	static void _bind_methods();
+
+private:
+	EXT_PROTO_XRRESULT_FUNC3(xrCreateSpatialAnchorFB,
+			(XrSession), session,
+			(const XrSpatialAnchorCreateInfoFB *), request,
+			(XrAsyncRequestIdFB *), requestId)
+
+	EXT_PROTO_XRRESULT_FUNC2(xrGetSpaceUuidFB,
+			(XrSpace), space,
+			(XrUuidEXT *), uuid)
+
+	EXT_PROTO_XRRESULT_FUNC4(xrEnumerateSpaceSupportedComponentsFB,
+			(XrSpace), space,
+			(uint32_t), componentTypeCapacityInput,
+			(uint32_t *), componentTypeCountOutput,
+			(XrSpaceComponentTypeFB *), componentTypes)
+
+	EXT_PROTO_XRRESULT_FUNC3(xrSetSpaceComponentStatusFB,
+			(XrSpace), space,
+			(const XrSpaceComponentStatusSetInfoFB *), info,
+			(XrAsyncRequestIdFB *), requestId)
+
+	EXT_PROTO_XRRESULT_FUNC3(xrGetSpaceComponentStatusFB,
+			(XrSpace), space,
+			(XrSpaceComponentTypeFB), componentType,
+			(XrSpaceComponentStatusFB *), status)
+
+	bool initialize_fb_spatial_entity_extension(const XrInstance& instance);
+
+	HashMap<String, bool *> request_extensions;
+	HashMap<XrAsyncRequestIdFB, SetSpaceComponentStatusCallback_t> set_status_callbacks;
+
+	void cleanup();
+
+	static OpenXRFbSpatialEntityExtensionWrapper *singleton;
+
+	bool fb_spatial_entity_ext = false;
+};

--- a/godotopenxrmeta/src/main/cpp/include/openxr_fb_spatial_entity_query_extension_wrapper.h
+++ b/godotopenxrmeta/src/main/cpp/include/openxr_fb_spatial_entity_query_extension_wrapper.h
@@ -1,0 +1,102 @@
+/**************************************************************************/
+/*  openxr_fb_spatial_entity_query_extension_wrapper.h                    */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
+#include <openxr/openxr.h>
+#include <openxr/fb_spatial_entity.h>
+#include <openxr/fb_spatial_entity_query.h>
+#include <godot_cpp/templates/hash_map.hpp>
+#include <godot_cpp/templates/vector.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+#include "util.h"
+
+#include <functional>
+#include <map>
+
+using namespace godot;
+
+typedef std::function<void(Vector<XrSpaceQueryResultFB>)> SpaceQueryCompleteCallback_t;
+
+// Wrapper for the set of Facebook XR spatial entity query extension.
+class OpenXRFbSpatialEntityQueryExtensionWrapper : public OpenXRExtensionWrapperExtension {
+	GDCLASS(OpenXRFbSpatialEntityQueryExtensionWrapper, OpenXRExtensionWrapperExtension);
+
+public:
+	Dictionary _get_requested_extensions() override;
+
+	void _on_instance_created(uint64_t instance) override;
+
+	void _on_instance_destroyed() override;
+
+	bool is_spatial_entity_query_supported() {
+		return fb_spatial_entity_query_ext;
+	}
+
+	virtual bool _on_event_polled(const void *event) override;
+
+	static OpenXRFbSpatialEntityQueryExtensionWrapper *get_singleton();
+
+	// Attempts to query spatial entities given an XrSpaceQueryInfoFB. The callback will run to
+	// deliver results when they are available.
+	void query_spatial_entities(const XrSpaceQueryInfoBaseHeaderFB* info, SpaceQueryCompleteCallback_t callback);
+
+	OpenXRFbSpatialEntityQueryExtensionWrapper();
+	~OpenXRFbSpatialEntityQueryExtensionWrapper();
+
+protected:
+	static void _bind_methods();
+
+private:
+	EXT_PROTO_XRRESULT_FUNC3(xrQuerySpacesFB,
+			(XrSession), session,
+			(const XrSpaceQueryInfoBaseHeaderFB *), info,
+			(XrAsyncRequestIdFB *), requestId)
+
+	EXT_PROTO_XRRESULT_FUNC3(xrRetrieveSpaceQueryResultsFB,
+			(XrSession), session,
+			(XrAsyncRequestIdFB), requestId,
+			(XrSpaceQueryResultsFB *), results)
+
+	bool initialize_fb_spatial_entity_query_extension(const XrInstance& instance);
+	void on_space_query_results(const XrEventDataSpaceQueryResultsAvailableFB* event);
+	void on_space_query_complete(const XrEventDataSpaceQueryCompleteFB* event);
+
+	HashMap<XrAsyncRequestIdFB, Vector<XrSpaceQueryResultFB>> query_results;
+	HashMap<String, bool *> request_extensions;
+	HashMap<XrAsyncRequestIdFB, SpaceQueryCompleteCallback_t> query_complete_callbacks;
+
+	void cleanup();
+
+	static OpenXRFbSpatialEntityQueryExtensionWrapper *singleton;
+
+	bool fb_spatial_entity_query_ext = false;
+};

--- a/godotopenxrmeta/src/main/cpp/openxr_fb_scene_extension_wrapper.cpp
+++ b/godotopenxrmeta/src/main/cpp/openxr_fb_scene_extension_wrapper.cpp
@@ -1,0 +1,164 @@
+/**************************************************************************/
+/*  openxr_fb_scene_extension_wrapper.cpp                                 */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "include/openxr_fb_scene_extension_wrapper.h"
+
+#include <godot_cpp/variant/utility_functions.hpp>
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
+#include <godot_cpp/classes/object.hpp>
+
+#include "include/openxr_fb_spatial_entity_extension_wrapper.h"
+
+using namespace godot;
+
+OpenXRFbSceneExtensionWrapper *OpenXRFbSceneExtensionWrapper::singleton = nullptr;
+
+OpenXRFbSceneExtensionWrapper *OpenXRFbSceneExtensionWrapper::get_singleton() {
+	if (singleton == nullptr) {
+		singleton = memnew(OpenXRFbSceneExtensionWrapper());
+	}
+	return singleton;
+}
+
+OpenXRFbSceneExtensionWrapper::OpenXRFbSceneExtensionWrapper() :
+		OpenXRExtensionWrapperExtension() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "An OpenXRFbSceneExtensionWrapper singleton already exists.");
+
+	request_extensions[XR_FB_SCENE_EXTENSION_NAME] = &fb_scene_ext;
+	singleton = this;
+}
+
+OpenXRFbSceneExtensionWrapper::~OpenXRFbSceneExtensionWrapper() {
+	cleanup();
+}
+
+void OpenXRFbSceneExtensionWrapper::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_scene_supported"), &OpenXRFbSceneExtensionWrapper::is_scene_supported);
+}
+
+void OpenXRFbSceneExtensionWrapper::cleanup() {
+	fb_scene_ext = false;
+}
+
+Dictionary OpenXRFbSceneExtensionWrapper::_get_requested_extensions() {
+	Dictionary result;
+	for (auto ext: request_extensions) {
+		uint64_t value = reinterpret_cast<uint64_t>(ext.value);
+		result[ext.key] = (Variant)value;
+	}
+	return result;
+}
+
+void OpenXRFbSceneExtensionWrapper::_on_instance_created(uint64_t instance) {
+	if (fb_scene_ext) {
+		bool result = initialize_fb_scene_extension((XrInstance)instance);
+		if (!result) {
+			UtilityFunctions::print("Failed to initialize fb_scene extension");
+			fb_scene_ext = false;
+		}
+	}
+}
+
+void OpenXRFbSceneExtensionWrapper::_on_instance_destroyed() {
+	cleanup();
+}
+
+std::optional<String> OpenXRFbSceneExtensionWrapper::get_semantic_labels(const XrSpace& space) {
+	if (!OpenXRFbSpatialEntityExtensionWrapper::get_singleton()->is_component_enabled(space, XR_SPACE_COMPONENT_TYPE_SEMANTIC_LABELS_FB)) {
+		return std::nullopt;
+	}
+
+	// List from https://developer.oculus.com/documentation/native/android/mobile-scene-api-ref/
+	static const CharString recognizedLabels =
+			"CEILING,DOOR_FRAME,FLOOR,INVISIBLE_WALL_FACE,WALL_ART,WALL_FACE,WINDOW_FRAME,COUCH,TABLE,BED,LAMP,PLANT,SCREEN,STORAGE,GLOBAL_MESH,OTHER";
+	const XrSemanticLabelsSupportInfoFB semanticLabelsSupportInfo = {
+		XR_TYPE_SEMANTIC_LABELS_SUPPORT_INFO_FB,
+		nullptr,
+		XR_SEMANTIC_LABELS_SUPPORT_MULTIPLE_SEMANTIC_LABELS_BIT_FB | XR_SEMANTIC_LABELS_SUPPORT_ACCEPT_DESK_TO_TABLE_MIGRATION_BIT_FB |
+		XR_SEMANTIC_LABELS_SUPPORT_ACCEPT_INVISIBLE_WALL_FACE_BIT_FB,
+		recognizedLabels.ptr(),
+	};
+
+	XrSemanticLabelsFB labels = {XR_TYPE_SEMANTIC_LABELS_FB, &semanticLabelsSupportInfo, 0};
+
+	// First call.
+	xrGetSpaceSemanticLabelsFB(SESSION, space, &labels);
+	// Second call
+	Vector<char> labelData;
+	labelData.resize(labels.bufferCountOutput);
+	labels.bufferCapacityInput = labelData.size();
+	labels.buffer = labelData.ptrw();
+	xrGetSpaceSemanticLabelsFB(SESSION, space, &labels);
+
+	// std::string necessary since buffer may not be null terminated
+	return String(std::string(labels.buffer, labels.bufferCountOutput).c_str());
+}
+
+void OpenXRFbSceneExtensionWrapper::get_shapes(const XrSpace& space, XrSceneObjectInternal& object) {
+	if (OpenXRFbSpatialEntityExtensionWrapper::get_singleton()->is_component_enabled(space, XR_SPACE_COMPONENT_TYPE_BOUNDED_2D_FB)) {
+		//  Grab both the bounding box 2D and the boundary
+		XrRect2Df boundingBox2D;
+		if (XR_SUCCEEDED(xrGetSpaceBoundingBox2DFB(SESSION, space, &boundingBox2D))) {
+			object.boundingBox2D = boundingBox2D;
+		}
+
+		XrBoundary2DFB boundary2D = {XR_TYPE_BOUNDARY_2D_FB, nullptr, 0};
+		if (XR_SUCCEEDED(xrGetSpaceBoundary2DFB(SESSION, space, &boundary2D))) {
+			Vector<XrVector2f> vertices;
+			vertices.resize(boundary2D.vertexCountOutput);
+			boundary2D.vertexCapacityInput = vertices.size();
+			boundary2D.vertices = vertices.ptrw();
+			if (XR_SUCCEEDED(xrGetSpaceBoundary2DFB(SESSION, space, &boundary2D))) {
+				object.boundary2D = vertices;
+			}
+		}
+	}
+
+	if (OpenXRFbSpatialEntityExtensionWrapper::get_singleton()->is_component_enabled(space, XR_SPACE_COMPONENT_TYPE_BOUNDED_3D_FB)) {
+		XrRect3DfFB boundingBox3D;
+		if (XR_SUCCEEDED(xrGetSpaceBoundingBox3DFB(SESSION, space, &boundingBox3D))) {
+			object.boundingBox3D = boundingBox3D;
+		}
+	}
+
+	// TODO: Need to enable the extension for this
+	// if (is_component_enabled(space, XR_SPACE_COMPONENT_TYPE_TRIANGLE_MESH_META)) {
+	// 	WARN_PRINT("Found component with XR_SPACE_COMPONENT_TYPE_TRIANGLE_MESH_META");
+	// }
+}
+
+bool OpenXRFbSceneExtensionWrapper::initialize_fb_scene_extension(const XrInstance p_instance) {
+	GDEXTENSION_INIT_XR_FUNC_V(xrGetSpaceBoundingBox2DFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrGetSpaceBoundingBox3DFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrGetSpaceSemanticLabelsFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrGetSpaceBoundary2DFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrGetSpaceRoomLayoutFB);
+
+	return true;
+}

--- a/godotopenxrmeta/src/main/cpp/openxr_fb_spatial_entity_container_extension_wrapper.cpp
+++ b/godotopenxrmeta/src/main/cpp/openxr_fb_spatial_entity_container_extension_wrapper.cpp
@@ -1,0 +1,103 @@
+/**************************************************************************/
+/*  openxr_fb_spatial_entity_container_extension_wrapper.cpp              */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "include/openxr_fb_spatial_entity_container_extension_wrapper.h"
+#include <godot_cpp/variant/utility_functions.hpp>
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
+#include <godot_cpp/classes/object.hpp>
+
+using namespace godot;
+
+OpenXRFbSpatialEntityContainerExtensionWrapper *OpenXRFbSpatialEntityContainerExtensionWrapper::singleton = nullptr;
+
+OpenXRFbSpatialEntityContainerExtensionWrapper *OpenXRFbSpatialEntityContainerExtensionWrapper::get_singleton() {
+	if (singleton == nullptr) {
+		singleton = memnew(OpenXRFbSpatialEntityContainerExtensionWrapper());
+	}
+	return singleton;
+}
+
+OpenXRFbSpatialEntityContainerExtensionWrapper::OpenXRFbSpatialEntityContainerExtensionWrapper() :
+		OpenXRExtensionWrapperExtension() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "An OpenXRFbSpatialEntityContainerExtensionWrapper singleton already exists.");
+
+	request_extensions[XR_FB_SPATIAL_ENTITY_CONTAINER_EXTENSION_NAME] = &fb_spatial_entity_container_ext;
+	singleton = this;
+}
+
+OpenXRFbSpatialEntityContainerExtensionWrapper::~OpenXRFbSpatialEntityContainerExtensionWrapper() {
+	cleanup();
+}
+
+void OpenXRFbSpatialEntityContainerExtensionWrapper::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_spatial_entity_container_supported"), &OpenXRFbSpatialEntityContainerExtensionWrapper::is_spatial_entity_container_supported);
+}
+
+void OpenXRFbSpatialEntityContainerExtensionWrapper::cleanup() {
+	fb_spatial_entity_container_ext = false;
+}
+
+Dictionary OpenXRFbSpatialEntityContainerExtensionWrapper::_get_requested_extensions() {
+	Dictionary result;
+	for (auto ext: request_extensions) {
+		uint64_t value = reinterpret_cast<uint64_t>(ext.value);
+		result[ext.key] = (Variant)value;
+	}
+	return result;
+}
+
+void OpenXRFbSpatialEntityContainerExtensionWrapper::_on_instance_created(uint64_t instance) {
+	if (fb_spatial_entity_container_ext) {
+		bool result = initialize_fb_spatial_entity_container_extension((XrInstance)instance);
+		if (!result) {
+			UtilityFunctions::print("Failed to initialize fb_spatial_entity_container extension");
+			fb_spatial_entity_container_ext = false;
+		}
+	}
+}
+
+void OpenXRFbSpatialEntityContainerExtensionWrapper::_on_instance_destroyed() {
+	cleanup();
+}
+
+bool OpenXRFbSpatialEntityContainerExtensionWrapper::initialize_fb_spatial_entity_container_extension(const XrInstance& p_instance) {
+	GDEXTENSION_INIT_XR_FUNC_V(xrGetSpaceContainerFB);
+	return true;
+}
+
+Vector<XrUuidEXT> OpenXRFbSpatialEntityContainerExtensionWrapper::get_contained_uuids(const XrSpace& space) {
+	XrSpaceContainerFB spaceContainer = {XR_TYPE_SPACE_CONTAINER_FB};
+	xrGetSpaceContainerFB(SESSION, space, &spaceContainer);
+	Vector<XrUuidEXT> uuids;
+	uuids.resize(spaceContainer.uuidCountOutput);
+	spaceContainer.uuidCapacityInput = uuids.size();
+	spaceContainer.uuids = uuids.ptrw();
+	xrGetSpaceContainerFB(SESSION, space, &spaceContainer);
+	return uuids;
+}

--- a/godotopenxrmeta/src/main/cpp/openxr_fb_spatial_entity_extension_wrapper.cpp
+++ b/godotopenxrmeta/src/main/cpp/openxr_fb_spatial_entity_extension_wrapper.cpp
@@ -1,0 +1,157 @@
+/**************************************************************************/
+/*  openxr_fb_spatial_entity_extension_wrapper.cpp                        */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "include/openxr_fb_spatial_entity_extension_wrapper.h"
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
+#include <godot_cpp/classes/object.hpp>
+#include <godot_cpp/templates/vector.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+using namespace godot;
+
+OpenXRFbSpatialEntityExtensionWrapper *OpenXRFbSpatialEntityExtensionWrapper::singleton = nullptr;
+
+OpenXRFbSpatialEntityExtensionWrapper *OpenXRFbSpatialEntityExtensionWrapper::get_singleton() {
+	if (singleton == nullptr) {
+		singleton = memnew(OpenXRFbSpatialEntityExtensionWrapper());
+	}
+	return singleton;
+}
+
+OpenXRFbSpatialEntityExtensionWrapper::OpenXRFbSpatialEntityExtensionWrapper() :
+		OpenXRExtensionWrapperExtension() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "An OpenXRFbSpatialEntityExtensionWrapper singleton already exists.");
+
+	request_extensions[XR_FB_SPATIAL_ENTITY_EXTENSION_NAME] = &fb_spatial_entity_ext;
+	singleton = this;
+}
+
+OpenXRFbSpatialEntityExtensionWrapper::~OpenXRFbSpatialEntityExtensionWrapper() {
+	cleanup();
+}
+
+void OpenXRFbSpatialEntityExtensionWrapper::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_spatial_entity_supported"), &OpenXRFbSpatialEntityExtensionWrapper::is_spatial_entity_supported);
+}
+
+void OpenXRFbSpatialEntityExtensionWrapper::cleanup() {
+	fb_spatial_entity_ext = false;
+}
+
+Dictionary OpenXRFbSpatialEntityExtensionWrapper::_get_requested_extensions() {
+	Dictionary result;
+	for (auto ext: request_extensions) {
+		uint64_t value = reinterpret_cast<uint64_t>(ext.value);
+		result[ext.key] = (Variant)value;
+	}
+	return result;
+}
+
+void OpenXRFbSpatialEntityExtensionWrapper::_on_instance_created(uint64_t instance) {
+	if (fb_spatial_entity_ext) {
+		bool result = initialize_fb_spatial_entity_extension((XrInstance)instance);
+		if (!result) {
+			UtilityFunctions::print("Failed to initialize fb_spatial_entity extension");
+			fb_spatial_entity_ext = false;
+		}
+	}
+}
+
+void OpenXRFbSpatialEntityExtensionWrapper::_on_instance_destroyed() {
+	cleanup();
+}
+
+bool OpenXRFbSpatialEntityExtensionWrapper::initialize_fb_spatial_entity_extension(const XrInstance& p_instance) {
+	GDEXTENSION_INIT_XR_FUNC_V(xrCreateSpatialAnchorFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrGetSpaceUuidFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrEnumerateSpaceSupportedComponentsFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrSetSpaceComponentStatusFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrGetSpaceComponentStatusFB);
+
+	return true;
+}
+
+bool OpenXRFbSpatialEntityExtensionWrapper::_on_event_polled(const void *event) {
+	if (static_cast<const XrEventDataBuffer*>(event)->type == XR_TYPE_EVENT_DATA_SPACE_SET_STATUS_COMPLETE_FB) {
+		auto eventData = (const XrEventDataSpaceSetStatusCompleteFB*) event;
+		if (set_status_callbacks.has(eventData->requestId)) {
+			set_status_callbacks[eventData->requestId](eventData);
+			set_status_callbacks.erase(eventData->requestId);
+		}
+		return true;
+	}
+
+	return false;
+}
+
+bool OpenXRFbSpatialEntityExtensionWrapper::is_component_supported(const XrSpace& space, XrSpaceComponentTypeFB type) {
+	uint32_t numComponents = 0;
+	xrEnumerateSpaceSupportedComponentsFB(space, 0, &numComponents, nullptr);
+	Vector<XrSpaceComponentTypeFB> components;
+	components.resize(numComponents);
+	xrEnumerateSpaceSupportedComponentsFB(space, numComponents, &numComponents, components.ptrw());
+
+	bool supported = false;
+	for (uint32_t c = 0; c < numComponents; ++c) {
+		if (components[c] == type) {
+			supported = true;
+			break;
+		}
+	}
+	return supported;
+}
+
+bool OpenXRFbSpatialEntityExtensionWrapper::is_component_enabled(const XrSpace& space, XrSpaceComponentTypeFB type) {
+	XrSpaceComponentStatusFB status = {XR_TYPE_SPACE_COMPONENT_STATUS_FB, nullptr};
+	xrGetSpaceComponentStatusFB(space, type, &status);
+	return (status.enabled && !status.changePending);
+}
+
+void OpenXRFbSpatialEntityExtensionWrapper::set_component_enabled(
+		const XrSpace& space,
+		XrSpaceComponentTypeFB type,
+		bool status,
+		std::optional<SetSpaceComponentStatusCallback_t> callback) {
+	XrSpaceComponentStatusSetInfoFB request = {
+		XR_TYPE_SPACE_COMPONENT_STATUS_SET_INFO_FB,
+		nullptr,
+		type,
+		status,
+		0,
+	};
+	XrAsyncRequestIdFB requestId;
+	if (!XR_SUCCEEDED(xrSetSpaceComponentStatusFB(space, &request, &requestId))) {
+		if (callback != std::nullopt){
+			(*callback)(nullptr);
+		}
+	}
+	if (callback != std::nullopt) {
+		set_status_callbacks[requestId] = *callback;
+	}
+}

--- a/godotopenxrmeta/src/main/cpp/openxr_fb_spatial_entity_query_extension_wrapper.cpp
+++ b/godotopenxrmeta/src/main/cpp/openxr_fb_spatial_entity_query_extension_wrapper.cpp
@@ -1,0 +1,163 @@
+/**************************************************************************/
+/*  openxr_fb_spatial_entity_query_extension_wrapper.cpp                  */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "include/openxr_fb_spatial_entity_query_extension_wrapper.h"
+#include <godot_cpp/variant/utility_functions.hpp>
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
+#include <godot_cpp/classes/object.hpp>
+
+using namespace godot;
+
+OpenXRFbSpatialEntityQueryExtensionWrapper *OpenXRFbSpatialEntityQueryExtensionWrapper::singleton = nullptr;
+
+OpenXRFbSpatialEntityQueryExtensionWrapper *OpenXRFbSpatialEntityQueryExtensionWrapper::get_singleton() {
+	if (singleton == nullptr) {
+		singleton = memnew(OpenXRFbSpatialEntityQueryExtensionWrapper());
+	}
+	return singleton;
+}
+
+OpenXRFbSpatialEntityQueryExtensionWrapper::OpenXRFbSpatialEntityQueryExtensionWrapper() :
+		OpenXRExtensionWrapperExtension() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "An OpenXRFbSpatialEntityQueryExtensionWrapper singleton already exists.");
+
+	request_extensions[XR_FB_SPATIAL_ENTITY_QUERY_EXTENSION_NAME] = &fb_spatial_entity_query_ext;
+	singleton = this;
+}
+
+OpenXRFbSpatialEntityQueryExtensionWrapper::~OpenXRFbSpatialEntityQueryExtensionWrapper() {
+	cleanup();
+}
+
+void OpenXRFbSpatialEntityQueryExtensionWrapper::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_spatial_entity_query_supported"), &OpenXRFbSpatialEntityQueryExtensionWrapper::is_spatial_entity_query_supported);
+}
+
+void OpenXRFbSpatialEntityQueryExtensionWrapper::cleanup() {
+	fb_spatial_entity_query_ext = false;
+}
+
+Dictionary OpenXRFbSpatialEntityQueryExtensionWrapper::_get_requested_extensions() {
+	Dictionary result;
+	for (auto ext: request_extensions) {
+		uint64_t value = reinterpret_cast<uint64_t>(ext.value);
+		result[ext.key] = (Variant)value;
+	}
+	return result;
+}
+
+void OpenXRFbSpatialEntityQueryExtensionWrapper::_on_instance_created(uint64_t instance) {
+	if (fb_spatial_entity_query_ext) {
+		bool result = initialize_fb_spatial_entity_query_extension((XrInstance)instance);
+		if (!result) {
+			UtilityFunctions::print("Failed to initialize fb_spatial_entity_query extension");
+			fb_spatial_entity_query_ext = false;
+		}
+	}
+}
+
+void OpenXRFbSpatialEntityQueryExtensionWrapper::_on_instance_destroyed() {
+	cleanup();
+}
+
+bool OpenXRFbSpatialEntityQueryExtensionWrapper::initialize_fb_spatial_entity_query_extension(const XrInstance& p_instance) {
+	GDEXTENSION_INIT_XR_FUNC_V(xrQuerySpacesFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrRetrieveSpaceQueryResultsFB);
+
+	return true;
+}
+
+bool OpenXRFbSpatialEntityQueryExtensionWrapper::_on_event_polled(const void *event) {
+	if (static_cast<const XrEventDataBuffer*>(event)->type == XR_TYPE_EVENT_DATA_SPACE_QUERY_RESULTS_AVAILABLE_FB) {
+		on_space_query_results((const XrEventDataSpaceQueryResultsAvailableFB*) event);
+		return true;
+	}
+
+	if (static_cast<const XrEventDataBuffer*>(event)->type == XR_TYPE_EVENT_DATA_SPACE_QUERY_COMPLETE_FB) {
+		on_space_query_complete((const XrEventDataSpaceQueryCompleteFB*) event);
+		return true;
+	}
+
+	return false;
+}
+
+void OpenXRFbSpatialEntityQueryExtensionWrapper::query_spatial_entities(const XrSpaceQueryInfoBaseHeaderFB* info, SpaceQueryCompleteCallback_t callback) {
+	XrAsyncRequestIdFB requestId;
+	const XrResult result = xrQuerySpacesFB(SESSION, info, &requestId);
+	if (!XR_SUCCEEDED(result)) {
+		WARN_PRINT("xrQuerySpacesFB failed!");
+		WARN_PRINT(get_openxr_api()->get_error_string(result));
+		callback({});
+		return;
+	}
+	query_complete_callbacks[requestId] = callback;
+}
+
+void OpenXRFbSpatialEntityQueryExtensionWrapper::on_space_query_results(const XrEventDataSpaceQueryResultsAvailableFB* event) {
+	// Query the results that are now available using two-call idiom
+	XrSpaceQueryResultsFB queryResults{
+		XR_TYPE_SPACE_QUERY_RESULTS_FB, // type
+		nullptr, // next
+		0, // resultCapacityInput
+		0, // resultCapacityOutput
+		nullptr, // results
+	};
+	XrResult result = xrRetrieveSpaceQueryResultsFB(SESSION, event->requestId, &queryResults);
+	if (!XR_SUCCEEDED(result)) {
+		WARN_PRINT("xrRetrieveSpaceQueryResultsFB (first call) failed!");
+		WARN_PRINT(get_openxr_api()->get_error_string(result));
+		return;
+	}
+
+	Vector<XrSpaceQueryResultFB> results;
+	results.resize(queryResults.resultCountOutput);
+	queryResults.resultCapacityInput = results.size();
+	queryResults.resultCountOutput = 0;
+	queryResults.results = results.ptrw();
+
+	result = xrRetrieveSpaceQueryResultsFB(SESSION, event->requestId, &queryResults);
+	if (!XR_SUCCEEDED(result)) {
+		WARN_PRINT("xrRetrieveSpaceQueryResultsFB 2 failed!");
+		WARN_PRINT(get_openxr_api()->get_error_string(result));
+		return;
+	}
+
+	// Store the results to send via callback later
+	query_results[event->requestId].append_array(results);
+}
+
+void OpenXRFbSpatialEntityQueryExtensionWrapper::on_space_query_complete(const XrEventDataSpaceQueryCompleteFB* event) {
+	if (query_complete_callbacks.has(event->requestId)) {
+		WARN_PRINT("Received unexpected XR_TYPE_EVENT_DATA_SPACE_QUERY_RESULTS_AVAILABLE_FB");
+		return;
+	}
+	query_complete_callbacks[event->requestId](query_results[event->requestId]);
+	query_complete_callbacks.erase(event->requestId);
+	query_results.erase(event->requestId);
+}

--- a/godotopenxrmeta/src/main/cpp/register_types.cpp
+++ b/godotopenxrmeta/src/main/cpp/register_types.cpp
@@ -38,6 +38,7 @@
 #include <godot_cpp/variant/utility_functions.hpp>
 
 #include "include/openxr_fb_scene_capture_extension_wrapper.h"
+#include "include/openxr_fb_spatial_entity_extension_wrapper.h"
 
 #include "export/export_plugin.h"
 #include "export/meta_export_plugin.h"
@@ -50,6 +51,9 @@ void initialize_plugin_module(ModuleInitializationLevel p_level)
 		case MODULE_INITIALIZATION_LEVEL_CORE: {
 			ClassDB::register_class<OpenXRFbSceneCaptureExtensionWrapper>();
 			OpenXRFbSceneCaptureExtensionWrapper::get_singleton()->register_extension_wrapper();
+
+			ClassDB::register_class<OpenXRFbSpatialEntityExtensionWrapper>();
+			OpenXRFbSpatialEntityExtensionWrapper::get_singleton()->register_extension_wrapper();
 		} break;
 
 		case MODULE_INITIALIZATION_LEVEL_SERVERS:
@@ -57,6 +61,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level)
 
 		case MODULE_INITIALIZATION_LEVEL_SCENE: {
 			Engine::get_singleton()->register_singleton("OpenXRFbSceneCaptureExtensionWrapper", OpenXRFbSceneCaptureExtensionWrapper::get_singleton());
+			Engine::get_singleton()->register_singleton("OpenXRFbSpatialEntityExtensionWrapper", OpenXRFbSpatialEntityExtensionWrapper::get_singleton());
 		} break;
 
 		case MODULE_INITIALIZATION_LEVEL_EDITOR: {

--- a/godotopenxrmeta/src/main/cpp/register_types.cpp
+++ b/godotopenxrmeta/src/main/cpp/register_types.cpp
@@ -37,6 +37,7 @@
 #include <godot_cpp/godot.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 
+#include "include/openxr_fb_scene_extension_wrapper.h"
 #include "include/openxr_fb_scene_capture_extension_wrapper.h"
 #include "include/openxr_fb_spatial_entity_extension_wrapper.h"
 #include "include/openxr_fb_spatial_entity_container_extension_wrapper.h"
@@ -62,6 +63,9 @@ void initialize_plugin_module(ModuleInitializationLevel p_level)
 
 			ClassDB::register_class<OpenXRFbSpatialEntityContainerExtensionWrapper>();
 			OpenXRFbSpatialEntityContainerExtensionWrapper::get_singleton()->register_extension_wrapper();
+
+			ClassDB::register_class<OpenXRFbSceneExtensionWrapper>();
+			OpenXRFbSceneExtensionWrapper::get_singleton()->register_extension_wrapper();
 		} break;
 
 		case MODULE_INITIALIZATION_LEVEL_SERVERS:
@@ -72,6 +76,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level)
 			Engine::get_singleton()->register_singleton("OpenXRFbSpatialEntityExtensionWrapper", OpenXRFbSpatialEntityExtensionWrapper::get_singleton());
 			Engine::get_singleton()->register_singleton("OpenXRFbSpatialEntityQueryExtensionWrapper", OpenXRFbSpatialEntityQueryExtensionWrapper::get_singleton());
 			Engine::get_singleton()->register_singleton("OpenXRFbSpatialEntityContainerExtensionWrapper", OpenXRFbSpatialEntityContainerExtensionWrapper::get_singleton());
+			Engine::get_singleton()->register_singleton("OpenXRFbSceneExtensionWrapper", OpenXRFbSceneExtensionWrapper::get_singleton());
 		} break;
 
 		case MODULE_INITIALIZATION_LEVEL_EDITOR: {

--- a/godotopenxrmeta/src/main/cpp/register_types.cpp
+++ b/godotopenxrmeta/src/main/cpp/register_types.cpp
@@ -39,6 +39,7 @@
 
 #include "include/openxr_fb_scene_capture_extension_wrapper.h"
 #include "include/openxr_fb_spatial_entity_extension_wrapper.h"
+#include "include/openxr_fb_spatial_entity_container_extension_wrapper.h"
 #include "include/openxr_fb_spatial_entity_query_extension_wrapper.h"
 
 #include "export/export_plugin.h"
@@ -58,6 +59,9 @@ void initialize_plugin_module(ModuleInitializationLevel p_level)
 
 			ClassDB::register_class<OpenXRFbSpatialEntityQueryExtensionWrapper>();
 			OpenXRFbSpatialEntityQueryExtensionWrapper::get_singleton()->register_extension_wrapper();
+
+			ClassDB::register_class<OpenXRFbSpatialEntityContainerExtensionWrapper>();
+			OpenXRFbSpatialEntityContainerExtensionWrapper::get_singleton()->register_extension_wrapper();
 		} break;
 
 		case MODULE_INITIALIZATION_LEVEL_SERVERS:
@@ -67,6 +71,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level)
 			Engine::get_singleton()->register_singleton("OpenXRFbSceneCaptureExtensionWrapper", OpenXRFbSceneCaptureExtensionWrapper::get_singleton());
 			Engine::get_singleton()->register_singleton("OpenXRFbSpatialEntityExtensionWrapper", OpenXRFbSpatialEntityExtensionWrapper::get_singleton());
 			Engine::get_singleton()->register_singleton("OpenXRFbSpatialEntityQueryExtensionWrapper", OpenXRFbSpatialEntityQueryExtensionWrapper::get_singleton());
+			Engine::get_singleton()->register_singleton("OpenXRFbSpatialEntityContainerExtensionWrapper", OpenXRFbSpatialEntityContainerExtensionWrapper::get_singleton());
 		} break;
 
 		case MODULE_INITIALIZATION_LEVEL_EDITOR: {

--- a/godotopenxrmeta/src/main/cpp/register_types.cpp
+++ b/godotopenxrmeta/src/main/cpp/register_types.cpp
@@ -39,6 +39,7 @@
 
 #include "include/openxr_fb_scene_capture_extension_wrapper.h"
 #include "include/openxr_fb_spatial_entity_extension_wrapper.h"
+#include "include/openxr_fb_spatial_entity_query_extension_wrapper.h"
 
 #include "export/export_plugin.h"
 #include "export/meta_export_plugin.h"
@@ -54,6 +55,9 @@ void initialize_plugin_module(ModuleInitializationLevel p_level)
 
 			ClassDB::register_class<OpenXRFbSpatialEntityExtensionWrapper>();
 			OpenXRFbSpatialEntityExtensionWrapper::get_singleton()->register_extension_wrapper();
+
+			ClassDB::register_class<OpenXRFbSpatialEntityQueryExtensionWrapper>();
+			OpenXRFbSpatialEntityQueryExtensionWrapper::get_singleton()->register_extension_wrapper();
 		} break;
 
 		case MODULE_INITIALIZATION_LEVEL_SERVERS:
@@ -62,6 +66,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level)
 		case MODULE_INITIALIZATION_LEVEL_SCENE: {
 			Engine::get_singleton()->register_singleton("OpenXRFbSceneCaptureExtensionWrapper", OpenXRFbSceneCaptureExtensionWrapper::get_singleton());
 			Engine::get_singleton()->register_singleton("OpenXRFbSpatialEntityExtensionWrapper", OpenXRFbSpatialEntityExtensionWrapper::get_singleton());
+			Engine::get_singleton()->register_singleton("OpenXRFbSpatialEntityQueryExtensionWrapper", OpenXRFbSpatialEntityQueryExtensionWrapper::get_singleton());
 		} break;
 
 		case MODULE_INITIALIZATION_LEVEL_EDITOR: {

--- a/godotopenxrmeta/src/main/java/org/godotengine/openxr/vendors/meta/GodotOpenXRMeta.kt
+++ b/godotopenxrmeta/src/main/java/org/godotengine/openxr/vendors/meta/GodotOpenXRMeta.kt
@@ -44,6 +44,7 @@ class GodotOpenXRMeta(godot: Godot?) : GodotPlugin(godot) {
         private val TAG = GodotOpenXRMeta::class.java.simpleName
 
         private const val EYE_TRACKING_PERMISSION = "com.oculus.permission.EYE_TRACKING"
+        private const val SCENE_PERMISSION = "com.oculus.permission.USE_SCENE"
 
         init {
             try {
@@ -66,6 +67,10 @@ class GodotOpenXRMeta(godot: Godot?) : GodotPlugin(godot) {
         if (PermissionsUtil.hasManifestPermission(activity, EYE_TRACKING_PERMISSION)) {
             Log.d(TAG, "Requesting permission '${EYE_TRACKING_PERMISSION}'")
             PermissionsUtil.requestPermission(EYE_TRACKING_PERMISSION, activity)
+        }
+        // Request the scene API permission if it's included in the manifest
+        if (PermissionsUtil.hasManifestPermission(activity, SCENE_PERMISSION)) {
+            PermissionsUtil.requestPermission(SCENE_PERMISSION, activity)
         }
         return null
     }


### PR DESCRIPTION
As title, following the pattern from the fb_scene_capture extension wrapper, I've added wrappers for the 4 extensions mentioned. They don't yet expose useful functionality to godot projects (beyond getting the singletons and checking if the extensions are supported), but provide most of the openxr related boilterplate so a later change can add an "XR Scene" abstraction that expresses a physical room's layout and surfaces to the a Godot scene.