### PR TITLE
Add XR_FB_hand_tracking_mesh extension wrapper and OpenXRFbHandTrackingMesh node

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Update to OpenXR 1.0.34 headers
 - Add XR_FB_render_model extension wrapper and OpenXRFBRenderModel node
 - Add XR_FB_passthrough extension wrapper
+- Add XR_FB_hand_tracking_mesh extension wrapper and OpenXRFbHandTrackingMesh node
 
 ## 2.0.3
 - Migrate the export scripts from gdscript to C++ via gdextension

--- a/common/src/main/cpp/classes/openxr_fb_hand_tracking_mesh.cpp
+++ b/common/src/main/cpp/classes/openxr_fb_hand_tracking_mesh.cpp
@@ -1,0 +1,130 @@
+/**************************************************************************/
+/*  openxr_fb_hand_tracking_mesh.cpp                                      */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "classes/openxr_fb_hand_tracking_mesh.h"
+
+#include "extensions/openxr_fb_hand_tracking_mesh_extension_wrapper.h"
+
+#include <godot_cpp/classes/xr_hand_modifier3d.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+using namespace godot;
+
+void OpenXRFbHandTrackingMesh::setup_hand_mesh(Hand p_hand) {
+	ERR_FAIL_COND_MSG(skeleton != nullptr, "OpenXRFbHandTrackingMesh skeleton has already been set up");
+
+	if (p_hand == hand) {
+		skeleton = memnew(Skeleton3D);
+		OpenXRFbHandTrackingMeshExtensionWrapper::get_singleton()->construct_skeleton(p_hand, skeleton);
+		add_child(skeleton);
+
+		mesh_instance = memnew(MeshInstance3D);
+		mesh_instance->set_mesh(OpenXRFbHandTrackingMeshExtensionWrapper::get_singleton()->get_mesh(p_hand));
+		mesh_instance->set_material_override(material);
+		skeleton->add_child(mesh_instance);
+	}
+
+	XRHandModifier3D *parent = Object::cast_to<XRHandModifier3D>(get_parent());
+	if (parent) {
+		parent->set_target(parent->get_path_to(skeleton));
+	}
+}
+
+Skeleton3D *OpenXRFbHandTrackingMesh::get_skeleton() const {
+	return skeleton;
+}
+
+MeshInstance3D *OpenXRFbHandTrackingMesh::get_mesh_instance() const {
+	return mesh_instance;
+}
+
+void OpenXRFbHandTrackingMesh::set_hand(Hand p_hand) {
+	hand = p_hand;
+}
+
+XRHandTracker::Hand OpenXRFbHandTrackingMesh::get_hand() const {
+	return hand;
+}
+
+void OpenXRFbHandTrackingMesh::set_material(const Ref<Material> &p_material) {
+	material = p_material;
+	if (mesh_instance) {
+		mesh_instance->set_material_override(material);
+	}
+}
+
+Ref<Material> OpenXRFbHandTrackingMesh::get_material() const {
+	return material;
+}
+
+void OpenXRFbHandTrackingMesh::set_use_scale_override(bool p_use) {
+	OpenXRFbHandTrackingMeshExtensionWrapper::get_singleton()->set_use_scale_override(hand, p_use);
+}
+
+bool OpenXRFbHandTrackingMesh::get_use_scale_override() const {
+	return OpenXRFbHandTrackingMeshExtensionWrapper::get_singleton()->get_use_scale_override(hand);
+}
+
+void OpenXRFbHandTrackingMesh::set_scale_override(float p_scale) {
+	OpenXRFbHandTrackingMeshExtensionWrapper::get_singleton()->set_scale_override(hand, p_scale);
+}
+
+float OpenXRFbHandTrackingMesh::get_scale_override() const {
+	return OpenXRFbHandTrackingMeshExtensionWrapper::get_singleton()->get_scale_override(hand);
+}
+
+void OpenXRFbHandTrackingMesh::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_POSTINITIALIZE: {
+			OpenXRFbHandTrackingMeshExtensionWrapper::get_singleton()->enable_fetch_hand_mesh_data();
+			OpenXRFbHandTrackingMeshExtensionWrapper::get_singleton()->connect("openxr_fb_hand_tracking_mesh_data_fetched", callable_mp(this, &OpenXRFbHandTrackingMesh::setup_hand_mesh));
+		} break;
+	}
+}
+
+void OpenXRFbHandTrackingMesh::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_skeleton"), &OpenXRFbHandTrackingMesh::get_skeleton);
+	ClassDB::bind_method(D_METHOD("get_mesh_instance"), &OpenXRFbHandTrackingMesh::get_mesh_instance);
+	ClassDB::bind_method(D_METHOD("set_hand", "hand"), &OpenXRFbHandTrackingMesh::set_hand);
+	ClassDB::bind_method(D_METHOD("get_hand"), &OpenXRFbHandTrackingMesh::get_hand);
+	ClassDB::bind_method(D_METHOD("set_material", "material"), &OpenXRFbHandTrackingMesh::set_material);
+	ClassDB::bind_method(D_METHOD("get_material"), &OpenXRFbHandTrackingMesh::get_material);
+	ClassDB::bind_method(D_METHOD("set_use_scale_override", "use_scale_override"), &OpenXRFbHandTrackingMesh::set_use_scale_override);
+	ClassDB::bind_method(D_METHOD("get_use_scale_override"), &OpenXRFbHandTrackingMesh::get_use_scale_override);
+	ClassDB::bind_method(D_METHOD("set_scale_override", "scale_override"), &OpenXRFbHandTrackingMesh::set_scale_override);
+	ClassDB::bind_method(D_METHOD("get_scale_override"), &OpenXRFbHandTrackingMesh::get_scale_override);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "hand", PROPERTY_HINT_ENUM, "Left Hand,Right Hand"), "set_hand", "get_hand");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "BaseMaterial3D,ShaderMaterial", PROPERTY_USAGE_DEFAULT), "set_material", "get_material");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_scale_override", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_use_scale_override", "get_use_scale_override");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "scale_override", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_scale_override", "get_scale_override");
+
+	BIND_ENUM_CONSTANT(Hand::HAND_LEFT);
+	BIND_ENUM_CONSTANT(Hand::HAND_RIGHT);
+}

