### PR TITLE
Initialize all values of XrHandTrackingScaleFB struct

### DIFF
--- a/common/src/main/cpp/extensions/openxr_fb_hand_tracking_mesh_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_fb_hand_tracking_mesh_extension_wrapper.cpp
@@ -105,8 +105,14 @@ uint64_t OpenXRFbHandTrackingMeshExtensionWrapper::_set_hand_joint_locations_and
 		return reinterpret_cast<uint64_t>(p_next_pointer);
 	}
 
-	hand_tracking_scale[p_hand_index].type = XR_TYPE_HAND_TRACKING_SCALE_FB;
-	hand_tracking_scale[p_hand_index].next = p_next_pointer;
+	hand_tracking_scale[p_hand_index] = {
+		XR_TYPE_HAND_TRACKING_SCALE_FB, // type
+		p_next_pointer, // next
+		1.0, // sensorOutput
+		1.0, // currentOutput
+		false, // overrideHandScale
+		1.0, // overrideValueInput
+	};
 
 	return reinterpret_cast<uint64_t>(&hand_tracking_scale[p_hand_index]);
 }


### PR DESCRIPTION
@dsnopek told me he was experiencing some bugs in the demo regarding the mesh scale for the XR_FB_hand_tracking_mesh implementation. He believed it was occurring because the override properties of the `XrHandTrackingScaleFB` struct were not being initialized, so junk data could be populating them. Hopefully this fixes that!