### PR TITLE
Add additional export options for Meta Quest features

### DIFF
--- a/godotopenxrmeta/src/main/cpp/export/meta_export_plugin.cpp
+++ b/godotopenxrmeta/src/main/cpp/export/meta_export_plugin.cpp
@@ -104,6 +104,46 @@ MetaEditorExportPlugin::MetaEditorExportPlugin() {
 			false,
 			false
 	);
+	_use_scene_api_option = _generate_export_option(
+			"meta_xr_features/use_scene_api",
+			"",
+			Variant::Type::BOOL,
+			PROPERTY_HINT_NONE,
+			"",
+			PROPERTY_USAGE_DEFAULT,
+			false,
+			false
+	);
+	_use_overlay_keyboard_option = _generate_export_option(
+			"meta_xr_features/use_overlay_keyboard",
+			"",
+			Variant::Type::BOOL,
+			PROPERTY_HINT_NONE,
+			"",
+			PROPERTY_USAGE_DEFAULT,
+			false,
+			false
+	);
+	_use_experimental_features_option = _generate_export_option(
+			"meta_xr_features/use_experimental_features",
+			"",
+			Variant::Type::BOOL,
+			PROPERTY_HINT_NONE,
+			"",
+			PROPERTY_USAGE_DEFAULT,
+			false,
+			false
+	);
+	_boundary_mode_option = _generate_export_option(
+			"meta_xr_features/boundary_mode",
+			"",
+			Variant::Type::INT,
+			PROPERTY_HINT_ENUM,
+			"Enabled,Disabled,Contextual",
+			PROPERTY_USAGE_DEFAULT,
+			BOUNDARY_ENABLED_VALUE,
+			false
+	);
 	_support_quest_1_option = _generate_export_option(
 			"meta_xr_features/quest_1_support",
 			"",
@@ -160,6 +200,10 @@ TypedArray<Dictionary> MetaEditorExportPlugin::_get_export_options(const Ref<Edi
 	export_options.append(_hand_tracking_frequency_option);
 	export_options.append(_passthrough_option);
 	export_options.append(_use_anchor_api_option);
+	export_options.append(_use_scene_api_option);
+	export_options.append(_use_overlay_keyboard_option);
+	export_options.append(_use_experimental_features_option);
+	export_options.append(_boundary_mode_option);
 	export_options.append(_support_quest_1_option);
 	export_options.append(_support_quest_2_option);
 	export_options.append(_support_quest_3_option);
@@ -238,6 +282,18 @@ String MetaEditorExportPlugin::_get_export_option_warning(const Ref<EditorExport
 		if (!openxr_enabled && _get_bool_option(option)) {
 			return "\"Use anchor API\" is only valid when \"XR Mode\" is \"OpenXR\".\n";
 		}
+	} else if (option == "meta_xr_features/use_scene_api") {
+		if (!openxr_enabled && _get_bool_option(option)) {
+			return "\"Use scene API\" is only valid when \"XR Mode\" is \"OpenXR\".\n";
+		}
+	} else if (option == "meta_xr_features/use_experimental_features") {
+		if (!openxr_enabled && _get_bool_option(option)) {
+			return "\"Use experimental features\" is only valid when \"XR Mode\" is \"OpenXR\".\n";
+		}
+	} else if (option == "meta_xr_features/boundary_mode") {
+		if (!openxr_enabled && _get_int_option(option, BOUNDARY_ENABLED_VALUE) > BOUNDARY_ENABLED_VALUE) {
+			return "Boundary mode changes require \"XR Mode\" to be \"OpenXR\".\n";
+		}
 	}
 
 	return OpenXREditorExportPlugin::_get_export_option_warning(platform, option);
@@ -285,6 +341,32 @@ String MetaEditorExportPlugin::_get_android_manifest_element_contents(const Ref<
 	bool use_anchor_api = _get_bool_option("meta_xr_features/use_anchor_api");
 	if (use_anchor_api) {
 		contents += "    <uses-permission android:name=\"com.oculus.permission.USE_ANCHOR_API\" />\n";
+	}
+
+	// Check for scene api
+	bool use_scene_api = _get_bool_option("meta_xr_features/use_scene_api");
+	if (use_scene_api) {
+		contents += "    <uses-permission android:name=\"com.oculus.permission.USE_SCENE\" />\n";
+	}
+
+	// Check for overlay keyboard
+	bool _use_overlay_keyboard_option = _get_bool_option("meta_xr_features/use_overlay_keyboard");
+	if (_use_overlay_keyboard_option) {
+		contents += "    <uses-feature android:name=\"oculus.software.overlay_keyboard\" android:required=\"true\" />\n";
+	}
+
+	// Check for experimental features
+	bool use_experimental_features = _get_bool_option("meta_xr_features/use_experimental_features");
+	if (use_experimental_features) {
+		contents += "    <uses-feature android:name=\"com.oculus.experimental.enabled\" />\n";
+	}
+
+	// Check for boundary mode
+	int boundary_mode = _get_int_option("meta_xr_features/boundary_mode", BOUNDARY_ENABLED_VALUE);
+	if (boundary_mode == BOUNDARY_DISABLED_VALUE) {
+		contents += "    <uses-feature tools:node=\"replace\" android:name=\"com.oculus.feature.BOUNDARYLESS_APP\" android:required=\"true\" />\n";
+	} else if (boundary_mode == BOUNDARY_CONTEXTUAL_VALUE) {
+		contents += "    <uses-feature tools:node=\"replace\" android:name=\"com.oculus.feature.CONTEXTUAL_BOUNDARYLESS_APP\" android:required=\"true\" />\n";
 	}
 
 	return contents;

--- a/godotopenxrmeta/src/main/cpp/export/meta_export_plugin.h
+++ b/godotopenxrmeta/src/main/cpp/export/meta_export_plugin.h
@@ -52,6 +52,10 @@ static const int HAND_TRACKING_REQUIRED_VALUE = 2;
 static const int HAND_TRACKING_FREQUENCY_LOW_VALUE = 0;
 static const int HAND_TRACKING_FREQUENCY_HIGH_VALUE = 1;
 
+static const int BOUNDARY_ENABLED_VALUE = 0;
+static const int BOUNDARY_DISABLED_VALUE = 1;
+static const int BOUNDARY_CONTEXTUAL_VALUE = 2;
+
 } // namespace
 
 class MetaEditorExportPlugin : public OpenXREditorExportPlugin {
@@ -83,6 +87,10 @@ private:
 	Dictionary _hand_tracking_frequency_option;
 	Dictionary _passthrough_option;
 	Dictionary _use_anchor_api_option;
+	Dictionary _use_scene_api_option;
+	Dictionary _use_overlay_keyboard_option;
+	Dictionary _use_experimental_features_option;
+	Dictionary _boundary_mode_option;
 	Dictionary _support_quest_1_option;
 	Dictionary _support_quest_2_option;
 	Dictionary _support_quest_3_option;


### PR DESCRIPTION
A lot of Meta Quest features are gated by AndroidManifest flags. Adding export options to support:
Experimental Features: https://developer.oculus.com/experimental/experimental-overview/
Overlay Keyboard: https://developer.oculus.com/documentation/unity/unity-keyboard-overlay/
Scene API: https://developer.oculus.com/documentation/native/native-spatial-data-perm/
Boundary Modes (can't find documentation, but already used by a few apps on the Quest Store)