### PR TITLE
Implement XR_FB_hand_tracking_aim extension

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - Add XR_FB_render_model extension wrapper and OpenXRFBRenderModel node
 - Add XR_FB_passthrough extension wrapper
 - Add XR_FB_hand_tracking_mesh extension wrapper and OpenXRFbHandTrackingMesh node
+- Add XR_FB_hand_tracking_aim support
 
 ## 2.0.3
 - Migrate the export scripts from gdscript to C++ via gdextension

--- a/common/src/main/cpp/extensions/openxr_fb_hand_tracking_aim_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_fb_hand_tracking_aim_extension_wrapper.cpp
@@ -1,0 +1,193 @@
+/**************************************************************************/
+/*  openxr_fb_hand_tracking_aim_extension_wrapper.cpp                     */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "extensions/openxr_fb_hand_tracking_aim_extension_wrapper.h"
+
+#include <godot_cpp/classes/project_settings.hpp>
+#include <godot_cpp/classes/xr_pose.hpp>
+
+using namespace godot;
+
+OpenXRFbHandTrackingAimExtensionWrapper *OpenXRFbHandTrackingAimExtensionWrapper::singleton = nullptr;
+
+OpenXRFbHandTrackingAimExtensionWrapper *OpenXRFbHandTrackingAimExtensionWrapper::get_singleton() {
+	if (singleton == nullptr) {
+		singleton = memnew(OpenXRFbHandTrackingAimExtensionWrapper());
+	}
+	return singleton;
+}
+
+OpenXRFbHandTrackingAimExtensionWrapper::OpenXRFbHandTrackingAimExtensionWrapper() :
+		OpenXRExtensionWrapperExtension() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "An OpenXRFbHandTrackingAimExtensionWrapper singleton already exists.");
+
+	request_extensions[XR_FB_HAND_TRACKING_AIM_EXTENSION_NAME] = &fb_hand_tracking_aim_ext;
+	singleton = this;
+}
+
+OpenXRFbHandTrackingAimExtensionWrapper::~OpenXRFbHandTrackingAimExtensionWrapper() {
+	cleanup();
+}
+
+void OpenXRFbHandTrackingAimExtensionWrapper::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_enabled"), &OpenXRFbHandTrackingAimExtensionWrapper::is_enabled);
+}
+
+void OpenXRFbHandTrackingAimExtensionWrapper::cleanup() {
+	XRServer *xr_server = XRServer::get_singleton();
+
+	for (int i = 0; i < Hand::HAND_MAX; i++) {
+		if (xr_server != nullptr) {
+			xr_server->remove_tracker(trackers[i]);
+		}
+		trackers[i].unref();
+	}
+
+	fb_hand_tracking_aim_ext = false;
+}
+
+godot::Dictionary OpenXRFbHandTrackingAimExtensionWrapper::_get_requested_extensions() {
+	godot::Dictionary result;
+	for (auto ext : request_extensions) {
+		godot::String key = ext.first;
+		uint64_t value = reinterpret_cast<uint64_t>(ext.second);
+		result[key] = (godot::Variant)value;
+	}
+	return result;
+}
+
+PackedStringArray OpenXRFbHandTrackingAimExtensionWrapper::_get_suggested_tracker_names() {
+	PackedStringArray arr = PackedStringArray();
+	arr.push_back(TRACKER_NAME_LEFT);
+	arr.push_back(TRACKER_NAME_RIGHT);
+	return arr;
+}
+
+void OpenXRFbHandTrackingAimExtensionWrapper::_on_state_ready() {
+	is_project_setting_enabled = ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/hand_tracking_aim");
+	if (!is_project_setting_enabled) {
+		return;
+	}
+
+	XRServer *xr_server = XRServer::get_singleton();
+	if (xr_server == nullptr) {
+		return;
+	}
+
+	trackers[Hand::HAND_LEFT].instantiate();
+	trackers[Hand::HAND_LEFT]->set_tracker_type(XRServer::TRACKER_CONTROLLER);
+	trackers[Hand::HAND_LEFT]->set_tracker_name(TRACKER_NAME_LEFT);
+	trackers[Hand::HAND_LEFT]->set_tracker_desc("FB Aim tracker Left");
+	xr_server->add_tracker(trackers[Hand::HAND_LEFT]);
+
+	trackers[Hand::HAND_RIGHT].instantiate();
+	trackers[Hand::HAND_RIGHT]->set_tracker_type(XRServer::TRACKER_CONTROLLER);
+	trackers[Hand::HAND_RIGHT]->set_tracker_name(TRACKER_NAME_RIGHT);
+	trackers[Hand::HAND_RIGHT]->set_tracker_desc("FB Aim tracker Right");
+	xr_server->add_tracker(trackers[Hand::HAND_RIGHT]);
+}
+
+void OpenXRFbHandTrackingAimExtensionWrapper::_on_instance_destroyed() {
+	cleanup();
+}
+
+uint64_t OpenXRFbHandTrackingAimExtensionWrapper::_set_hand_joint_locations_and_get_next_pointer(int32_t p_hand_index, void *p_next_pointer) {
+	ERR_FAIL_INDEX_V_MSG(p_hand_index, Hand::HAND_MAX, reinterpret_cast<uint64_t>(p_next_pointer), vformat("Invalid hand index %d", p_hand_index));
+
+	if (!fb_hand_tracking_aim_ext) {
+		return reinterpret_cast<uint64_t>(p_next_pointer);
+	}
+
+	aim_state[p_hand_index] = {
+		XR_TYPE_HAND_TRACKING_AIM_STATE_FB, // type
+		p_next_pointer, // next
+		0, // status
+		{ { 0, 0, 0, 0 }, { 0, 0, 0 } }, // aimPose
+		0, // pinchStrengthIndex
+		0, // pinchStrengthMiddle
+		0, // pinchStrengthRing
+		0, // pinchStrengthLittle
+	};
+
+	return reinterpret_cast<uint64_t>(&aim_state[p_hand_index]);
+}
+
+void OpenXRFbHandTrackingAimExtensionWrapper::_on_process() {
+	if (!is_enabled() || !is_project_setting_enabled) {
+		return;
+	}
+
+	for (int i = 0; i < Hand::HAND_MAX; i++) {
+		if (!trackers[i].is_valid()) {
+			continue;
+		}
+
+		XrPosef aim_pose = aim_state[i].aimPose;
+		XrQuaternionf aim_quat = aim_pose.orientation;
+		XrVector3f aim_position = aim_pose.position;
+		Quaternion quat = Quaternion(aim_quat.x, aim_quat.y, aim_quat.z, aim_quat.w);
+		Vector3 origin = Vector3(aim_position.x, aim_position.y, aim_position.z);
+
+		Transform3D transform = Transform3D(quat, origin);
+		Vector3 linear_velocity = Vector3(0.0, 0.0, 0.0);
+		Vector3 angular_velocity = Vector3(0.0, 0.0, 0.0);
+
+		XRPose::TrackingConfidence confidence = XRPose::TrackingConfidence::XR_TRACKING_CONFIDENCE_LOW;
+		if (!(aim_state[i].status & XR_HAND_TRACKING_AIM_VALID_BIT_FB)) {
+			confidence = XRPose::TrackingConfidence::XR_TRACKING_CONFIDENCE_NONE;
+		}
+
+		trackers[i]->set_pose("default", transform, linear_velocity, angular_velocity, confidence);
+		trackers[i]->set_input("index_pinch", (bool)(aim_state[i].status & XR_HAND_TRACKING_AIM_INDEX_PINCHING_BIT_FB));
+		trackers[i]->set_input("middle_pinch", (bool)(aim_state[i].status & XR_HAND_TRACKING_AIM_MIDDLE_PINCHING_BIT_FB));
+		trackers[i]->set_input("ring_pinch", (bool)(aim_state[i].status & XR_HAND_TRACKING_AIM_RING_PINCHING_BIT_FB));
+		trackers[i]->set_input("little_pinch", (bool)(aim_state[i].status & XR_HAND_TRACKING_AIM_LITTLE_PINCHING_BIT_FB));
+		trackers[i]->set_input("index_pinch_strength", aim_state[i].pinchStrengthIndex);
+		trackers[i]->set_input("middle_pinch_strength", aim_state[i].pinchStrengthMiddle);
+		trackers[i]->set_input("ring_pinch_strength", aim_state[i].pinchStrengthRing);
+		trackers[i]->set_input("little_pinch_strength", aim_state[i].pinchStrengthLittle);
+		trackers[i]->set_input("system_gesture", (bool)(aim_state[i].status & XR_HAND_TRACKING_AIM_SYSTEM_GESTURE_BIT_FB));
+		trackers[i]->set_input("menu_gesture", (bool)(aim_state[i].status & XR_HAND_TRACKING_AIM_MENU_PRESSED_BIT_FB));
+		trackers[i]->set_input("dominant_hand", (bool)(aim_state[i].status & XR_HAND_TRACKING_AIM_DOMINANT_HAND_BIT_FB));
+	}
+}
+
+void OpenXRFbHandTrackingAimExtensionWrapper::add_project_setting() {
+	String p_name = "xr/openxr/extensions/hand_tracking_aim";
+	if (!ProjectSettings::get_singleton()->has_setting(p_name)) {
+		ProjectSettings::get_singleton()->set_setting(p_name, false);
+	}
+
+	ProjectSettings::get_singleton()->set_initial_value(p_name, false);
+	Dictionary property_info;
+	property_info["name"] = p_name;
+	property_info["type"] = Variant::Type::BOOL;
+	property_info["hint"] = PROPERTY_HINT_NONE;
+	ProjectSettings::get_singleton()->add_property_info(property_info);
+}

