### PR TITLE
Add additional export options for Meta Quest features

### DIFF
--- a/godotopenxrmeta/src/main/cpp/export/meta_export_plugin.h
+++ b/godotopenxrmeta/src/main/cpp/export/meta_export_plugin.h
@@ -52,6 +52,10 @@ static const int HAND_TRACKING_REQUIRED_VALUE = 2;
 static const int HAND_TRACKING_FREQUENCY_LOW_VALUE = 0;
 static const int HAND_TRACKING_FREQUENCY_HIGH_VALUE = 1;
 
+static const int BOUNDARY_ENABLED_VALUE = 0;
+static const int BOUNDARY_DISABLED_VALUE = 1;
+static const int BOUNDARY_CONTEXTUAL_VALUE = 2;
+
 } // namespace
 
 class MetaEditorExportPlugin : public OpenXREditorExportPlugin {
@@ -84,6 +88,9 @@ private:
 	Dictionary _passthrough_option;
 	Dictionary _use_anchor_api_option;
 	Dictionary _use_scene_api_option;
+	Dictionary _use_overlay_keyboard_option;
+	Dictionary _use_experimental_features_option;
+	Dictionary _boundary_mode_option;
 	Dictionary _support_quest_1_option;
 	Dictionary _support_quest_2_option;
 	Dictionary _support_quest_3_option;

--- a/godotopenxrmeta/src/main/java/org/godotengine/openxr/vendors/meta/GodotOpenXRMeta.kt
+++ b/godotopenxrmeta/src/main/java/org/godotengine/openxr/vendors/meta/GodotOpenXRMeta.kt
@@ -70,6 +70,7 @@ class GodotOpenXRMeta(godot: Godot?) : GodotPlugin(godot) {
         }
         // Request the scene API permission if it's included in the manifest
         if (PermissionsUtil.hasManifestPermission(activity, SCENE_PERMISSION)) {
+            Log.d(TAG, "Requesting permission '${SCENE_PERMISSION}'")
             PermissionsUtil.requestPermission(SCENE_PERMISSION, activity)
         }
         return null


### PR DESCRIPTION
A lot of Meta Quest features are gated by AndroidManifest flags. Adding export options to support:
- Experimental Features: https://developer.oculus.com/experimental/experimental-overview/
- Overlay Keyboard: https://developer.oculus.com/documentation/unity/unity-keyboard-overlay/
- Boundary Modes (can't find documentation, but already used by a few apps on the Quest Store)

Co-authored by @maunvz 