### PR TITLE
Switch to composition layer API that allows multiple layers.

### DIFF
--- a/common/src/main/cpp/extensions/openxr_fb_passthrough_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_fb_passthrough_extension_wrapper.cpp
@@ -210,13 +210,22 @@ bool OpenXRFbPassthroughExtensionWrapper::start_passthrough() {
 	return true;
 }
 
-uint64_t OpenXRFbPassthroughExtensionWrapper::_get_composition_layer() {
-	if (is_passthrough_enabled()) {
+int OpenXRFbPassthroughExtensionWrapper::_get_composition_layer_count() {
+	return is_passthrough_enabled() ? 1 : 0;
+}
+
+uint64_t OpenXRFbPassthroughExtensionWrapper::_get_composition_layer(int p_index) {
+	if (p_index == 0) {
 		composition_passthrough_layer.layerHandle = passthrough_layer;
 		return reinterpret_cast<uint64_t>(&composition_passthrough_layer);
 	} else {
 		return 0;
 	}
+}
+
+int OpenXRFbPassthroughExtensionWrapper::_get_composition_layer_order(int p_index) {
+	// Ensure the passthrough layer will be behind the projection layer.
+	return -100;
 }
 
 void OpenXRFbPassthroughExtensionWrapper::stop_passthrough() {

--- a/common/src/main/cpp/include/extensions/openxr_fb_passthrough_extension_wrapper.h
+++ b/common/src/main/cpp/include/extensions/openxr_fb_passthrough_extension_wrapper.h
@@ -60,7 +60,9 @@ public:
 	void _on_state_ready() override;
 	void _on_process() override;
 
-	uint64_t _get_composition_layer() override;
+	int _get_composition_layer_count() override;
+	uint64_t _get_composition_layer(int p_index) override;
+	int _get_composition_layer_order(int p_index) override;
 
 	bool is_passthrough_supported() {
 		return fb_passthrough_ext;


### PR DESCRIPTION
This adapts the passthrough extension wrapper for the GDExtension API changes in PR https://github.com/godotengine/godot/pull/89460

~~Leaving this marked as a draft until that PR is merged.~~