--- a/common/src/main/cpp/include/extensions/openxr_fb_hand_tracking_aim_extension_wrapper.h
+++ b/common/src/main/cpp/include/extensions/openxr_fb_hand_tracking_aim_extension_wrapper.h
@@ -1,0 +1,93 @@
+/**************************************************************************/
+/*  openxr_fb_hand_tracking_aim_extension_wrapper.h                       */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef OPENXR_FB_HAND_TRACKING_AIM_EXTENSION_WRAPPER_H
+#define OPENXR_FB_HAND_TRACKING_AIM_EXTENSION_WRAPPER_H
+
+#include <openxr/openxr.h>
+#include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
+#include <godot_cpp/classes/open_xr_interface.hpp>
+#include <godot_cpp/classes/xr_positional_tracker.hpp>
+
+#include <map>
+
+using namespace godot;
+
+// Wrapper for the set of Facebook XR hand tracking aim extension.
+class OpenXRFbHandTrackingAimExtensionWrapper : public OpenXRExtensionWrapperExtension {
+	GDCLASS(OpenXRFbHandTrackingAimExtensionWrapper, OpenXRExtensionWrapperExtension);
+
+public:
+	using Hand = OpenXRInterface::Hand;
+
+	godot::Dictionary _get_requested_extensions() override;
+
+	PackedStringArray _get_suggested_tracker_names() override;
+
+	void _on_state_ready() override;
+
+	void _on_instance_destroyed() override;
+
+	uint64_t _set_hand_joint_locations_and_get_next_pointer(int32_t p_hand_index, void *p_next_pointer) override;
+
+	bool is_enabled() {
+		return fb_hand_tracking_aim_ext;
+	}
+
+	void _on_process() override;
+
+	void add_project_setting();
+
+	static OpenXRFbHandTrackingAimExtensionWrapper *get_singleton();
+
+	OpenXRFbHandTrackingAimExtensionWrapper();
+	~OpenXRFbHandTrackingAimExtensionWrapper();
+
+protected:
+	static void _bind_methods();
+
+private:
+	std::map<godot::String, bool *> request_extensions;
+
+	void cleanup();
+
+	static OpenXRFbHandTrackingAimExtensionWrapper *singleton;
+
+	const String TRACKER_NAME_LEFT = "/user/fbhandaim/left";
+	const String TRACKER_NAME_RIGHT = "/user/fbhandaim/right";
+
+	bool fb_hand_tracking_aim_ext = false;
+	bool is_project_setting_enabled = false;
+
+	Ref<XRPositionalTracker> trackers[Hand::HAND_MAX];
+
+	XrHandTrackingAimStateFB aim_state[Hand::HAND_MAX];
+};
+
+#endif // OPENXR_FB_HAND_TRACKING_AIM_EXTENSION_WRAPPER_H

