### PR TITLE
Make XR_FB_hand_tracking_aim project setting basic

### DIFF
--- a/common/src/main/cpp/extensions/openxr_fb_hand_tracking_aim_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_fb_hand_tracking_aim_extension_wrapper.cpp
@@ -185,6 +185,7 @@ void OpenXRFbHandTrackingAimExtensionWrapper::add_project_setting() {
 	}
 
 	ProjectSettings::get_singleton()->set_initial_value(p_name, false);
+	ProjectSettings::get_singleton()->set_as_basic(p_name, true);
 	Dictionary property_info;
 	property_info["name"] = p_name;
 	property_info["type"] = Variant::Type::BOOL;


### PR DESCRIPTION
Project setting for `XR_FB_hand_tracking_aim` extension is currently an advanced project setting, but it was discussed in the xr contributors chat that it should be basic. This applies that!