--- a/common/src/main/cpp/extensions/openxr_fb_hand_tracking_mesh_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_fb_hand_tracking_mesh_extension_wrapper.cpp
@@ -1,0 +1,345 @@
+/**************************************************************************/
+/*  openxr_fb_hand_tracking_mesh_extension_wrapper.cpp                    */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "extensions/openxr_fb_hand_tracking_mesh_extension_wrapper.h"
+
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+using namespace godot;
+
+OpenXRFbHandTrackingMeshExtensionWrapper *OpenXRFbHandTrackingMeshExtensionWrapper::singleton = nullptr;
+
+OpenXRFbHandTrackingMeshExtensionWrapper *OpenXRFbHandTrackingMeshExtensionWrapper::get_singleton() {
+	if (singleton == nullptr) {
+		singleton = memnew(OpenXRFbHandTrackingMeshExtensionWrapper());
+	}
+	return singleton;
+}
+
+OpenXRFbHandTrackingMeshExtensionWrapper::OpenXRFbHandTrackingMeshExtensionWrapper() :
+		OpenXRExtensionWrapperExtension() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "An OpenXRFbHandTrackingMeshExtensionWrapper singleton already exists.");
+
+	request_extensions[XR_FB_HAND_TRACKING_MESH_EXTENSION_NAME] = &fb_hand_tracking_mesh_ext;
+	singleton = this;
+}
+
+OpenXRFbHandTrackingMeshExtensionWrapper::~OpenXRFbHandTrackingMeshExtensionWrapper() {
+	cleanup();
+}
+
+void OpenXRFbHandTrackingMeshExtensionWrapper::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("openxr_fb_hand_tracking_mesh_data_fetched", PropertyInfo(Variant::INT, "hand_index")));
+}
+
+void OpenXRFbHandTrackingMeshExtensionWrapper::cleanup() {
+	fb_hand_tracking_mesh_ext = false;
+	should_fetch_hand_mesh_data = false;
+
+	for (int i = 0; i < Hand::HAND_MAX; i++) {
+		if (hand_mesh[i].is_valid()) {
+			hand_mesh[i].unref();
+		}
+
+		hand_tracking_scale[i].overrideHandScale = false;
+		hand_tracking_scale[i].overrideValueInput = 1.0;
+		bone_data[i].joint_poses.clear();
+		bone_data[i].joint_radii.clear();
+		bone_data[i].joint_parents.clear();
+	}
+}
+
+godot::Dictionary OpenXRFbHandTrackingMeshExtensionWrapper::_get_requested_extensions() {
+	godot::Dictionary result;
+	for (auto ext : request_extensions) {
+		godot::String key = ext.first;
+		uint64_t value = reinterpret_cast<uint64_t>(ext.second);
+		result[key] = (godot::Variant)value;
+	}
+	return result;
+}
+
+void OpenXRFbHandTrackingMeshExtensionWrapper::_on_instance_created(uint64_t instance) {
+	if (fb_hand_tracking_mesh_ext) {
+		bool result = initialize_fb_hand_tracking_mesh_extension((XrInstance)instance);
+		if (!result) {
+			UtilityFunctions::print("Failed to initialize fb_hand_tracking_mesh extension");
+			fb_hand_tracking_mesh_ext = false;
+		}
+	}
+}
+
+void OpenXRFbHandTrackingMeshExtensionWrapper::_on_instance_destroyed() {
+	cleanup();
+}
+
+uint64_t OpenXRFbHandTrackingMeshExtensionWrapper::_set_hand_joint_locations_and_get_next_pointer(int32_t p_hand_index, void *p_next_pointer) {
+	if (!fb_hand_tracking_mesh_ext) {
+		return reinterpret_cast<uint64_t>(p_next_pointer);
+	}
+
+	hand_tracking_scale[p_hand_index].type = XR_TYPE_HAND_TRACKING_SCALE_FB;
+	hand_tracking_scale[p_hand_index].next = p_next_pointer;
+
+	return reinterpret_cast<uint64_t>(&hand_tracking_scale[p_hand_index]);
+}
+
+void OpenXRFbHandTrackingMeshExtensionWrapper::_on_process() {
+	if (!is_enabled() || get_openxr_api().is_null()) {
+		return;
+	}
+
+	if (!should_fetch_hand_mesh_data) {
+		return;
+	}
+
+	for (int i = 0; i < Hand::HAND_MAX; i++) {
+		if (hand_mesh[i].is_null()) {
+			XrHandTrackerEXT hand_tracker = reinterpret_cast<XrHandTrackerEXT>(get_openxr_api()->get_hand_tracker(i));
+			if (hand_tracker != XR_NULL_HANDLE) {
+				if (fetch_hand_mesh_data(Hand(i))) {
+					emit_signal("openxr_fb_hand_tracking_mesh_data_fetched", i);
+				}
+			}
+		}
+	}
+}
+
+void OpenXRFbHandTrackingMeshExtensionWrapper::set_use_scale_override(Hand p_hand, bool p_use) {
+	hand_tracking_scale[p_hand].overrideHandScale = p_use;
+}
+
+bool OpenXRFbHandTrackingMeshExtensionWrapper::get_use_scale_override(Hand p_hand) const {
+	return hand_tracking_scale[p_hand].overrideHandScale;
+}
+
+void OpenXRFbHandTrackingMeshExtensionWrapper::set_scale_override(Hand p_hand, float p_scale) {
+	hand_tracking_scale[p_hand].overrideValueInput = p_scale;
+}
+
+float OpenXRFbHandTrackingMeshExtensionWrapper::get_scale_override(Hand p_hand) const {
+	return hand_tracking_scale[p_hand].overrideValueInput;
+}
+
+void OpenXRFbHandTrackingMeshExtensionWrapper::enable_fetch_hand_mesh_data() {
+	should_fetch_hand_mesh_data = true;
+}
+
+bool OpenXRFbHandTrackingMeshExtensionWrapper::fetch_hand_mesh_data(Hand p_hand) {
+	ERR_FAIL_COND_V_MSG(!is_enabled(), false, "OpenXR extension XR_FB_hand_tracking_mesh is not available");
+
+	XrHandTrackingMeshFB xr_hand_mesh;
+	xr_hand_mesh.type = XR_TYPE_HAND_TRACKING_MESH_FB;
+	xr_hand_mesh.next = nullptr;
+	xr_hand_mesh.jointCapacityInput = 0;
+	xr_hand_mesh.vertexCapacityInput = 0;
+	xr_hand_mesh.indexCapacityInput = 0;
+	XrHandTrackerEXT hand_tracker = reinterpret_cast<XrHandTrackerEXT>(get_openxr_api()->get_hand_tracker(p_hand));
+
+	XrResult result = xrGetHandMeshFB(hand_tracker, &xr_hand_mesh);
+	if (XR_FAILED(result)) {
+		UtilityFunctions::print("Failed to retrieve capacity inputs for OpenXR XR_FB_hand_tracking_mesh extension, error code: ", result);
+		return false;
+	}
+
+	xr_hand_mesh.jointCapacityInput = xr_hand_mesh.jointCountOutput;
+	xr_hand_mesh.vertexCapacityInput = xr_hand_mesh.vertexCountOutput;
+	xr_hand_mesh.indexCapacityInput = xr_hand_mesh.indexCountOutput;
+
+	// skeleton data persists in BoneData structs
+	bone_data[p_hand].joint_poses.resize(xr_hand_mesh.jointCapacityInput);
+	xr_hand_mesh.jointBindPoses = bone_data[p_hand].joint_poses.ptr();
+	bone_data[p_hand].joint_radii.resize(xr_hand_mesh.jointCapacityInput);
+	xr_hand_mesh.jointRadii = bone_data[p_hand].joint_radii.ptr();
+	bone_data[p_hand].joint_parents.resize(xr_hand_mesh.jointCapacityInput);
+	xr_hand_mesh.jointParents = bone_data[p_hand].joint_parents.ptr();
+
+	// mesh data will be used to construct ArrayMeshes and then be discarded
+	LocalVector<XrVector3f> vertex_positions;
+	vertex_positions.resize(xr_hand_mesh.vertexCapacityInput);
+	xr_hand_mesh.vertexPositions = vertex_positions.ptr();
+	LocalVector<XrVector3f> vertex_normals;
+	vertex_normals.resize(xr_hand_mesh.vertexCapacityInput);
+	xr_hand_mesh.vertexNormals = vertex_normals.ptr();
+	LocalVector<XrVector2f> vertex_uvs;
+	vertex_uvs.resize(xr_hand_mesh.vertexCapacityInput);
+	xr_hand_mesh.vertexUVs = vertex_uvs.ptr();
+	LocalVector<XrVector4sFB> vertex_blend_indices;
+	vertex_blend_indices.resize(xr_hand_mesh.vertexCapacityInput);
+	xr_hand_mesh.vertexBlendIndices = vertex_blend_indices.ptr();
+	LocalVector<XrVector4f> vertex_blend_weights;
+	vertex_blend_weights.resize(xr_hand_mesh.vertexCapacityInput);
+	xr_hand_mesh.vertexBlendWeights = vertex_blend_weights.ptr();
+	LocalVector<int16_t> indices;
+	indices.resize(xr_hand_mesh.indexCapacityInput);
+	xr_hand_mesh.indices = indices.ptr();
+
+	result = xrGetHandMeshFB(hand_tracker, &xr_hand_mesh);
+	if (XR_FAILED(result)) {
+		UtilityFunctions::print("Failed to retrieve hand mesh data for OpenXR XR_FB_hand_tracking_mesh extension, error code: ", result);
+		return false;
+	}
+
+	// convert to clockwise winding order to cull correct face side
+	const int VERTICES_PER_TRIANGLE = 3;
+	for (int i = 0; i < xr_hand_mesh.indexCapacityInput; i += VERTICES_PER_TRIANGLE) {
+		SWAP(xr_hand_mesh.indices[i], xr_hand_mesh.indices[i + VERTICES_PER_TRIANGLE - 1]);
+	}
+
+	PackedVector3Array godot_vertex_positions = PackedVector3Array();
+	PackedVector3Array godot_vertex_normals = PackedVector3Array();
+	PackedVector2Array godot_vertex_uvs = PackedVector2Array();
+	PackedInt32Array godot_bone_indices = PackedInt32Array();
+	PackedFloat32Array godot_bone_weights = PackedFloat32Array();
+	for (int i = 0; i < xr_hand_mesh.vertexCapacityInput; i++) {
+		godot_vertex_positions.push_back(Vector3(xr_hand_mesh.vertexPositions[i].x, xr_hand_mesh.vertexPositions[i].y, xr_hand_mesh.vertexPositions[i].z));
+		godot_vertex_normals.push_back(Vector3(xr_hand_mesh.vertexNormals[i].x, xr_hand_mesh.vertexNormals[i].y, xr_hand_mesh.vertexNormals[i].z));
+		godot_vertex_uvs.push_back(Vector2(xr_hand_mesh.vertexUVs[i].x, xr_hand_mesh.vertexUVs[i].y));
+
+		godot_bone_indices.push_back(xr_hand_mesh.vertexBlendIndices[i].x);
+		godot_bone_indices.push_back(xr_hand_mesh.vertexBlendIndices[i].y);
+		godot_bone_indices.push_back(xr_hand_mesh.vertexBlendIndices[i].z);
+		godot_bone_indices.push_back(xr_hand_mesh.vertexBlendIndices[i].w);
+
+		godot_bone_weights.push_back(xr_hand_mesh.vertexBlendWeights[i].x);
+		godot_bone_weights.push_back(xr_hand_mesh.vertexBlendWeights[i].y);
+		godot_bone_weights.push_back(xr_hand_mesh.vertexBlendWeights[i].z);
+		godot_bone_weights.push_back(xr_hand_mesh.vertexBlendWeights[i].w);
+	}
+
+	PackedInt32Array godot_indices = PackedInt32Array();
+	for (int i = 0; i < xr_hand_mesh.indexCapacityInput; i++) {
+		godot_indices.push_back(xr_hand_mesh.indices[i]);
+	}
+
+	Array arrays;
+	arrays.resize(Mesh::ARRAY_MAX);
+	arrays[Mesh::ARRAY_VERTEX] = godot_vertex_positions;
+	arrays[Mesh::ARRAY_NORMAL] = godot_vertex_normals;
+	arrays[Mesh::ARRAY_TEX_UV] = godot_vertex_uvs;
+	arrays[Mesh::ARRAY_BONES] = godot_bone_indices;
+	arrays[Mesh::ARRAY_WEIGHTS] = godot_bone_weights;
+	arrays[Mesh::ARRAY_INDEX] = godot_indices;
+
+	Ref<ArrayMesh> array_mesh;
+	array_mesh.instantiate();
+	array_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, arrays);
+
+	hand_mesh[p_hand] = array_mesh;
+
+	return true;
+}
+
+Ref<ArrayMesh> OpenXRFbHandTrackingMeshExtensionWrapper::get_mesh(Hand p_hand) {
+	ERR_FAIL_COND_V_MSG(!is_enabled(), Ref<ArrayMesh>(), "OpenXR extension XR_FB_hand_tracking_mesh is not available");
+	ERR_FAIL_COND_V_MSG(hand_mesh[p_hand].is_null(), Ref<ArrayMesh>(), "OpenXR extension XR_FB_hand_tracking_mesh has not populated mesh data");
+
+	return hand_mesh[p_hand];
+}
+
+void OpenXRFbHandTrackingMeshExtensionWrapper::construct_skeleton(Hand p_hand, Skeleton3D *r_skeleton) {
+	ERR_FAIL_COND_MSG(!is_enabled(), "OpenXR extension XR_FB_hand_tracking_mesh is not available");
+	ERR_FAIL_COND_MSG(hand_mesh[p_hand].is_null(), "OpenXR extension XR_FB_hand_tracking_mesh has not populated mesh data");
+	ERR_FAIL_NULL_MSG(r_skeleton, "Skeleton3D r_skeleton not valid");
+
+	r_skeleton->clear_bones();
+
+	static const String bone_names[XRHandTracker::HAND_JOINT_MAX] = {
+		"Palm",
+		"Hand",
+		"ThumbMetacarpal",
+		"ThumbProximal",
+		"ThumbDistal",
+		"ThumbTip",
+		"IndexMetacarpal",
+		"IndexProximal",
+		"IndexIntermediate",
+		"IndexDistal",
+		"IndexTip",
+		"MiddleMetacarpal",
+		"MiddleProximal",
+		"MiddleIntermediate",
+		"MiddleDistal",
+		"MiddleTip",
+		"RingMetacarpal",
+		"RingProximal",
+		"RingIntermediate",
+		"RingDistal",
+		"RingTip",
+		"LittleMetacarpal",
+		"LittleProximal",
+		"LittleIntermediate",
+		"LittleDistal",
+		"LittleTip",
+	};
+
+	static const String bone_name_format[2] = {
+		"Left<bone>",
+		"Right<bone>",
+	};
+
+	for (int i = 0; i < XRHandTracker::HAND_JOINT_MAX; i++) {
+		String bone_name = bone_name_format[p_hand].replace("<bone>", bone_names[i]);
+		r_skeleton->add_bone(bone_name);
+
+		int parent_index = static_cast<int>(bone_data[p_hand].joint_parents[i]);
+
+		// rotation adjustment to conform with SKELETON_RIG_HUMANOID
+		const Quaternion rot_adjustment(0.0, -Math_SQRT12, Math_SQRT12, 0.0);
+
+		XrQuaternionf rot = bone_data[p_hand].joint_poses[i].orientation;
+		XrVector3f pos = bone_data[p_hand].joint_poses[i].position;
+		Transform3D transform = Transform3D(Quaternion(rot.x, rot.y, rot.z, rot.w) * rot_adjustment, Vector3(pos.x, pos.y, pos.z));
+
+		if (i == 1) {
+			r_skeleton->set_bone_rest(i, transform);
+		} else {
+			XrQuaternionf parent_rot = bone_data[p_hand].joint_poses[parent_index].orientation;
+			XrVector3f parent_pos = bone_data[p_hand].joint_poses[parent_index].position;
+			Transform3D parent_transform = Transform3D(Quaternion(parent_rot.x, parent_rot.y, parent_rot.z, parent_rot.w) * rot_adjustment, Vector3(parent_pos.x, parent_pos.y, parent_pos.z));
+			r_skeleton->set_bone_rest(i, parent_transform.inverse() * transform);
+		}
+
+		if (i > 1) {
+			r_skeleton->set_bone_parent(i, parent_index);
+		}
+	}
+
+	// palm bone is added before wrist, so parent it here
+	r_skeleton->set_bone_parent(0, 1);
+
+	r_skeleton->reset_bone_poses();
+}
+
+bool OpenXRFbHandTrackingMeshExtensionWrapper::initialize_fb_hand_tracking_mesh_extension(const XrInstance instance) {
+	GDEXTENSION_INIT_XR_FUNC_V(xrGetHandMeshFB);
+
+	return true;
+}