--- a/common/src/main/cpp/register_types.cpp
+++ b/common/src/main/cpp/register_types.cpp
@@ -44,6 +44,7 @@
 #include "export/pico_export_plugin.h"
 
 #include "extensions/openxr_fb_face_tracking_extension_wrapper.h"
+#include "extensions/openxr_fb_hand_tracking_aim_extension_wrapper.h"
 #include "extensions/openxr_fb_hand_tracking_mesh_extension_wrapper.h"
 #include "extensions/openxr_fb_passthrough_extension_wrapper.h"
 #include "extensions/openxr_fb_render_model_extension_wrapper.h"
@@ -87,6 +88,9 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 
 			ClassDB::register_class<OpenXRFbHandTrackingMeshExtensionWrapper>();
 			OpenXRFbHandTrackingMeshExtensionWrapper::get_singleton()->register_extension_wrapper();
+
+			ClassDB::register_class<OpenXRFbHandTrackingAimExtensionWrapper>();
+			OpenXRFbHandTrackingAimExtensionWrapper::get_singleton()->register_extension_wrapper();
 		} break;
 
 		case MODULE_INITIALIZATION_LEVEL_SERVERS:
@@ -101,9 +105,12 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			Engine::get_singleton()->register_singleton("OpenXRFbSpatialEntityContainerExtensionWrapper", OpenXRFbSpatialEntityContainerExtensionWrapper::get_singleton());
 			Engine::get_singleton()->register_singleton("OpenXRFbSceneExtensionWrapper", OpenXRFbSceneExtensionWrapper::get_singleton());
 			Engine::get_singleton()->register_singleton("OpenXRFbFaceTrackingExtensionWrapper", OpenXRFbFaceTrackingExtensionWrapper::get_singleton());
