### PR TITLE
Add Android Surface swapchain support

### DIFF
--- a/common/src/main/cpp/classes/android_surface_layer.cpp
+++ b/common/src/main/cpp/classes/android_surface_layer.cpp
@@ -1,0 +1,129 @@
+/**************************************************************************/
+/*  android_surface_layer.cpp                                             */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "classes/android_surface_layer.h"
+
+using namespace godot;
+
+AndroidSurfaceLayer::AndroidSurfaceLayer() {
+	set_notify_transform(true);
+	layer = std::make_shared<QuadSurfaceLayer>();
+	layer->handle = -1; // Start off invalid
+	layer->layer.type = XR_TYPE_COMPOSITION_LAYER_QUAD;
+	layer->layer.layerFlags = XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT | XR_COMPOSITION_LAYER_CORRECT_CHROMATIC_ABERRATION_BIT;
+	layer->layer.eyeVisibility = XR_EYE_VISIBILITY_BOTH;
+}
+
+AndroidSurfaceLayer::~AndroidSurfaceLayer() {
+#ifdef ANDROID
+	OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::get_singleton()->free_swapchain(layer);
+	OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::get_singleton()->stop_drawing_layer(layer);
+#endif
+}
+
+void AndroidSurfaceLayer::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_supported"), &AndroidSurfaceLayer::is_supported);
+	ClassDB::bind_method(D_METHOD("get_android_surface_handle"), &AndroidSurfaceLayer::get_android_surface_handle);
+	ClassDB::bind_method(D_METHOD("set_layer_resolution"), &AndroidSurfaceLayer::set_layer_resolution);
+	ClassDB::bind_method(D_METHOD("set_size_2d_meters"), &AndroidSurfaceLayer::set_size_2d_meters);
+	ClassDB::bind_method(D_METHOD("set_sort_order"), &AndroidSurfaceLayer::set_sort_order);
+}
+
+bool AndroidSurfaceLayer::is_supported() {
+#ifdef ANDROID
+	return OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::get_singleton()->is_android_surface_swapchain_supported();
+#else
+	return false;
+#endif
+}
+
+int AndroidSurfaceLayer::get_android_surface_handle() {
+	return layer->handle;
+}
+
+void AndroidSurfaceLayer::set_layer_resolution(int widthPx, int heightPx) {
+	if (layer->handle != -1) {
+		WARN_PRINT("Swapchain is already allocated! Bailing");
+		return;
+	}
+#ifdef ANDROID
+	layer->layer.subImage.imageRect = {{0, 0}, {widthPx, heightPx}};
+	OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::get_singleton()->allocate_swapchain(
+			layer,
+			static_cast<uint32_t>(widthPx),
+			static_cast<uint32_t>(heightPx));
+#endif
+}
+
+void AndroidSurfaceLayer::set_size_2d_meters(float p_width_m, float p_height_m) {
+	layer->layer.size.width = p_width_m;
+	layer->layer.size.height = p_height_m;
+}
+
+void AndroidSurfaceLayer::set_sort_order(int p_sort_order) {
+	layer->order = p_sort_order;
+}
+
+void AndroidSurfaceLayer::update_transform() {
+	auto transform = get_global_transform();
+	auto rot = transform.get_basis().get_rotation_quaternion();
+	auto pos = transform.get_origin();
+
+	layer->layer.pose.orientation.x = rot.x;
+	layer->layer.pose.orientation.y = rot.y;
+	layer->layer.pose.orientation.z = rot.z;
+	layer->layer.pose.orientation.w = rot.w;
+	layer->layer.pose.position.x = pos.x;
+	layer->layer.pose.position.y = pos.y;
+	layer->layer.pose.position.z = pos.z;
+}
+
+void AndroidSurfaceLayer::update_visibility() {
+#ifdef ANDROID
+	if (is_visible_in_tree()) {
+		OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::get_singleton()->start_drawing_layer(layer);
+	} else {
+		OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::get_singleton()->stop_drawing_layer(layer);
+	}
+#endif
+}
+
+void AndroidSurfaceLayer::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_TRANSFORM_CHANGED: {
+			update_transform();
+			break;
+		}
+		case NOTIFICATION_READY:
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			update_visibility();
+			break;
+		}
+	}
+}

