### PR TITLE
Fix double free

### DIFF
--- a/godotopenxrkhronos/src/main/cpp/export/khronos_export_plugin.cpp
+++ b/godotopenxrkhronos/src/main/cpp/export/khronos_export_plugin.cpp
@@ -35,7 +35,7 @@ void KhronosEditorPlugin::_bind_methods() {}
 
 void KhronosEditorPlugin::_enter_tree() {
 	// Initialize the editor export plugin
-	khronos_export_plugin = memnew(KhronosEditorExportPlugin);
+	khronos_export_plugin.instantiate();
 	add_export_plugin(khronos_export_plugin);
 }
 
@@ -43,8 +43,7 @@ void KhronosEditorPlugin::_exit_tree() {
 	// Clean up the editor export plugin
 	remove_export_plugin(khronos_export_plugin);
 
-	memfree(khronos_export_plugin);
-	khronos_export_plugin = nullptr;
+	khronos_export_plugin.unref();
 }
 
 KhronosEditorExportPlugin::KhronosEditorExportPlugin() {

--- a/godotopenxrkhronos/src/main/cpp/export/khronos_export_plugin.h
+++ b/godotopenxrkhronos/src/main/cpp/export/khronos_export_plugin.h
@@ -58,5 +58,5 @@ protected:
 	static void _bind_methods();
 
 private:
-	KhronosEditorExportPlugin *khronos_export_plugin = nullptr;
+	Ref<KhronosEditorExportPlugin> khronos_export_plugin;
 };

--- a/godotopenxrlynx/src/main/cpp/export/lynx_export_plugin.cpp
+++ b/godotopenxrlynx/src/main/cpp/export/lynx_export_plugin.cpp
@@ -35,7 +35,7 @@ void LynxEditorPlugin::_bind_methods() {}
 
 void LynxEditorPlugin::_enter_tree() {
 	// Initialize the editor export plugin
-	lynx_export_plugin = memnew(OpenXREditorExportPlugin);
+	lynx_export_plugin.instantiate();
 	lynx_export_plugin->set_vendor_name(LYNX_VENDOR_NAME);
 	add_export_plugin(lynx_export_plugin);
 }
@@ -44,6 +44,5 @@ void LynxEditorPlugin::_exit_tree() {
 	// Clean up the editor export plugin
 	remove_export_plugin(lynx_export_plugin);
 
-	memfree(lynx_export_plugin);
-	lynx_export_plugin = nullptr;
+	lynx_export_plugin.unref();
 }

--- a/godotopenxrlynx/src/main/cpp/export/lynx_export_plugin.h
+++ b/godotopenxrlynx/src/main/cpp/export/lynx_export_plugin.h
@@ -46,5 +46,5 @@ protected:
 	static void _bind_methods();
 
 private:
-	OpenXREditorExportPlugin *lynx_export_plugin = nullptr;
+	Ref<OpenXREditorExportPlugin> lynx_export_plugin;
 };

--- a/godotopenxrmeta/src/main/cpp/export/meta_export_plugin.cpp
+++ b/godotopenxrmeta/src/main/cpp/export/meta_export_plugin.cpp
@@ -37,7 +37,7 @@ void MetaEditorPlugin::_bind_methods() {}
 
 void MetaEditorPlugin::_enter_tree() {
 	// Initialize the editor export plugin
-	meta_export_plugin = memnew(MetaEditorExportPlugin);
+	meta_export_plugin.instantiate();
 	add_export_plugin(meta_export_plugin);
 }
 
@@ -45,8 +45,7 @@ void MetaEditorPlugin::_exit_tree() {
 	// Clean up the editor export plugin
 	remove_export_plugin(meta_export_plugin);
 
-	memfree(meta_export_plugin);
-	meta_export_plugin = nullptr;
+	meta_export_plugin.unref();
 }
 
 MetaEditorExportPlugin::MetaEditorExportPlugin() {

--- a/godotopenxrmeta/src/main/cpp/export/meta_export_plugin.h
+++ b/godotopenxrmeta/src/main/cpp/export/meta_export_plugin.h
@@ -101,6 +101,5 @@ protected:
 	static void _bind_methods();
 
 private:
-	MetaEditorExportPlugin *meta_export_plugin = nullptr;
-
+	Ref<MetaEditorExportPlugin> meta_export_plugin;
 };

--- a/godotopenxrpico/src/main/cpp/export/pico_export_plugin.cpp
+++ b/godotopenxrpico/src/main/cpp/export/pico_export_plugin.cpp
@@ -35,7 +35,7 @@ void PicoEditorPlugin::_bind_methods() {}
 
 void PicoEditorPlugin::_enter_tree() {
 	// Initialize the editor export plugin
-	pico_export_plugin = memnew(OpenXREditorExportPlugin);
+	pico_export_plugin.instantiate();
 	pico_export_plugin->set_vendor_name(PICO_VENDOR_NAME);
 	add_export_plugin(pico_export_plugin);
 }
@@ -44,6 +44,5 @@ void PicoEditorPlugin::_exit_tree() {
 	// Clean up the editor export plugin
 	remove_export_plugin(pico_export_plugin);
 
-	memfree(pico_export_plugin);
-	pico_export_plugin = nullptr;
+	pico_export_plugin.unref();
 }

--- a/godotopenxrpico/src/main/cpp/export/pico_export_plugin.h
+++ b/godotopenxrpico/src/main/cpp/export/pico_export_plugin.h
@@ -46,5 +46,5 @@ protected:
 	static void _bind_methods();
 
 private:
-	OpenXREditorExportPlugin *pico_export_plugin = nullptr;
+	Ref<OpenXREditorExportPlugin> pico_export_plugin;
 };


### PR DESCRIPTION
I looked at the stack trace with gdb after reproducing #67 to see a double free error: 
```
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=139885056115072)
    at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=139885056115072)
    at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=139885056115072, signo=signo@entry=6)
    at ./nptl/pthread_kill.c:89
#3  0x00007f3987187476 in __GI_raise (sig=sig@entry=6)
    at ../sysdeps/posix/raise.c:26
#4  0x00007f398716d885 in __GI_abort () at ./stdlib/abort.c:100
#5  0x00007f39871ce676 in __libc_message (action=action@entry=do_abort, 
    fmt=fmt@entry=0x7f3987320b77 "%s\n") at ../sysdeps/posix/libc_fatal.c:155
#6  0x00007f39871e5cfc in malloc_printerr (
    str=str@entry=0x7f39873236f0 "free(): double free detected in tcache 2")
    at ./malloc/malloc.c:5664
#7  0x00007f39871e80ab in _int_free (av=0x7f398735fc80 <main_arena>, 
    p=0x1faab050, have_lock=0) at ./malloc/malloc.c:4473
#8  0x00007f39871ea453 in __GI___libc_free (mem=<optimized out>)
    at ./malloc/malloc.c:3391
#9  0x00007f397f8126e2 in ?? ()
   from /path/to/game/addons/godotopenxrvendors/pico/.bin/libgodotopenxrpico.linux.template_debug.x86_64.so
```
I've noticed that remove_export_plugin [frees the export plugin](https://github.com/godotengine/godot/blob/4.2/editor/export/editor_export.cpp#L162) meaning that the memfree called after is throwing the error.

I can't test it, but I'm almost sure this fixes the error. I haven't worked with C++ yet, first time.