+			Engine::get_singleton()->register_singleton("OpenXRFbHandTrackingAimExtensionWrapper", OpenXRFbHandTrackingAimExtensionWrapper::get_singleton());
 
 			ClassDB::register_class<OpenXRFbRenderModel>();
 			ClassDB::register_class<OpenXRFbHandTrackingMesh>();
+
+			OpenXRFbHandTrackingAimExtensionWrapper::get_singleton()->add_project_setting();
 		} break;
 
 		case MODULE_INITIALIZATION_LEVEL_EDITOR: {

--- a/demo/main.gd
+++ b/demo/main.gd
@@ -1,5 +1,7 @@
 extends Node3D
 
+@onready var left_hand: XRController3D = $XROrigin3D/LeftHand
+@onready var right_hand: XRController3D = $XROrigin3D/RightHand
 @onready var left_hand_mesh: MeshInstance3D = $XROrigin3D/LeftHand/LeftHandMesh
 @onready var right_hand_mesh: MeshInstance3D = $XROrigin3D/RightHand/RightHandMesh
 @onready var left_controller_model: OpenXRFbRenderModel = $XROrigin3D/LeftHand/LeftControllerFbRenderModel
@@ -32,6 +34,22 @@ func _physics_process(_delta: float) -> void:
 
 		var controller = left_controller_model if (hand == OpenXRInterface.HAND_LEFT) else right_controller_model
 		controller.visible = (source == OpenXRInterface.HAND_TRACKED_SOURCE_CONTROLLER)
+
+		if source == OpenXRInterface.HAND_TRACKED_SOURCE_UNOBSTRUCTED:
+			match hand:
+				OpenXRInterface.HAND_LEFT:
+					left_hand.tracker = "/user/fbhandaim/left"
+				OpenXRInterface.HAND_RIGHT:
+					right_hand.tracker = "/user/fbhandaim/right"
+		else:
+			match hand:
+				OpenXRInterface.HAND_LEFT:
+					left_hand.tracker = "left_hand"
+					left_hand.pose = "grip"
+				OpenXRInterface.HAND_RIGHT:
+					right_hand.tracker = "right_hand"
+					right_hand.pose = "grip"
+
 		hand_tracking_source[hand] = source
 
 

--- a/demo/main.tscn
+++ b/demo/main.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=15 format=3 uid="uid://cqsodpswgup8w"]
+[gd_scene load_steps=16 format=3 uid="uid://cqsodpswgup8w"]
 
 [ext_resource type="Script" path="res://main.gd" id="1_fsva1"]
 [ext_resource type="PackedScene" uid="uid://c0uv4eu2yjm3b" path="res://viewport_2d_in_3d.tscn" id="2_7whgo"]
 [ext_resource type="PackedScene" uid="uid://d4b4rllli6tqp" path="res://tablet_content.tscn" id="3_45w5g"]
 [ext_resource type="PackedScene" uid="uid://ikxieb2fyavg" path="res://assets/face/Face.gltf" id="4_wrwst"]
