### PR TITLE
Fix XR_FB_face_tracking on PC

### DIFF
--- a/common/src/main/cpp/extensions/openxr_fb_face_tracking_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_fb_face_tracking_extension_wrapper.cpp
@@ -175,6 +175,7 @@ void OpenXRFbFaceTrackingExtensionWrapper::_on_session_created(uint64_t instance
 	}
 
 	// Configure the weights struct
+	face_expression_weights.type = XR_TYPE_FACE_EXPRESSION_WEIGHTS_FB;
 	face_expression_weights.weightCount = XR_FACE_EXPRESSION_COUNT_FB;
 	face_expression_weights.weights = weights;
 	face_expression_weights.confidenceCount  = XR_FACE_CONFIDENCE_COUNT_FB;
@@ -185,7 +186,7 @@ void OpenXRFbFaceTrackingExtensionWrapper::_on_session_created(uint64_t instance
 	createInfo.faceExpressionSet = XR_FACE_EXPRESSION_SET_DEFAULT_FB;
 	XrResult result = xrCreateFaceTrackerFB(SESSION, &createInfo, &face_tracker);
 	if (XR_FAILED(result)) {
-		UtilityFunctions::print("Failed to create face-tracker handle");
+		UtilityFunctions::print("Failed to create face-tracker handle: ", result);
 	}
 }
 
@@ -198,7 +199,7 @@ void OpenXRFbFaceTrackingExtensionWrapper::_on_session_destroyed() {
 	// Destroy the face-tracker handle
 	XrResult result = xrDestroyFaceTrackerFB(face_tracker);
 	if (XR_FAILED(result)) {
-		UtilityFunctions::print("Failed to destroy face-tracker handle");
+		UtilityFunctions::print("Failed to destroy face-tracker handle: ", result);
 	}
 	face_tracker = XR_NULL_HANDLE;
 
@@ -223,7 +224,7 @@ void OpenXRFbFaceTrackingExtensionWrapper::_on_process() {
 	expression_info.time = next_frame_time;
 	XrResult result = xrGetFaceExpressionWeightsFB(face_tracker, &expression_info, &face_expression_weights);
 	if (XR_FAILED(result)) {
-		UtilityFunctions::print("Failed to get face expression weights");
+		UtilityFunctions::print("Failed to get face expression weights: ", result);
 	}
 }
 


### PR DESCRIPTION
I didn't realize the Oculus PC app has an option to enable "Natural Facial Expressions over Oculus Link". After trying it I found a missing initialization of the XrFaceExpressionWeightsFB type field - which apparently the Android runtime didn't bother checking. Additionally this PR adds printing of the OpenXR failure result codes.

Testing on PC:

https://github.com/GodotVR/godot_openxr_vendors/assets/1863707/cd436b17-f3d1-412a-9e7d-7fd078c24562

Testing on Quest Pro Native;

https://github.com/GodotVR/godot_openxr_vendors/assets/1863707/e1346576-74fd-4a7e-84c8-32ea3b72c3ce