--- a/common/src/main/cpp/extensions/openxr_khr_android_surface_swapchain_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_khr_android_surface_swapchain_extension_wrapper.cpp
@@ -1,0 +1,277 @@
+/**************************************************************************/
+/*  openxr_khr_android_surface_swapchain_extension_wrapper.cpp            */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef ANDROID
+
+#include <algorithm>
+#include "extensions/openxr_khr_android_surface_swapchain_extension_wrapper.h"
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
+
+using namespace godot;
+
+namespace {
+
+// get_jni_env() is not available in gdextension, so use JNI_OnLoad hook to grab it manually
+// https://github.com/godotengine/godot-proposals/issues/6734
+static JavaVM *jvm = NULL;
+
+// this will be called when Android plugin initialize
+extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
+	JNIEnv *env;
+	if (vm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK)
+		return JNI_ERR;
+	jvm = vm;
+	return JNI_VERSION_1_6;
+}
+
+static JNIEnv* get_jni_env() {
+	JNIEnv *env;
+	if (jvm->GetEnv((void **)&env, JNI_VERSION_1_6) != JNI_OK)
+		return nullptr;
+	return env;
+}
+
+static int deliverSurfaceToJava(jobject surface) {
+	JNIEnv *env = get_jni_env();
+	// Java lookups
+	jclass surfaceStorageClass = env->FindClass("org/godotengine/openxr/vendors/meta/SurfaceStorage");
+	if (surfaceStorageClass == nullptr) {
+		WARN_PRINT("JNI: Failed to find SurfaceStorage class");
+		return -1;
+	}
+	jmethodID storeSurfaceMid = env->GetStaticMethodID(surfaceStorageClass, "storeSurfaceForSwapchain", "(Landroid/view/Surface;)I");
+	if (storeSurfaceMid == nullptr) {
+		WARN_PRINT("JNI: Failed to find storeSurfaceForSwapchain method");
+		return -1;
+	}
+
+	// Execute
+	jint handle = env->CallStaticIntMethod(surfaceStorageClass, storeSurfaceMid, surface);
+	if (env->ExceptionOccurred()) {
+		WARN_PRINT("JNI: Exception ocurred!");
+		return -1;
+	}
+	return handle;
+}
+
+static void releaseSurfaceFromJava(int handle) {
+	JNIEnv *env = get_jni_env();
+
+	// Java lookups
+	jclass surfaceStorageClass = env->FindClass("org/godotengine/openxr/vendors/meta/SurfaceStorage");
+	if (surfaceStorageClass == nullptr) {
+		WARN_PRINT("JNI: Failed to find SurfaceStorage class");
+		return;
+	}
+	jmethodID releaseSurfaceMid = env->GetStaticMethodID(surfaceStorageClass, "releaseSurface", "(I)V");
+	if (releaseSurfaceMid == nullptr) {
+		WARN_PRINT("JNI: Failed to find storeSurfaceForSwapchain method");
+		return;
+	}
+
+	// Execute
+	env->CallStaticVoidMethod(surfaceStorageClass, releaseSurfaceMid, handle);
+	if (env->ExceptionOccurred()) {
+		WARN_PRINT("JNI: Exception ocurred!");
+		return;
+	}
+}
+
+} // anonymous namespace
+
+OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper *OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::singleton = nullptr;
+
+OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper *OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::get_singleton() {
+	if (singleton == nullptr) {
+		singleton = memnew(OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper());
+	}
+	return singleton;
+}
+
+OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper() :
+		OpenXRExtensionWrapperExtension() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "An OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper singleton already exists.");
+
+	request_extensions[XR_KHR_ANDROID_SURFACE_SWAPCHAIN_EXTENSION_NAME] = &khr_android_surface_swapchain_ext;
+	request_extensions[XR_FB_ANDROID_SURFACE_SWAPCHAIN_CREATE_EXTENSION_NAME] = &fb_android_surface_swapchain_create_ext;
+	request_extensions[XR_FB_COMPOSITION_LAYER_IMAGE_LAYOUT_EXTENSION_NAME] = &fb_composition_layer_image_layout_ext;
+	singleton = this;
+}
+
+OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::~OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper() {
+	cleanup();
+}
+
+void OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::_bind_methods() {}
+
+void OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::cleanup() {
+	khr_android_surface_swapchain_ext = false;
+	fb_android_surface_swapchain_create_ext = false;
+	fb_composition_layer_image_layout_ext = false;
+}
+
+Dictionary OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::_get_requested_extensions() {
+	Dictionary result;
+	for (auto ext : request_extensions) {
+		uint64_t value = reinterpret_cast<uint64_t>(ext.value);
+		result[ext.key] = (Variant)value;
+	}
+	return result;
+}
+
+void OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::_on_instance_created(uint64_t instance) {
+	if (khr_android_surface_swapchain_ext && fb_android_surface_swapchain_create_ext) {
+		bool result = initialize_khr_android_surface_swapchain_extension((XrInstance)instance);
+		if (!result) {
+			WARN_PRINT("Failed to initialize khr_android_surface_swapchain_ext extension");
+			khr_android_surface_swapchain_ext = false;
+			fb_android_surface_swapchain_create_ext = false;
+			fb_composition_layer_image_layout_ext = false;
+		}
+	}
+}
+
+void OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::_on_session_created(uint64_t p_session) {
+	if (khr_android_surface_swapchain_ext && fb_android_surface_swapchain_create_ext && fb_composition_layer_image_layout_ext) {
+		get_openxr_api()->register_composition_layer_provider(this);
+	}
+};
+
+void OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::_on_session_destroyed() {
+	if (khr_android_surface_swapchain_ext && fb_android_surface_swapchain_create_ext && fb_composition_layer_image_layout_ext) {
+		get_openxr_api()->unregister_composition_layer_provider(this);
+	}
+};
+
+void OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::_on_instance_destroyed() {
+	cleanup();
+}
+
+int OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::_get_composition_layer_count() {
+	return layers.size();
+};
+
+uint64_t OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::_get_composition_layer(int p_index) {
+	XrCompositionLayerQuad* layer = &layers[p_index]->layer;
+
+	composition_layout_ext.type = XR_TYPE_COMPOSITION_LAYER_IMAGE_LAYOUT_FB;
+	composition_layout_ext.next = nullptr;
+	composition_layout_ext.flags = XR_COMPOSITION_LAYER_IMAGE_LAYOUT_VERTICAL_FLIP_BIT_FB;
+
+	layer->next = &composition_layout_ext;
+	layer->space = (XrSpace) get_openxr_api()->get_play_space();
+	layer->subImage.swapchain = layers[p_index]->swapchain;
+	layer->subImage.imageArrayIndex = 0;
+
+	return reinterpret_cast<uint64_t>(layer);
+};
+
+int OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::_get_composition_layer_order(int p_index) {
+	auto layer = layers[p_index];
+	return layer->order;
+};
+
+bool OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::initialize_khr_android_surface_swapchain_extension(const XrInstance &p_instance) {
+	GDEXTENSION_INIT_XR_FUNC_V(xrCreateSwapchainAndroidSurfaceKHR);
+	GDEXTENSION_INIT_XR_FUNC_V(xrDestroySwapchain);
+
+	return true;
+}
+
+int OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::allocate_swapchain(
+		std::shared_ptr<QuadSurfaceLayer> layer,
+		uint32_t widthPx,
+		uint32_t heightPx) {
+	XrAndroidSurfaceSwapchainCreateInfoFB swapchainExt;
+	swapchainExt.type = XR_TYPE_ANDROID_SURFACE_SWAPCHAIN_CREATE_INFO_FB;
+	swapchainExt.createFlags = 0;
+	swapchainExt.createFlags |= XR_ANDROID_SURFACE_SWAPCHAIN_SYNCHRONOUS_BIT_FB;
+
+	XrSwapchainCreateInfo swapchain_create_info = {
+		XR_TYPE_SWAPCHAIN_CREATE_INFO, // type
+		&swapchainExt, // next
+		0, // createFlags
+		XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT | XR_SWAPCHAIN_USAGE_MUTABLE_FORMAT_BIT, // usageFlags
+		0, // format (required by xrCreateSwapchainAndroidSurfaceKHR)
+		0, // sampleCount (required by xrCreateSwapchainAndroidSurfaceKHR)
+		widthPx, // width
+		heightPx, // height
+		0, // faceCount (required by xrCreateSwapchainAndroidSurfaceKHR)
+		0, // arraySize (required by xrCreateSwapchainAndroidSurfaceKHR)
+		0 // mipCount (required by xrCreateSwapchainAndroidSurfaceKHR)
+	};
+
+	jobject surface_obj;
+	XrSwapchain new_swapchain;
+	XrResult result = xrCreateSwapchainAndroidSurfaceKHR(SESSION, &swapchain_create_info, &new_swapchain, &surface_obj);
+	if (XR_FAILED(result)) {
+		WARN_PRINT("OpenXR: Failed to get swapchain [" + get_openxr_api()->get_error_string(result) + "]");
+		return -1;
+	}
+
+	int handle = deliverSurfaceToJava(surface_obj);
+	if (handle == -1) {
+		WARN_PRINT("OpenXR: Failed to store surface");
+		return -1;
+	}
+
+	layer->handle = handle;
+	layer->swapchain = new_swapchain;
+
+	return handle;
+}
+
+void OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::free_swapchain(std::shared_ptr<QuadSurfaceLayer> layer) {
+	if (layer->handle == -1) {
+		WARN_PRINT("Tried releasing an invalid layer");
+		return;
+	}
+
+	releaseSurfaceFromJava(layer->handle);
+	xrDestroySwapchain(layer->swapchain);
+	layer->handle = -1;
+}
+
+void OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::start_drawing_layer(std::shared_ptr<QuadSurfaceLayer> layer) {
+	// WARN_PRINT("Start drawing layer. " +  String("Count:{0}").format(Array::make(layers.size())));
+	layers.push_back(layer);
+}
+
+void OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::stop_drawing_layer(std::shared_ptr<QuadSurfaceLayer> layer) {
+	auto remove = std::remove_if(
+		layers.begin(), layers.end(),
+		[layer](std::shared_ptr<QuadSurfaceLayer> layer_b) {return layer_b->handle == layer->handle;});
+	if (remove == layers.end()) {
+		WARN_PRINT("Unable to remove layer");
+	} else {
+		layers.erase(remove);
+	}
+}
+
+#endif // ANDROID