+[ext_resource type="PackedScene" uid="uid://bwfyi8pgigune" path="res://xr_fb_hand_tracking_aim_demo.tscn" id="5_6bxyh"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_0x6cv"]
 sky_horizon_color = Color(0.64625, 0.65575, 0.67075, 1)
@@ -62,6 +63,7 @@ tracker = &"left_hand"
 pose = &"grip"
 
 [node name="LeftHandMesh" type="MeshInstance3D" parent="XROrigin3D/LeftHand"]
+visible = false
 mesh = SubResource("BoxMesh_3kt6b")
 
 [node name="HandTablet" type="MeshInstance3D" parent="XROrigin3D/LeftHand"]
@@ -85,6 +87,7 @@ tracker = &"right_hand"
 pose = &"grip"
 
 [node name="RightHandMesh" type="MeshInstance3D" parent="XROrigin3D/RightHand"]
+visible = false
 mesh = SubResource("BoxMesh_ey3x4")
 
 [node name="RightControllerFbRenderModel" type="OpenXRFbRenderModel" parent="XROrigin3D/RightHand"]
@@ -119,8 +122,15 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.4, -1)
 [node name="XRFaceModifier3D" type="XRFaceModifier3D" parent="Floor/TrackedFace/Face/Face" index="0"]
 target = NodePath("..")
 
+[node name="XRFbHandTrackingAimDemo" parent="." instance=ExtResource("5_6bxyh")]
+transform = Transform3D(0.707107, 0, 0.707107, 0, 1, 0, -0.707107, 0, 0.707107, -1, 1, -1)
+
 [connection signal="button_pressed" from="XROrigin3D/LeftHand" to="." method="_on_left_hand_button_pressed"]
+[connection signal="button_pressed" from="XROrigin3D/LeftHand" to="XRFbHandTrackingAimDemo" method="_on_left_hand_button_pressed"]
+[connection signal="button_released" from="XROrigin3D/LeftHand" to="XRFbHandTrackingAimDemo" method="_on_left_hand_button_released"]
 [connection signal="openxr_fb_render_model_loaded" from="XROrigin3D/LeftHand/LeftControllerFbRenderModel" to="." method="_on_left_controller_fb_render_model_render_model_loaded"]
+[connection signal="button_pressed" from="XROrigin3D/RightHand" to="XRFbHandTrackingAimDemo" method="_on_right_hand_button_pressed"]
+[connection signal="button_released" from="XROrigin3D/RightHand" to="XRFbHandTrackingAimDemo" method="_on_right_hand_button_released"]
 [connection signal="openxr_fb_render_model_loaded" from="XROrigin3D/RightHand/RightControllerFbRenderModel" to="." method="_on_right_controller_fb_render_model_render_model_loaded"]
 
 [editable path="Floor/TrackedFace/Face"]

--- a/demo/project.godot
+++ b/demo/project.godot
@@ -30,3 +30,4 @@ textures/vram_compression/import_etc2_astc=true
 openxr/enabled=true
 openxr/extensions/eye_gaze_interaction=true
 shaders/enabled=true
+openxr/extensions/hand_tracking_aim=true

--- a/demo/xr_fb_hand_tracking_aim_demo.gd
+++ b/demo/xr_fb_hand_tracking_aim_demo.gd
@@ -1,0 +1,67 @@
+extends Node3D
+
+@onready var little_left: MeshInstance3D = $LittleLeft
+@onready var ring_left: MeshInstance3D = $RingLeft
+@onready var middle_left: MeshInstance3D = $MiddleLeft
+@onready var index_left: MeshInstance3D = $IndexLeft
+@onready var little_right: MeshInstance3D = $LittleRight
+@onready var ring_right: MeshInstance3D = $RingRight
+@onready var middle_right: MeshInstance3D = $MiddleRight
+@onready var index_right: MeshInstance3D = $IndexRight
+@onready var system_gesture_left: MeshInstance3D = $SystemGestureLeft
+@onready var system_gesture_right: MeshInstance3D = $SystemGestureRight
+
+func _on_right_hand_button_pressed(name: String) -> void:
+	match name:
+		"index_pinch":
+			index_right.material_override.albedo_color = Color.GREEN
+		"middle_pinch":
+			middle_right.material_override.albedo_color = Color.GREEN
+		"ring_pinch":
+			ring_right.material_override.albedo_color = Color.GREEN
+		"little_pinch":
+			little_right.material_override.albedo_color = Color.GREEN
+		"system_gesture":
+			system_gesture_right.material_override.albedo_color = Color.GREEN
+
+
+func _on_right_hand_button_released(name: String) -> void:
+	match name:
+		"index_pinch":
+			index_right.material_override.albedo_color = Color.RED
+		"middle_pinch":
+			middle_right.material_override.albedo_color = Color.RED
+		"ring_pinch":
+			ring_right.material_override.albedo_color = Color.RED
+		"little_pinch":
+			little_right.material_override.albedo_color = Color.RED
+		"system_gesture":
+			system_gesture_right.material_override.albedo_color = Color.RED
+
+
+func _on_left_hand_button_pressed(name: String) -> void:
+	match name:
+		"index_pinch":
+			index_left.material_override.albedo_color = Color.GREEN
+		"middle_pinch":
+			middle_left.material_override.albedo_color = Color.GREEN
+		"ring_pinch":
+			ring_left.material_override.albedo_color = Color.GREEN
+		"little_pinch":
+			little_left.material_override.albedo_color = Color.GREEN
+		"system_gesture":
+			system_gesture_left.material_override.albedo_color = Color.GREEN
+
+
+func _on_left_hand_button_released(name: String) -> void:
+	match name:
+		"index_pinch":
+			index_left.material_override.albedo_color = Color.RED
+		"middle_pinch":
+			middle_left.material_override.albedo_color = Color.RED
+		"ring_pinch":
+			ring_left.material_override.albedo_color = Color.RED
+		"little_pinch":
+			little_left.material_override.albedo_color = Color.RED
+		"system_gesture":
+			system_gesture_left.material_override.albedo_color = Color.RED