--- a/common/src/main/cpp/include/classes/openxr_fb_hand_tracking_mesh.h
+++ b/common/src/main/cpp/include/classes/openxr_fb_hand_tracking_mesh.h
@@ -1,0 +1,78 @@
+/**************************************************************************/
+/*  openxr_fb_hand_tracking_mesh.h                                        */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef OPENXR_FB_HAND_TRACKING_MESH_H
+#define OPENXR_FB_HAND_TRACKING_MESH_H
+
+#include <godot_cpp/classes/material.hpp>
+#include <godot_cpp/classes/mesh_instance3d.hpp>
+#include <godot_cpp/classes/skeleton3d.hpp>
+#include <godot_cpp/classes/xr_hand_tracker.hpp>
+
+namespace godot {
+class OpenXRFbHandTrackingMesh : public Node3D {
+	GDCLASS(OpenXRFbHandTrackingMesh, Node3D)
+public:
+	using Hand = XRHandTracker::Hand;
+
+private:
+	Hand hand = Hand::HAND_LEFT;
+	Ref<Material> material;
+
+	Skeleton3D *skeleton = nullptr;
+
+	MeshInstance3D *mesh_instance = nullptr;
+
+	void setup_hand_mesh(Hand p_hand);
+
+protected:
+	void _notification(int p_what);
+
+	static void _bind_methods();
+
+public:
+	Skeleton3D *get_skeleton() const;
+
+	MeshInstance3D *get_mesh_instance() const;
+
+	void set_hand(Hand p_hand);
+	Hand get_hand() const;
+
+	void set_material(const Ref<Material> &p_material);
+	Ref<Material> get_material() const;
+
+	void set_use_scale_override(bool p_use);
+	bool get_use_scale_override() const;
+
+	void set_scale_override(float p_scale);
+	float get_scale_override() const;
+};
+} //namespace godot
+
+#endif

