### PR TITLE
Register singletons the usual way

### DIFF
--- a/demo/main.gd
+++ b/demo/main.gd
@@ -9,8 +9,8 @@ func _ready():
 	if xr_interface and xr_interface.is_initialized():
 		var vp: Viewport = get_viewport()
 		vp.use_xr = true
-		
-	scene_capture = OpenXRFbSceneCaptureExtensionWrapper.get_singleton()
+
+	scene_capture = Engine.get_singleton("OpenXRFbSceneCaptureExtensionWrapper")
 	scene_capture.connect("scene_capture_completed", _on_scene_capture_completed)
 
 

--- a/godotopenxrmeta/src/main/cpp/openxr_fb_scene_capture_extension_wrapper.cpp
+++ b/godotopenxrmeta/src/main/cpp/openxr_fb_scene_capture_extension_wrapper.cpp
@@ -62,7 +62,6 @@ OpenXRFbSceneCaptureExtensionWrapper::~OpenXRFbSceneCaptureExtensionWrapper() {
 
 void OpenXRFbSceneCaptureExtensionWrapper::_bind_methods() {
 
-	ClassDB::bind_static_method("OpenXRFbSceneCaptureExtensionWrapper", D_METHOD("get_singleton"), &OpenXRFbSceneCaptureExtensionWrapper::get_singleton);
 	ClassDB::bind_method(D_METHOD("is_scene_capture_supported"), &OpenXRFbSceneCaptureExtensionWrapper::is_scene_capture_supported);
 	ClassDB::bind_method(D_METHOD("is_scene_capture_enabled"), &OpenXRFbSceneCaptureExtensionWrapper::is_scene_capture_enabled);
 	ClassDB::bind_method(D_METHOD("request_scene_capture"), &OpenXRFbSceneCaptureExtensionWrapper::request_scene_capture);

--- a/godotopenxrmeta/src/main/cpp/register_types.cpp
+++ b/godotopenxrmeta/src/main/cpp/register_types.cpp
@@ -31,6 +31,7 @@
 
 #include <gdextension_interface.h>
 
+#include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/core/class_db.hpp>
 #include <godot_cpp/core/defs.hpp>
 #include <godot_cpp/godot.hpp>
@@ -51,6 +52,13 @@ void initialize_plugin_module(ModuleInitializationLevel p_level)
 			OpenXRFbSceneCaptureExtensionWrapper::get_singleton()->register_extension_wrapper();
 		} break;
 
+		case MODULE_INITIALIZATION_LEVEL_SERVERS:
+			break;
+
+		case MODULE_INITIALIZATION_LEVEL_SCENE: {
+			Engine::get_singleton()->register_singleton("OpenXRFbSceneCaptureExtensionWrapper", OpenXRFbSceneCaptureExtensionWrapper::get_singleton());
+		} break;
+
 		case MODULE_INITIALIZATION_LEVEL_EDITOR: {
 			ClassDB::register_class<OpenXREditorExportPlugin>();
 			ClassDB::register_class<MetaEditorExportPlugin>();
@@ -59,8 +67,6 @@ void initialize_plugin_module(ModuleInitializationLevel p_level)
 			EditorPlugins::add_by_type<MetaEditorPlugin>();
 		} break;
 
-		case MODULE_INITIALIZATION_LEVEL_SERVERS:
-		case MODULE_INITIALIZATION_LEVEL_SCENE:
 		case MODULE_INITIALIZATION_LEVEL_MAX:
 			break;
 	}
@@ -80,7 +86,7 @@ extern "C"
 
         init_obj.register_initializer(initialize_plugin_module);
         init_obj.register_terminator(terminate_plugin_module);
-		init_obj.set_minimum_library_initialization_level(MODULE_INITIALIZATION_LEVEL_CORE);
+		init_obj.set_minimum_library_initialization_level(MODULE_INITIALIZATION_LEVEL_SCENE);
 
 		return init_obj.init();
 	}


### PR DESCRIPTION
Registers the singleton the usual way that singletons are registered in GDExtension, via `Engine::get_singleton()->register_singleton()`

Supersedes https://github.com/GodotVR/godot_openxr_vendors/pull/72