### PR TITLE
Fix the plugin version for the export plugins

### DIFF
--- a/common/src/main/cpp/export/export_plugin.cpp
+++ b/common/src/main/cpp/export/export_plugin.cpp
@@ -33,7 +33,7 @@
 
 using namespace godot;
 
-OpenXREditorExportPlugin::OpenXREditorExportPlugin() {}
+OpenXREditorExportPlugin::OpenXREditorExportPlugin() : _plugin_version(PLUGIN_VERSION) {}
 
 void OpenXREditorExportPlugin::_bind_methods() {}
 

--- a/common/src/main/cpp/export/export_plugin.h
+++ b/common/src/main/cpp/export/export_plugin.h
@@ -37,6 +37,8 @@
 
 using namespace godot;
 
+static const char *PLUGIN_VERSION = "2.0.2-stable";
+
 // Set of supported vendors
 static const char *META_VENDOR_NAME = "meta";
 static const char *PICO_VENDOR_NAME = "pico";
@@ -79,10 +81,6 @@ public:
 
 	void set_vendor_name(const String &vendor_name) {
 		_vendor = vendor_name;
-	}
-
-	void set_plugin_version(const String &plugin_version) {
-		_plugin_version = plugin_version;
 	}
 
 protected:
@@ -137,5 +135,5 @@ private:
 
 
 	String _vendor;
-	String _plugin_version;
+	const String _plugin_version;
 };

--- a/godotopenxrkhronos/src/main/cpp/export/khronos_export_plugin.cpp
+++ b/godotopenxrkhronos/src/main/cpp/export/khronos_export_plugin.cpp
@@ -36,8 +36,6 @@ void KhronosEditorPlugin::_bind_methods() {}
 void KhronosEditorPlugin::_enter_tree() {
 	// Initialize the editor export plugin
 	khronos_export_plugin = memnew(KhronosEditorExportPlugin);
-	khronos_export_plugin->set_plugin_version(get_plugin_version());
-
 	add_export_plugin(khronos_export_plugin);
 }
 

--- a/godotopenxrlynx/src/main/cpp/export/lynx_export_plugin.cpp
+++ b/godotopenxrlynx/src/main/cpp/export/lynx_export_plugin.cpp
@@ -37,8 +37,6 @@ void LynxEditorPlugin::_enter_tree() {
 	// Initialize the editor export plugin
 	lynx_export_plugin = memnew(OpenXREditorExportPlugin);
 	lynx_export_plugin->set_vendor_name(LYNX_VENDOR_NAME);
-	lynx_export_plugin->set_plugin_version(get_plugin_version());
-
 	add_export_plugin(lynx_export_plugin);
 }
 

--- a/godotopenxrmeta/src/main/cpp/export/meta_export_plugin.cpp
+++ b/godotopenxrmeta/src/main/cpp/export/meta_export_plugin.cpp
@@ -38,8 +38,6 @@ void MetaEditorPlugin::_bind_methods() {}
 void MetaEditorPlugin::_enter_tree() {
 	// Initialize the editor export plugin
 	meta_export_plugin = memnew(MetaEditorExportPlugin);
-	meta_export_plugin->set_plugin_version(get_plugin_version());
-
 	add_export_plugin(meta_export_plugin);
 }
 

--- a/godotopenxrpico/src/main/cpp/export/pico_export_plugin.cpp
+++ b/godotopenxrpico/src/main/cpp/export/pico_export_plugin.cpp
@@ -37,8 +37,6 @@ void PicoEditorPlugin::_enter_tree() {
 	// Initialize the editor export plugin
 	pico_export_plugin = memnew(OpenXREditorExportPlugin);
 	pico_export_plugin->set_vendor_name(PICO_VENDOR_NAME);
-	pico_export_plugin->set_plugin_version(get_plugin_version());
-
 	add_export_plugin(pico_export_plugin);
 }
 


### PR DESCRIPTION
The previous logic relied on [`EditorPlugin::get_plugin_version()`](https://docs.godotengine.org/en/stable/classes/class_editorplugin.html#class-editorplugin-method-get-plugin-version), whose value became empty once we switched to gdextension and removed the `plugin.cfg` config file.