--- a/common/src/main/cpp/include/extensions/openxr_fb_hand_tracking_mesh_extension_wrapper.h
+++ b/common/src/main/cpp/include/extensions/openxr_fb_hand_tracking_mesh_extension_wrapper.h
@@ -1,0 +1,110 @@
+/**************************************************************************/
+/*  openxr_fb_hand_tracking_mesh_extension_wrapper.h                      */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef OPENXR_FB_HAND_TRACKING_MESH_EXTENSION_WRAPPER_H
+#define OPENXR_FB_HAND_TRACKING_MESH_EXTENSION_WRAPPER_H
+
+#include <openxr/openxr.h>
+#include <godot_cpp/classes/array_mesh.hpp>
+#include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
+#include <godot_cpp/classes/skeleton3d.hpp>
+#include <godot_cpp/classes/xr_hand_tracker.hpp>
+#include <godot_cpp/templates/local_vector.hpp>
+#include <map>
+
+#include "util.h"
+
+using namespace godot;
+
+// Wrapper for the set of Facebook XR hand tracking mesh extension.
+class OpenXRFbHandTrackingMeshExtensionWrapper : public OpenXRExtensionWrapperExtension {
+	GDCLASS(OpenXRFbHandTrackingMeshExtensionWrapper, OpenXRExtensionWrapperExtension);
+
+public:
+	struct BoneData {
+		LocalVector<XrPosef> joint_poses;
+		LocalVector<float> joint_radii;
+		LocalVector<XrHandJointEXT> joint_parents;
+	};
+
+	using Hand = XRHandTracker::Hand;
+
+	godot::Dictionary _get_requested_extensions() override;
+
+	void _on_instance_created(uint64_t instance) override;
+
+	void _on_instance_destroyed() override;
+
+	uint64_t _set_hand_joint_locations_and_get_next_pointer(int32_t p_hand_index, void *p_next_pointer) override;
+
+	void _on_process() override;
+
+	bool is_enabled() { return fb_hand_tracking_mesh_ext; }
+
+	static OpenXRFbHandTrackingMeshExtensionWrapper *get_singleton();
+
+	void set_use_scale_override(Hand p_hand, bool p_use);
+	bool get_use_scale_override(Hand p_hand) const;
+
+	void set_scale_override(Hand p_hand, float p_scale);
+	float get_scale_override(Hand p_hand) const;
+
+	void enable_fetch_hand_mesh_data();
+	bool fetch_hand_mesh_data(Hand p_hand);
+	Ref<ArrayMesh> get_mesh(Hand p_hand);
+	void construct_skeleton(Hand p_hand, Skeleton3D *r_skeleton);
+
+	OpenXRFbHandTrackingMeshExtensionWrapper();
+	~OpenXRFbHandTrackingMeshExtensionWrapper();
+
+protected:
+	static void _bind_methods();
+
+private:
+	EXT_PROTO_XRRESULT_FUNC2(xrGetHandMeshFB,
+			(XrHandTrackerEXT), handTracker,
+			(XrHandTrackingMeshFB *), mesh);
+
+	bool initialize_fb_hand_tracking_mesh_extension(const XrInstance instance);
+
+	void cleanup();
+
+	static OpenXRFbHandTrackingMeshExtensionWrapper *singleton;
+
+	std::map<godot::String, bool *> request_extensions;
+
+	bool fb_hand_tracking_mesh_ext = false;
+
+	bool should_fetch_hand_mesh_data = false;
+	Ref<ArrayMesh> hand_mesh[Hand::HAND_MAX];
+	BoneData bone_data[Hand::HAND_MAX];
+	XrHandTrackingScaleFB hand_tracking_scale[Hand::HAND_MAX];
+};
+
+#endif // OPENXR_FB_HAND_TRACKING_MESH_EXTENSION_WRAPPER_H