--- a/demo/xr_fb_hand_tracking_aim_demo.tscn
+++ b/demo/xr_fb_hand_tracking_aim_demo.tscn
@@ -1,0 +1,178 @@
+[gd_scene load_steps=14 format=3 uid="uid://bwfyi8pgigune"]
+
+[ext_resource type="Script" path="res://xr_fb_hand_tracking_aim_demo.gd" id="1_uw1lv"]
+
+[sub_resource type="PlaneMesh" id="PlaneMesh_w5hi3"]
+size = Vector2(2, 1)
+orientation = 2
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_st2lk"]
+albedo_color = Color(1, 0.0803461, 0, 1)
+
+[sub_resource type="CylinderMesh" id="CylinderMesh_7osyw"]
+top_radius = 0.075
+bottom_radius = 0.075
+height = 0.05
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_lm06k"]
+albedo_color = Color(1, 0.0803461, 0, 1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_kqv6h"]
+albedo_color = Color(1, 0.0803461, 0, 1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_c5c27"]
+albedo_color = Color(1, 0.0803461, 0, 1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_sis8y"]
+albedo_color = Color(1, 0.0784314, 0, 1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_qpvbn"]
+albedo_color = Color(1, 0.0784314, 0, 1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_25a4t"]
+albedo_color = Color(1, 0.0803461, 0, 1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_sfj61"]
+albedo_color = Color(1, 0.0803461, 0, 1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_k36l5"]
+albedo_color = Color(1, 0.0803461, 0, 1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_7hmop"]
+albedo_color = Color(1, 0.0784314, 0, 1)
+
+[node name="XRFbHandTrackingAimDemo" type="Node3D"]
+script = ExtResource("1_uw1lv")
+
+[node name="Back" type="MeshInstance3D" parent="."]
+mesh = SubResource("PlaneMesh_w5hi3")
+
+[node name="IndexLeft" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -0.2, 0.1, 0.0170253)
+material_override = SubResource("StandardMaterial3D_st2lk")
+mesh = SubResource("CylinderMesh_7osyw")
+skeleton = NodePath("../Back")
+metadata/_edit_group_ = true
+
+[node name="Label3D" type="Label3D" parent="IndexLeft"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 5.96046e-08, 0.00532681, -0.2)
+text = "Index
+Left"
+font_size = 12
+
+[node name="MiddleLeft" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -0.4, 0.1, 0.0170253)
+material_override = SubResource("StandardMaterial3D_lm06k")
+mesh = SubResource("CylinderMesh_7osyw")
+skeleton = NodePath("../Back")
+metadata/_edit_group_ = true
+
+[node name="Label3D" type="Label3D" parent="MiddleLeft"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 5.96046e-08, 0.00532681, -0.2)
+text = "Middle
+Left"
+font_size = 12
+
+[node name="RingLeft" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -0.6, 0.1, 0.0170253)
+material_override = SubResource("StandardMaterial3D_kqv6h")
+mesh = SubResource("CylinderMesh_7osyw")
+skeleton = NodePath("../Back")
+metadata/_edit_group_ = true
+
+[node name="Label3D" type="Label3D" parent="RingLeft"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 5.96046e-08, 0.00532681, -0.2)
+text = "Ring
+Left"
+font_size = 12
+
+[node name="LittleLeft" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -0.8, 0.1, 0.0170253)
+material_override = SubResource("StandardMaterial3D_c5c27")
+mesh = SubResource("CylinderMesh_7osyw")
+skeleton = NodePath("../Back")
+metadata/_edit_group_ = true
+
+[node name="Label3D" type="Label3D" parent="LittleLeft"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 5.96046e-08, 0.00532681, -0.2)
+text = "Little
+Left"
+font_size = 12
+
+[node name="SystemGestureLeft" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, -0.5, -0.3, 0.0170253)
+material_override = SubResource("StandardMaterial3D_sis8y")
+mesh = SubResource("CylinderMesh_7osyw")
+skeleton = NodePath("../Back")
+metadata/_edit_group_ = true
+
+[node name="Label3D" type="Label3D" parent="SystemGestureLeft"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 5.96046e-08, 0.00532681, -0.2)
+text = "System Gesture
+Left"
+font_size = 12
+
+[node name="IndexRight" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.2, 0.1, 0.0170253)
+material_override = SubResource("StandardMaterial3D_qpvbn")
+mesh = SubResource("CylinderMesh_7osyw")
+skeleton = NodePath("../Back")
+metadata/_edit_group_ = true
+
+[node name="Label3D" type="Label3D" parent="IndexRight"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 5.96046e-08, 0.00532681, -0.2)
+text = "Index
+Right"
+font_size = 12
+
+[node name="MiddleRight" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.4, 0.1, 0.0170253)
+material_override = SubResource("StandardMaterial3D_25a4t")
+mesh = SubResource("CylinderMesh_7osyw")
+skeleton = NodePath("../Back")
+metadata/_edit_group_ = true
+
+[node name="Label3D" type="Label3D" parent="MiddleRight"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 5.96046e-08, 0.00532681, -0.2)
+text = "Middle
+Right"
+font_size = 12
+
+[node name="RingRight" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.6, 0.1, 0.0170253)
+material_override = SubResource("StandardMaterial3D_sfj61")
+mesh = SubResource("CylinderMesh_7osyw")
+skeleton = NodePath("../Back")
+metadata/_edit_group_ = true
+
+[node name="Label3D" type="Label3D" parent="RingRight"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 5.96046e-08, 0.00532681, -0.2)
+text = "Ring
+Right"
+font_size = 12
+
+[node name="LittleRight" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.8, 0.1, 0.0170253)
+material_override = SubResource("StandardMaterial3D_k36l5")
+mesh = SubResource("CylinderMesh_7osyw")
+skeleton = NodePath("../Back")
+metadata/_edit_group_ = true
+
+[node name="Label3D" type="Label3D" parent="LittleRight"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 5.96046e-08, 0.00532681, -0.2)
+text = "Little
+Right"
+font_size = 12
+
+[node name="SystemGestureRight" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.5, -0.3, 0.0170253)
+material_override = SubResource("StandardMaterial3D_7hmop")
+mesh = SubResource("CylinderMesh_7osyw")
+skeleton = NodePath("../Back")
+metadata/_edit_group_ = true
+
+[node name="Label3D" type="Label3D" parent="SystemGestureRight"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 5.96046e-08, 0.00532681, -0.2)
+text = "System Gesture
+Right"
+font_size = 12


### PR DESCRIPTION
This PR depends on Godot PR [87546](https://github.com/godotengine/godot/pull/87546)

Adds extension wrapper for the [XR_FB_hand_tracking_aim](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_FB_hand_tracking_aim) extension. The added singleton has methods to determine gesture states / pinch strength while hand tracking, and also provides a number of signals indicating when certain gestures begin/end.

Since this extension wrapper will only be supported by 4.3 onward, as well as the others listed in the above Godot PR, maybe it would make since to merge this into a 4.3 branch instead of master?

Also, one thing that might be worth discussing is how we should implement demos of these extension wrappers moving forward. Right now they're being dropped in `main.tscn`, but these are only meta extensions, so it doesn't really make sense to have them always present. Maybe we want to start thinking of implementing a menu to navigate implemented extensions and load corresponding demos?