### PR TITLE
Move implementation of `XR_FB_passthrough` into godot_openxr_vendors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - Add XR_FB_face_tracking support
 - Update to OpenXR 1.0.34 headers
 - Add XR_FB_render_model extension wrapper and OpenXRFBRenderModel node
+- Add XR_FB_passthrough extension wrapper
 
 ## 2.0.3
 - Migrate the export scripts from gdscript to C++ via gdextension

--- a/common/src/main/cpp/extensions/openxr_fb_passthrough_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_fb_passthrough_extension_wrapper.cpp
@@ -1,0 +1,281 @@
+/**************************************************************************/
+/*  openxr_fb_passthrough_extension_wrapper.cpp                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "extensions/openxr_fb_passthrough_extension_wrapper.h"
+
+#include <godot_cpp/classes/main_loop.hpp>
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
+#include <godot_cpp/classes/os.hpp>
+#include <godot_cpp/classes/scene_tree.hpp>
+#include <godot_cpp/classes/viewport.hpp>
+#include <godot_cpp/classes/xr_server.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+using namespace godot;
+
+OpenXRFbPassthroughExtensionWrapper *OpenXRFbPassthroughExtensionWrapper::singleton = nullptr;
+
+OpenXRFbPassthroughExtensionWrapper *OpenXRFbPassthroughExtensionWrapper::get_singleton() {
+	if (singleton == nullptr) {
+		singleton = memnew(OpenXRFbPassthroughExtensionWrapper());
+	}
+	return singleton;
+}
+
+OpenXRFbPassthroughExtensionWrapper::OpenXRFbPassthroughExtensionWrapper() :
+		OpenXRExtensionWrapperExtension() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "An OpenXRFbPassthroughExtensionWrapper singleton already exists.");
+
+	request_extensions[XR_FB_PASSTHROUGH_EXTENSION_NAME] = &fb_passthrough_ext;
+	request_extensions[XR_FB_TRIANGLE_MESH_EXTENSION_NAME] = &fb_triangle_mesh_ext;
+
+	singleton = this;
+}
+
+OpenXRFbPassthroughExtensionWrapper::~OpenXRFbPassthroughExtensionWrapper() {
+	cleanup();
+}
+
+void OpenXRFbPassthroughExtensionWrapper::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_passthrough_supported"), &OpenXRFbPassthroughExtensionWrapper::is_passthrough_supported);
+	ClassDB::bind_method(D_METHOD("is_passthrough_enabled"), &OpenXRFbPassthroughExtensionWrapper::is_passthrough_enabled);
+}
+
+godot::Dictionary OpenXRFbPassthroughExtensionWrapper::_get_requested_extensions() {
+	godot::Dictionary result;
+	for (auto ext: request_extensions) {
+		godot::String key = ext.first;
+		uint64_t value = reinterpret_cast<uint64_t>(ext.second);
+		result[key] = (godot::Variant)value;
+	}
+	return result;
+}
+
+void OpenXRFbPassthroughExtensionWrapper::cleanup() {
+	fb_passthrough_ext = false;
+	fb_triangle_mesh_ext = false;
+}
+
+void OpenXRFbPassthroughExtensionWrapper::_on_instance_created(uint64_t p_instance) {
+	XrInstance instance = (XrInstance)p_instance;
+	if (fb_passthrough_ext) {
+		bool result = initialize_fb_passthrough_extension(instance);
+		if (!result) {
+			UtilityFunctions::print("Failed to initialize fb_passthrough extension");
+			fb_passthrough_ext = false;
+		}
+	}
+
+	if (fb_triangle_mesh_ext) {
+		bool result = initialize_fb_triangle_mesh_extension(instance);
+		if (!result) {
+			UtilityFunctions::print("Failed to initialize fb_triangle_mesh extension");
+			fb_triangle_mesh_ext = false;
+		}
+	}
+}
+
+void OpenXRFbPassthroughExtensionWrapper::_on_session_created(uint64_t p_session) {
+	XrSession session = (XrSession)p_session;
+	if (fb_passthrough_ext) {
+		// If it's already supported, then we don't want to emulate it.
+		if (get_openxr_api()->is_environment_blend_mode_alpha_supported() != OpenXRAPIExtension::OPENXR_ALPHA_BLEND_MODE_SUPPORT_NONE) {
+			return;
+		}
+
+		// Create the passthrough feature and start it.
+		XrPassthroughCreateInfoFB passthrough_create_info = {
+			XR_TYPE_PASSTHROUGH_CREATE_INFO_FB,
+			nullptr,
+			0,
+		};
+
+		XrResult result = xrCreatePassthroughFB(session, &passthrough_create_info, &passthrough_handle);
+		if (XR_FAILED(result)) {
+			UtilityFunctions::print("Failed to create passthrough");
+			passthrough_handle = XR_NULL_HANDLE;
+			return;
+		}
+
+		get_openxr_api()->register_composition_layer_provider(this);
+		get_openxr_api()->set_emulate_environment_blend_mode_alpha_blend(true);
+	}
+}
+
+void OpenXRFbPassthroughExtensionWrapper::_on_state_ready() {
+	XRInterface::EnvironmentBlendMode blend_mode = get_blend_mode();
+	if (blend_mode == XRInterface::XR_ENV_BLEND_MODE_ALPHA_BLEND) {
+		start_passthrough();
+	}
+	previous_blend_mode = blend_mode;
+}
+
+void OpenXRFbPassthroughExtensionWrapper::_on_process() {
+	XRInterface::EnvironmentBlendMode blend_mode = get_blend_mode();
+
+	if (previous_blend_mode != XRInterface::XR_ENV_BLEND_MODE_ALPHA_BLEND && blend_mode == XRInterface::XR_ENV_BLEND_MODE_ALPHA_BLEND) {
+		start_passthrough();
+	} else if (previous_blend_mode == XRInterface::XR_ENV_BLEND_MODE_ALPHA_BLEND && blend_mode != XRInterface::XR_ENV_BLEND_MODE_ALPHA_BLEND) {
+		stop_passthrough();
+	}
+
+	previous_blend_mode = blend_mode;
+}
+
+void OpenXRFbPassthroughExtensionWrapper::_on_session_destroyed() {
+	if (fb_passthrough_ext) {
+		stop_passthrough();
+
+		XrResult result;
+		if (passthrough_handle != XR_NULL_HANDLE) {
+			result = xrDestroyPassthroughFB(passthrough_handle);
+			if (XR_FAILED(result)) {
+				UtilityFunctions::print("Unable to destroy passthrough feature");
+			}
+			passthrough_handle = XR_NULL_HANDLE;
+
+			get_openxr_api()->unregister_composition_layer_provider(this);
+			get_openxr_api()->set_emulate_environment_blend_mode_alpha_blend(false);
+		}
+	}
+}
+
+void OpenXRFbPassthroughExtensionWrapper::_on_instance_destroyed() {
+	cleanup();
+}
+
+bool OpenXRFbPassthroughExtensionWrapper::is_passthrough_enabled() {
+	return fb_passthrough_ext && passthrough_handle != XR_NULL_HANDLE && passthrough_layer != XR_NULL_HANDLE;
+}
+
+bool OpenXRFbPassthroughExtensionWrapper::start_passthrough() {
+	if (passthrough_handle == XR_NULL_HANDLE) {
+		return false;
+	}
+
+	if (is_passthrough_enabled()) {
+		return true;
+	}
+
+	// Start the passthrough feature
+	XrResult result = xrPassthroughStartFB(passthrough_handle);
+	if (XR_FAILED(result)) {
+		UtilityFunctions::print("Failed to start passthrough");
+		stop_passthrough();
+		return false;
+	}
+
+	// Create the passthrough layer
+	XrPassthroughLayerCreateInfoFB passthrough_layer_config = {
+		XR_TYPE_PASSTHROUGH_LAYER_CREATE_INFO_FB,
+		nullptr,
+		passthrough_handle,
+		XR_PASSTHROUGH_IS_RUNNING_AT_CREATION_BIT_FB,
+		XR_PASSTHROUGH_LAYER_PURPOSE_RECONSTRUCTION_FB,
+	};
+	result = xrCreatePassthroughLayerFB(SESSION, &passthrough_layer_config, &passthrough_layer);
+	if (XR_FAILED(result)) {
+		UtilityFunctions::print("Failed to create the passthrough layer");
+		stop_passthrough();
+		return false;
+	}
+
+	return true;
+}
+
+uint64_t OpenXRFbPassthroughExtensionWrapper::_get_composition_layer() {
+	if (is_passthrough_enabled()) {
+		composition_passthrough_layer.layerHandle = passthrough_layer;
+		return reinterpret_cast<uint64_t>(&composition_passthrough_layer);
+	} else {
+		return 0;
+	}
+}
+
+void OpenXRFbPassthroughExtensionWrapper::stop_passthrough() {
+	if (!fb_passthrough_ext) {
+		return;
+	}
+
+	XrResult result;
+	if (passthrough_layer != XR_NULL_HANDLE) {
+		// Destroy the layer
+		result = xrDestroyPassthroughLayerFB(passthrough_layer);
+		if (XR_FAILED(result)) {
+			UtilityFunctions::print("Unable to destroy passthrough layer");
+		}
+		passthrough_layer = XR_NULL_HANDLE;
+	}
+
+	if (passthrough_handle != XR_NULL_HANDLE) {
+		result = xrPassthroughPauseFB(passthrough_handle);
+		if (XR_FAILED(result)) {
+			UtilityFunctions::print("Unable to stop passthrough feature");
+		}
+	}
+}
+
+XRInterface::EnvironmentBlendMode OpenXRFbPassthroughExtensionWrapper::get_blend_mode() {
+	Ref<XRInterface> xr_interface = XRServer::get_singleton()->find_interface("OpenXR");
+	if (xr_interface.is_valid()) {
+		return xr_interface->get_environment_blend_mode();
+	}
+	return XRInterface::XR_ENV_BLEND_MODE_OPAQUE;
+}
+
+bool OpenXRFbPassthroughExtensionWrapper::initialize_fb_passthrough_extension(const XrInstance p_instance) {
+	GDEXTENSION_INIT_XR_FUNC_V(xrCreatePassthroughFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrDestroyPassthroughFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrPassthroughStartFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrPassthroughPauseFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrCreatePassthroughLayerFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrDestroyPassthroughLayerFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrPassthroughLayerPauseFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrPassthroughLayerResumeFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrPassthroughLayerSetStyleFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrCreateGeometryInstanceFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrDestroyGeometryInstanceFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrGeometryInstanceSetTransformFB);
+
+	return true;
+}
+
+bool OpenXRFbPassthroughExtensionWrapper::initialize_fb_triangle_mesh_extension(const XrInstance p_instance) {
+	GDEXTENSION_INIT_XR_FUNC_V(xrCreateTriangleMeshFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrDestroyTriangleMeshFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrTriangleMeshGetVertexBufferFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrTriangleMeshGetIndexBufferFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrTriangleMeshBeginUpdateFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrTriangleMeshEndUpdateFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrTriangleMeshBeginVertexBufferUpdateFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrTriangleMeshEndVertexBufferUpdateFB);
+
+	return true;
+}

--- a/common/src/main/cpp/include/extensions/openxr_fb_passthrough_extension_wrapper.h
+++ b/common/src/main/cpp/include/extensions/openxr_fb_passthrough_extension_wrapper.h
@@ -1,0 +1,233 @@
+/**************************************************************************/
+/*  openxr_fb_passthrough_extension_wrapper.h                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef OPENXR_FB_PASSTHROUGH_EXTENSION_WRAPPER_H
+#define OPENXR_FB_PASSTHROUGH_EXTENSION_WRAPPER_H
+
+#include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
+#include <godot_cpp/classes/xr_interface.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+#include <openxr/openxr.h>
+
+#include "util.h"
+
+#include <map>
+
+using namespace godot;
+
+// Wrapper for the set of Facebook XR passthrough extensions.
+class OpenXRFbPassthroughExtensionWrapper : public OpenXRExtensionWrapperExtension {
+	GDCLASS(OpenXRFbPassthroughExtensionWrapper, OpenXRExtensionWrapperExtension);
+
+public:
+	OpenXRFbPassthroughExtensionWrapper();
+	~OpenXRFbPassthroughExtensionWrapper();
+
+	godot::Dictionary _get_requested_extensions() override;
+
+	void _on_instance_created(uint64_t p_instance) override;
+	void _on_session_created(uint64_t p_session) override;
+	void _on_session_destroyed() override;
+	void _on_instance_destroyed() override;
+	void _on_state_ready() override;
+	void _on_process() override;
+
+	uint64_t _get_composition_layer() override;
+
+	bool is_passthrough_supported() {
+		return fb_passthrough_ext;
+	}
+
+	bool is_passthrough_enabled();
+
+	bool start_passthrough();
+	void stop_passthrough();
+
+	static OpenXRFbPassthroughExtensionWrapper *get_singleton();
+
+protected:
+	static void _bind_methods();
+
+private:
+	// Create a passthrough feature
+	EXT_PROTO_XRRESULT_FUNC3(xrCreatePassthroughFB,
+			(XrSession), session,
+			(const XrPassthroughCreateInfoFB *), create_info,
+			(XrPassthroughFB *), feature_out)
+
+	// Destroy a previously created passthrough feature
+	EXT_PROTO_XRRESULT_FUNC1(xrDestroyPassthroughFB, (XrPassthroughFB), feature)
+
+	//*** Passthrough feature state management functions *********
+	// Start the passthrough feature
+	EXT_PROTO_XRRESULT_FUNC1(xrPassthroughStartFB, (XrPassthroughFB), passthrough)
+	// Pause the passthrough feature
+	EXT_PROTO_XRRESULT_FUNC1(xrPassthroughPauseFB, (XrPassthroughFB), passthrough)
+
+	EXT_PROTO_XRRESULT_FUNC3(xrCreatePassthroughLayerFB, (XrSession), session,
+			(const XrPassthroughLayerCreateInfoFB *), config,
+			(XrPassthroughLayerFB *), layer_out)
+
+	EXT_PROTO_XRRESULT_FUNC1(xrDestroyPassthroughLayerFB, (XrPassthroughLayerFB), layer)
+
+	EXT_PROTO_XRRESULT_FUNC1(xrPassthroughLayerPauseFB, (XrPassthroughLayerFB), layer)
+	EXT_PROTO_XRRESULT_FUNC1(xrPassthroughLayerResumeFB, (XrPassthroughLayerFB), layer)
+
+	// Set the style of an existing passthrough layer. If the enabled feature set
+	// doesn’t change, this is a lightweight operation that can be called in every
+	// frame to animate the style. Changes that may incur a bigger cost:
+	// - Enabling/disabling the color mapping, or changing the type of mapping
+	//   (monochromatic to RGBA or back).
+	// - Changing `textureOpacityFactor` from 0 to non-zero or vice versa
+	// - Changing `edgeColor[3]` from 0 to non-zero or vice versa
+	// NOTE: For XR_FB_passthrough, all color values are treated as linear.
+	EXT_PROTO_XRRESULT_FUNC2(xrPassthroughLayerSetStyleFB,
+			(XrPassthroughLayerFB), layer,
+			(const XrPassthroughStyleFB *), style)
+
+	// Create a geometry instance to be used as a projection surface for passthrough.
+	// A geometry instance assigns a triangle mesh as part of the specified layer's
+	// projection surface.
+	// The operation is only valid if the passthrough layer's purpose has been set to
+	// `XR_PASSTHROUGH_LAYER_PURPOSE_PROJECTED_FB`. Otherwise, the call this function will
+	// result in an error. In the specified layer, Passthrough will be visible where the view
+	// is covered by the user-specified geometries.
+	//
+	// A triangle mesh object can be instantiated multiple times - in the same or different layers'
+	// projection surface. Each instantiation has its own transformation, which
+	// can be updated using `xrGeometryInstanceSetTransformFB`.
+	EXT_PROTO_XRRESULT_FUNC3(xrCreateGeometryInstanceFB,
+			(XrSession), session,
+			(const XrGeometryInstanceCreateInfoFB *), create_info,
+			(XrGeometryInstanceFB *), out_geometry_instance)
+
+	// Destroys a previously created geometry instance from passthrough rendering.
+	// This removes the geometry instance from passthrough rendering.
+	// The operation has no effect on other instances or the underlying mesh.
+	EXT_PROTO_XRRESULT_FUNC1(xrDestroyGeometryInstanceFB, (XrGeometryInstanceFB), instance)
+
+	// Update the transformation of a passthrough geometry instance.
+	EXT_PROTO_XRRESULT_FUNC2(xrGeometryInstanceSetTransformFB,
+			(XrGeometryInstanceFB), instance,
+			(const XrGeometryInstanceTransformFB *), transformation)
+
+	// Create a triangle mesh geometry object.
+	// Depending on the behavior flags, the mesh could be created immutable (data is assigned
+	// at creation and cannot be changed) or mutable (the mesh is created empty and can be updated
+	// by calling begin/end update functions).
+	EXT_PROTO_XRRESULT_FUNC3(xrCreateTriangleMeshFB,
+			(XrSession), session,
+			(const XrTriangleMeshCreateInfoFB *), create_info,
+			(XrTriangleMeshFB *), out_triangle_mesh)
+
+	// Destroy an `XrTriangleMeshFB` object along with its data. The mesh buffers must not be
+	// accessed anymore after their parent mesh object has been destroyed.
+	EXT_PROTO_XRRESULT_FUNC1(xrDestroyTriangleMeshFB, (XrTriangleMeshFB), mesh)
+
+	// Retrieve a pointer to the vertex buffer. The vertex buffer is structured as an array of 3 floats
+	// per vertex representing x, y, and z: `[x0, y0, z0, x1, y1, z1, ...]`. The size of the buffer is
+	// `maxVertexCount * 3` floats. The application must call `xrTriangleMeshBeginUpdateFB` or
+	// `xrTriangleMeshBeginVertexBufferUpdateFB` before making modifications to the vertex
+	// buffer. The buffer location is guaranteed to remain constant over the lifecycle of the mesh
+	// object.
+	EXT_PROTO_XRRESULT_FUNC2(xrTriangleMeshGetVertexBufferFB,
+			(XrTriangleMeshFB), mesh,
+			(XrVector3f **), out_vertex_buffer)
+
+	// Retrieve the index buffer that defines the topology of the triangle mesh. Each triplet of
+	// consecutive elements point to three vertices in the vertex buffer and thus form a triangle. The
+	// size of each element is `indexElementSize` bytes, and thus the size of the buffer is
+	// `maxTriangleCount * 3 * indexElementSize` bytes. The application must call
+	// `xrTriangleMeshBeginUpdateFB` before making modifications to the index buffer. The buffer
+	// location is guaranteed to remain constant over the lifecycle of the mesh object.
+	EXT_PROTO_XRRESULT_FUNC2(xrTriangleMeshGetIndexBufferFB,
+			(XrTriangleMeshFB), mesh,
+			(uint32_t **), out_index_buffer)
+
+	// Begin updating the mesh buffer data. The application must call this function before it makes any
+	// modifications to the buffers retrieved by `xrTriangleMeshGetVertexBufferFB` and
+	// `xrTriangleMeshGetIndexBufferFB`. If only the vertex buffer needs to be updated,
+	// `xrTriangleMeshBeginVertexBufferUpdateFB` can be used instead. To commit the
+	// modifications, the application must call `xrTriangleMeshEndUpdateFB`.
+	EXT_PROTO_XRRESULT_FUNC1(xrTriangleMeshBeginUpdateFB, (XrTriangleMeshFB), mesh)
+
+	// Signal the API that the application has finished updating the mesh buffers after a call to
+	// `xrTriangleMeshBeginUpdateFB`. `vertexCount` and `triangleCount` specify the actual
+	// number of primitives that make up the mesh after the update. They must be larger than zero but
+	// smaller or equal to the maximum counts defined at create time. Buffer data beyond these counts
+	// is ignored.
+	EXT_PROTO_XRRESULT_FUNC3(xrTriangleMeshEndUpdateFB,
+			(XrTriangleMeshFB), mesh,
+			(uint32_t), vertexCount,
+			(uint32_t), triangle_count)
+
+	// Update the vertex positions of a triangle mesh. Can only be called once the mesh topology has
+	// been set using `xrTriangleMeshBeginUpdateFB`/`xrTriangleMeshEndUpdateFB`. The
+	// vertex count is defined by the last invocation to `xrTriangleMeshEndUpdateFB`. Once the
+	// modification is done, `xrTriangleMeshEndVertexBufferUpdateFB` must be called.
+	EXT_PROTO_XRRESULT_FUNC2(xrTriangleMeshBeginVertexBufferUpdateFB,
+			(XrTriangleMeshFB), mesh,
+			(uint32_t *), out_vertex_count)
+
+	// Signal the API that the contents of the vertex buffer data has been updated
+	// after a call to `xrTriangleMeshBeginVertexBufferUpdateFB`.
+	EXT_PROTO_XRRESULT_FUNC1(xrTriangleMeshEndVertexBufferUpdateFB, (XrTriangleMeshFB), mesh)
+
+	XRInterface::EnvironmentBlendMode get_blend_mode();
+
+	bool initialize_fb_passthrough_extension(const XrInstance instance);
+
+	bool initialize_fb_triangle_mesh_extension(const XrInstance instance);
+
+	void cleanup();
+
+	static OpenXRFbPassthroughExtensionWrapper *singleton;
+
+	std::map<godot::String, bool *> request_extensions;
+
+	bool fb_passthrough_ext = false; // required for any passthrough functionality
+	bool fb_triangle_mesh_ext = false; // only use for projected passthrough
+
+	XRInterface::EnvironmentBlendMode previous_blend_mode = XRInterface::XR_ENV_BLEND_MODE_OPAQUE;
+
+	XrPassthroughFB passthrough_handle = XR_NULL_HANDLE;
+	XrPassthroughLayerFB passthrough_layer = XR_NULL_HANDLE;
+
+	XrCompositionLayerPassthroughFB composition_passthrough_layer = {
+		XR_TYPE_COMPOSITION_LAYER_PASSTHROUGH_FB,
+		nullptr,
+		XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT,
+		XR_NULL_HANDLE,
+		XR_NULL_HANDLE,
+	};
+};
+
+#endif // OPENXR_FB_PASSTHROUGH_EXTENSION_WRAPPER_H

--- a/common/src/main/cpp/register_types.cpp
+++ b/common/src/main/cpp/register_types.cpp
@@ -44,6 +44,7 @@
 #include "export/pico_export_plugin.h"
 
 #include "extensions/openxr_fb_face_tracking_extension_wrapper.h"
+#include "extensions/openxr_fb_passthrough_extension_wrapper.h"
 #include "extensions/openxr_fb_render_model_extension_wrapper.h"
 #include "extensions/openxr_fb_scene_capture_extension_wrapper.h"
 #include "extensions/openxr_fb_scene_extension_wrapper.h"
@@ -58,6 +59,9 @@ using namespace godot;
 void initialize_plugin_module(ModuleInitializationLevel p_level) {
 	switch (p_level) {
 		case MODULE_INITIALIZATION_LEVEL_CORE: {
+			ClassDB::register_class<OpenXRFbPassthroughExtensionWrapper>();
+			OpenXRFbPassthroughExtensionWrapper::get_singleton()->register_extension_wrapper();
+
 			ClassDB::register_class<OpenXRFbRenderModelExtensionWrapper>();
 			OpenXRFbRenderModelExtensionWrapper::get_singleton()->register_extension_wrapper();
 
@@ -84,6 +88,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			break;
 
 		case MODULE_INITIALIZATION_LEVEL_SCENE: {
+			Engine::get_singleton()->register_singleton("OpenXRFbPassthroughExtensionWrapper", OpenXRFbPassthroughExtensionWrapper::get_singleton());
 			Engine::get_singleton()->register_singleton("OpenXRFbRenderModelExtensionWrapper", OpenXRFbRenderModelExtensionWrapper::get_singleton());
 			Engine::get_singleton()->register_singleton("OpenXRFbSceneCaptureExtensionWrapper", OpenXRFbSceneCaptureExtensionWrapper::get_singleton());
 			Engine::get_singleton()->register_singleton("OpenXRFbSpatialEntityExtensionWrapper", OpenXRFbSpatialEntityExtensionWrapper::get_singleton());

--- a/demo/addons/godotopenxrvendors/plugin.gdextension
+++ b/demo/addons/godotopenxrvendors/plugin.gdextension
@@ -1,7 +1,7 @@
 [configuration]
 
 entry_symbol = "plugin_library_init"
-compatibility_minimum = "4.2"
+compatibility_minimum = "4.3"
 android_aar_plugin = true
 
 [libraries]


### PR DESCRIPTION
This depends on PR https://github.com/godotengine/godot/pull/87630

Moving `XR_FB_passthrough` into 'godot_openxr_vendors' would allow us to expand the passthrough functionality to include more Meta-specific features, which wouldn't necessarily be accepted into Godot.

**Note: This will fail CI until the Godot PR is merged, and we start using an `extension_api.json` from Godot master.**