--- a/common/src/main/cpp/include/classes/android_surface_layer.h
+++ b/common/src/main/cpp/include/classes/android_surface_layer.h
@@ -1,0 +1,64 @@
+/**************************************************************************/
+/*  android_surface_layer.h                                               */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <memory>
+#include <godot_cpp/classes/node3d.hpp>
+#include <godot_cpp/templates/vector.hpp>
+
+#include "extensions/openxr_khr_android_surface_swapchain_extension_wrapper.h"
+
+namespace godot {
+
+class AndroidSurfaceLayer : public Node3D {
+	GDCLASS(AndroidSurfaceLayer, Node3D)
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	AndroidSurfaceLayer();
+	~AndroidSurfaceLayer();
+
+	int get_android_surface_handle();
+	void set_layer_resolution(int widthPx, int heightPx);
+	void set_size_2d_meters(float width, float height);
+	void set_sort_order(int sort_order);
+	bool is_supported();
+
+	void update_visibility();
+	void update_transform();
+
+private:
+	std::shared_ptr<QuadSurfaceLayer> layer;
+};
+
+} //namespace godot

--- a/common/src/main/cpp/include/extensions/openxr_khr_android_surface_swapchain_extension_wrapper.h
+++ b/common/src/main/cpp/include/extensions/openxr_khr_android_surface_swapchain_extension_wrapper.h
@@ -1,0 +1,112 @@
+/**************************************************************************/
+/*  openxr_khr_android_surface_swapchain_extension_wrapper.h              */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <openxr/openxr.h>
+
+struct QuadSurfaceLayer {
+	int handle;
+	int order;
+	XrSwapchain swapchain;
+	XrCompositionLayerQuad layer;
+};
+
+#ifdef ANDROID
+#define XR_USE_PLATFORM_ANDROID
+#include <jni.h>
+#include <openxr/openxr_platform.h>
+
+#include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
+#include <godot_cpp/classes/ref_counted.hpp>
+#include <godot_cpp/templates/hash_map.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+#include "util.h"
+
+using namespace godot;
+
+class OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper : public OpenXRExtensionWrapperExtension {
+	GDCLASS(OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper, OpenXRExtensionWrapperExtension);
+
+public:
+	Dictionary _get_requested_extensions() override;
+
+	void _on_instance_created(uint64_t p_instance) override;
+	void _on_session_created(uint64_t p_session) override;
+	void _on_session_destroyed() override;
+	void _on_instance_destroyed() override;
+
+	int _get_composition_layer_count() override;
+	uint64_t _get_composition_layer(int p_index) override;
+	int _get_composition_layer_order(int p_index) override;
+
+	int allocate_swapchain(std::shared_ptr<QuadSurfaceLayer> layer, uint32_t widthPx, uint32_t heightPx);
+	void free_swapchain(std::shared_ptr<QuadSurfaceLayer> layer);
+
+	void start_drawing_layer(std::shared_ptr<QuadSurfaceLayer> layer);
+	void stop_drawing_layer(std::shared_ptr<QuadSurfaceLayer> layer);
+
+	bool is_android_surface_swapchain_supported() {
+		return khr_android_surface_swapchain_ext && fb_android_surface_swapchain_create_ext;
+	}
+
+	static OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper *get_singleton();
+
+	OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper();
+	~OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper();
+
+protected:
+	static void _bind_methods();
+
+private:
+	EXT_PROTO_XRRESULT_FUNC4(xrCreateSwapchainAndroidSurfaceKHR,
+			(XrSession), session,
+			(const XrSwapchainCreateInfo *), info,
+			(XrSwapchain *), swapchain,
+			(jobject *), surface);
+
+	EXT_PROTO_XRRESULT_FUNC1(xrDestroySwapchain,
+			(XrSwapchain), swapchain);
+
+	bool initialize_khr_android_surface_swapchain_extension(const XrInstance &instance);
+	void cleanup();
+
+	static OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper *singleton;
+
+	HashMap<String, bool *> request_extensions;
+	bool khr_android_surface_swapchain_ext = false;
+	bool fb_android_surface_swapchain_create_ext = false;
+	bool fb_composition_layer_image_layout_ext = false;
+
+	std::vector<std::shared_ptr<QuadSurfaceLayer>> layers;
+	XrCompositionLayerImageLayoutFB composition_layout_ext = {};
+};
+
+#endif // ANDROID