--- a/common/src/main/cpp/register_types.cpp
+++ b/common/src/main/cpp/register_types.cpp
@@ -44,6 +44,7 @@
 #include "export/pico_export_plugin.h"
 
 #include "extensions/openxr_fb_face_tracking_extension_wrapper.h"
+#include "extensions/openxr_fb_hand_tracking_mesh_extension_wrapper.h"
 #include "extensions/openxr_fb_passthrough_extension_wrapper.h"
 #include "extensions/openxr_fb_render_model_extension_wrapper.h"
 #include "extensions/openxr_fb_scene_capture_extension_wrapper.h"
@@ -52,6 +53,7 @@
 #include "extensions/openxr_fb_spatial_entity_extension_wrapper.h"
 #include "extensions/openxr_fb_spatial_entity_query_extension_wrapper.h"
 
+#include "classes/openxr_fb_hand_tracking_mesh.h"
 #include "classes/openxr_fb_render_model.h"
 
 using namespace godot;
@@ -82,6 +84,9 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 
 			ClassDB::register_class<OpenXRFbFaceTrackingExtensionWrapper>();
 			OpenXRFbFaceTrackingExtensionWrapper::get_singleton()->register_extension_wrapper();
+
+			ClassDB::register_class<OpenXRFbHandTrackingMeshExtensionWrapper>();
+			OpenXRFbHandTrackingMeshExtensionWrapper::get_singleton()->register_extension_wrapper();
 		} break;
 
 		case MODULE_INITIALIZATION_LEVEL_SERVERS:
