### PR TITLE
Preparing release 2.0.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,11 @@
 # Change history for the Godot OpenXR loaders asset
 
-## 2.1.0
+## 2.0.3
 - Migrate the export scripts from gdscript to C++ via gdextension
+- Manually request eye tracking permission if it's included in the app manifest
+- Change how singletons are accessed
+- Fix the plugin version for the export plugins
+- Add OpenXR extension wrappers for fb_scene, fb_spatial_entity, fb_spatial_entity_query, fb_spatial_entity_container
 
 ## 2.0.0
 - Update to the new Godot 4.2 Android plugin packaging format

--- a/common/src/main/cpp/export/export_plugin.h
+++ b/common/src/main/cpp/export/export_plugin.h
@@ -37,7 +37,7 @@
 
 using namespace godot;
 
-static const char *PLUGIN_VERSION = "2.0.2-stable";
+static const char *PLUGIN_VERSION = "2.0.3-stable";
 
 // Set of supported vendors
 static const char *META_VENDOR_NAME = "meta";


### PR DESCRIPTION
Updating version number and changes document in preparation of release 2.0.3.

Note #61 and #66 were both merged but marked as `2.1.0` PRs. I've moved them under 2.0.3 in the changes document. We'll need to update the milestones if this was correct.

If either does not belong in 2.0.3, they need to be reverted until we release 2.0.3, and then resubmitted.