--- a/common/src/main/cpp/register_types.cpp
+++ b/common/src/main/cpp/register_types.cpp
@@ -54,6 +54,11 @@
 #include "extensions/openxr_fb_spatial_entity_extension_wrapper.h"
 #include "extensions/openxr_fb_spatial_entity_query_extension_wrapper.h"
 
+#ifdef ANDROID
+#include "extensions/openxr_khr_android_surface_swapchain_extension_wrapper.h"
+#endif
+
+#include "classes/android_surface_layer.h"
 #include "classes/openxr_fb_hand_tracking_mesh.h"
 #include "classes/openxr_fb_render_model.h"
 
@@ -91,6 +96,11 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 
 			ClassDB::register_class<OpenXRFbHandTrackingAimExtensionWrapper>();
 			OpenXRFbHandTrackingAimExtensionWrapper::get_singleton()->register_extension_wrapper();
+
+#ifdef ANDROID
+			ClassDB::register_class<OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper>();
+			OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::get_singleton()->register_extension_wrapper();
+#endif
 		} break;
 
 		case MODULE_INITIALIZATION_LEVEL_SERVERS:
@@ -107,6 +117,11 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			Engine::get_singleton()->register_singleton("OpenXRFbFaceTrackingExtensionWrapper", OpenXRFbFaceTrackingExtensionWrapper::get_singleton());
 			Engine::get_singleton()->register_singleton("OpenXRFbHandTrackingAimExtensionWrapper", OpenXRFbHandTrackingAimExtensionWrapper::get_singleton());
 