@@ -98,6 +103,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			Engine::get_singleton()->register_singleton("OpenXRFbFaceTrackingExtensionWrapper", OpenXRFbFaceTrackingExtensionWrapper::get_singleton());
 
 			ClassDB::register_class<OpenXRFbRenderModel>();
+			ClassDB::register_class<OpenXRFbHandTrackingMesh>();
 		} break;
 
 		case MODULE_INITIALIZATION_LEVEL_EDITOR: {

--- a/demo/main.tscn
+++ b/demo/main.tscn
@@ -64,10 +64,9 @@ pose = &"grip"
 [node name="LeftHandMesh" type="MeshInstance3D" parent="XROrigin3D/LeftHand"]
 mesh = SubResource("BoxMesh_3kt6b")
 
-[node name="LeftControllerFbRenderModel" type="OpenXRFbRenderModel" parent="XROrigin3D/LeftHand"]
-
 [node name="HandTablet" type="MeshInstance3D" parent="XROrigin3D/LeftHand"]
 transform = Transform3D(1, 0, 0, 0, -0.392209, 0.919876, 0, -0.919876, -0.392209, 0, -0.236189, -0.208883)
+visible = false
 mesh = SubResource("QuadMesh_1oamj")
 surface_material_override/0 = SubResource("StandardMaterial3D_pmc5p")
 
@@ -77,6 +76,8 @@ screen_size = Vector2(0.35, 0.25)
 enabled = false
 scene = ExtResource("3_45w5g")
 unshaded = true
+
+[node name="LeftControllerFbRenderModel" type="OpenXRFbRenderModel" parent="XROrigin3D/LeftHand"]
 
 [node name="RightHand" type="XRController3D" parent="XROrigin3D"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.478861, 0.468292, -0.241097)
@@ -96,6 +97,16 @@ tracker = &"/user/eyes_ext"
 [node name="EyeGazeMesh" type="MeshInstance3D" parent="XROrigin3D/EyeGaze"]
 transform = Transform3D(1, 0, 0, 0, -0.0133513, 0.999911, 0, -0.999911, -0.0133513, 0, 0, -1.18886)
 mesh = SubResource("SphereMesh_5gcab")
+
+[node name="LeftXRHandModifier3D" type="XRHandModifier3D" parent="XROrigin3D"]
+
+[node name="LeftHandModel" type="OpenXRFbHandTrackingMesh" parent="XROrigin3D/LeftXRHandModifier3D"]
+
+[node name="RightXRHandModifier3D" type="XRHandModifier3D" parent="XROrigin3D"]
+hand_tracker = &"/user/right"
+
+[node name="RightHandModel" type="OpenXRFbHandTrackingMesh" parent="XROrigin3D/RightXRHandModifier3D"]
+hand = 1
 
 [node name="Floor" type="MeshInstance3D" parent="."]
 mesh = SubResource("PlaneMesh_mjcgt")


### PR DESCRIPTION
Adds support for [XR_FB_hand_tracking_mesh](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_FB_hand_tracking_mesh) via a new `OpenXRFbHandTrackingMesh` node.

https://github.com/GodotVR/godot_openxr_vendors/assets/95497005/9a830f73-940c-4a9a-9ecd-764a5f6d5232

This node is intended to work with the new [`XRHandModifier3D`](https://github.com/godotengine/godot/pull/88639) node. The `target` property of `XRHandModifier3D` needs to be directed to `OpenXRFbHandTrackingMesh`'s `Skeleton3D` after all of the bones have been constructed. So, after skeleton construction, `OpenXRFbHandTrackingMesh` will check to see if it is a child of `XRHandModifier3D`, and it will set its `target` property accordingly.

`OpenXRFbHandTrackingMesh` has properties (`use_scale_override` and `scale_override`) that correspond to the `XrHandTrackingScaleFB` struct. If `use_scale_override` is set to true, `scale_override` will be applied to the mesh/skeleton. At the moment I'm not convinced this is how the mesh is supposed to scale (the wrists don't seem to scale at all), but I'm not positive how it's supposed to look, I'll put a picture of an example of a hand scaled 0.5 and 1.75 below.

![hand-scale](https://github.com/GodotVR/godot_openxr_vendors/assets/95497005/94f5c462-0db8-45fd-9693-6510d4ea5d5e)