### PR TITLE
Add .gitignore for asset to prevent checking in temp dlls

### DIFF
--- a/demo/addons/godotopenxrvendors/.gitignore
+++ b/demo/addons/godotopenxrvendors/.gitignore
@@ -1,0 +1,2 @@
+# Ignore copies of the binaries Godot makes at startup
+.bin/windows/*/*/~*.dll


### PR DESCRIPTION
Small change, this PR adds a `.gitignore` file into the asset folder that is distributed within the asset zip file.

This has no effect on this repo itself as we already exclude DLLs, though those should be included in projects using this asset.
However the Godot editor will now make copies of the dll files before opening them to allow live reloading. For projects using our asset these dlls show up as items to be checked in. This gitignore prevents that.

**note 1** ideally this should be in the users root `.gitignore` file and may in the near future be added in Godot upstream.
**note 2** I don't know if similar behaviour happens on Linux or Mac, if so we may want to add additional entries.