+#ifdef ANDROID
+			Engine::get_singleton()->register_singleton("OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper", OpenXRKhrAndroidSurfaceSwapchainExtensionWrapper::get_singleton());
+#endif
+
+			ClassDB::register_class<AndroidSurfaceLayer>();
 			ClassDB::register_class<OpenXRFbRenderModel>();
 			ClassDB::register_class<OpenXRFbHandTrackingMesh>();
 

--- a/godotopenxrmeta/src/main/java/org/godotengine/openxr/vendors/meta/SurfaceStorage.java
+++ b/godotopenxrmeta/src/main/java/org/godotengine/openxr/vendors/meta/SurfaceStorage.java
@@ -1,0 +1,67 @@
+/**************************************************************************/
+/*  SurfaceStorage.java                                                   */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+package org.godotengine.openxr.vendors.meta;
+
+import android.util.Log;
+import android.util.SparseArray;
+import android.view.Surface;
+
+/**
+ * Stores Android Surface objects created to back XrSwapchains
+ */
+public class SurfaceStorage {
+    static {
+        System.loadLibrary("godotopenxrvendors");
+    }
+
+  private static final String TAG = "SurfaceStorage";
+  private static final SparseArray<Surface> surfaces = new SparseArray();
+  private static int latestIndex = 0;
+
+  // Called by Java requesting the Surface
+  public static Surface getSurfaceForSwapchain(int index) {
+      Log.d(TAG, "getSurfaceForSwapchain(" + index + ")" + "will return " + surfaces.get(index) + " from array " + surfaces);
+      return surfaces.get(index);
+  }
+
+  // Called by Native storing the Surface
+  private static int storeSurfaceForSwapchain(Surface surface) {
+      int index = latestIndex;
+      Log.d(TAG, "storeSurfaceForSwapchain: " + surface + " at index " + index + " of array " + surfaces);
+      surfaces.put(index, surface);
+      latestIndex++;
+      return index;
+  }
+
+  private static void releaseSurface(int index) {
+      // No need to manually release, that's handled by xrDestroySwapchain
+      surfaces.delete(index);
+  }
+}


### PR DESCRIPTION
This is a draft for adding an AndroidSurfaceLayer object that extends Node3D and does the following:
 - Creates an Android Surface backed swapchain
 - Sets up an XrCompositionLayerQuad to submit (using Node3D pose, visibility, etc)
 - Stores an in handle for that Surface that can be passed to an Android plugin to retrieve the Surface

With this change, a project can use Android Surfaces to display content on OpenXR layers and control them with the Godot scene graph.

TODO: Add an example to the demo project