### PR TITLE
Add support for spatial anchor storage

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -18,6 +18,7 @@ sources += Glob("#common/src/main/cpp/*.cpp")
 sources += Glob("#common/src/main/cpp/export/*.cpp")
 sources += Glob("#common/src/main/cpp/extensions/*.cpp")
 sources += Glob("#common/src/main/cpp/classes/*.cpp")
+sources += Glob("#common/src/main/cpp/utils/*.cpp")
 
 binary_path = '#demo/addons/godotopenxrvendors/.bin'
 project_name = 'godotopenxrvendors'

--- a/common/src/main/cpp/extensions/openxr_fb_spatial_entity_query_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_fb_spatial_entity_query_extension_wrapper.cpp
@@ -28,12 +28,19 @@
 /**************************************************************************/
 
 #include "extensions/openxr_fb_spatial_entity_query_extension_wrapper.h"
+#include "extensions/openxr_fb_spatial_entity_extension_wrapper.h"
 
+#include <godot_cpp/variant/utility_functions.hpp>
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
 #include <godot_cpp/classes/object.hpp>
 #include <godot_cpp/classes/open_xrapi_extension.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 
+#include "utils/xr_godot_utils.h"
+
 using namespace godot;
+
+static const uint32_t MAX_PERSISTENT_SPACES = 100;
 
 OpenXRFbSpatialEntityQueryExtensionWrapper *OpenXRFbSpatialEntityQueryExtensionWrapper::singleton = nullptr;
 
@@ -58,6 +65,8 @@ OpenXRFbSpatialEntityQueryExtensionWrapper::~OpenXRFbSpatialEntityQueryExtension
 
 void OpenXRFbSpatialEntityQueryExtensionWrapper::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_spatial_entity_query_supported"), &OpenXRFbSpatialEntityQueryExtensionWrapper::is_spatial_entity_query_supported);
+	ClassDB::bind_method(D_METHOD("query_persisted_anchors"), &OpenXRFbSpatialEntityQueryExtensionWrapper::query_persisted_anchors);
+	ADD_SIGNAL(MethodInfo("persisted_anchors_found", PropertyInfo(Variant::PACKED_STRING_ARRAY, "name")));
 }
 
 void OpenXRFbSpatialEntityQueryExtensionWrapper::cleanup() {
@@ -108,6 +117,56 @@ bool OpenXRFbSpatialEntityQueryExtensionWrapper::_on_event_polled(const void *ev
 	return false;
 }
 
+void OpenXRFbSpatialEntityQueryExtensionWrapper::query_persisted_anchors() {
+	XrSpaceQueryInfoFB queryInfo = {
+			XR_TYPE_SPACE_QUERY_INFO_FB,
+			nullptr,
+			XR_SPACE_QUERY_ACTION_LOAD_FB,
+			MAX_PERSISTENT_SPACES,
+			0,
+			nullptr,
+			nullptr};
+	query_spatial_entities((XrSpaceQueryInfoBaseHeaderFB*) &queryInfo, [=](Vector<XrSpaceQueryResultFB> results) {
+		PackedStringArray found_anchor_uuids;
+		for (const auto& result : results) {
+			// TODO: Filter for the persisted anchors only, ignore the room itself
+			OpenXRFbSpatialEntityExtensionWrapper::get_singleton()->print_supported_components(result.space);
+			found_anchor_uuids.push_back(String(XrGodotUtils::uuidToString(result.uuid).c_str()));
+		}
+
+		emit_signal("persisted_anchors_found", found_anchor_uuids);
+	});
+}
+
+void OpenXRFbSpatialEntityQueryExtensionWrapper::query_spatial_entities_by_uuid(const String& uuid, SpaceQueryCompleteCallback_t callback) {
+	std::vector<XrUuidEXT> uuids = {XrGodotUtils::uuidFromString(std::string(uuid.ascii()))};
+
+	XrSpaceStorageLocationFilterInfoFB storageLocationFilterInfo = {
+		XR_TYPE_SPACE_STORAGE_LOCATION_FILTER_INFO_FB,
+		nullptr,
+		XR_SPACE_STORAGE_LOCATION_LOCAL_FB
+	};
+
+	// First query the anchor by UUID
+	XrSpaceUuidFilterInfoFB uuidFilter = {
+		XR_TYPE_SPACE_UUID_FILTER_INFO_FB,
+		&storageLocationFilterInfo,
+		1,
+		&uuids[0],
+	};
+
+	XrSpaceQueryInfoFB queryInfo = {
+			XR_TYPE_SPACE_QUERY_INFO_FB,
+			nullptr,
+			XR_SPACE_QUERY_ACTION_LOAD_FB,
+			MAX_PERSISTENT_SPACES,
+			0,
+			(XrSpaceFilterInfoBaseHeaderFB*)&uuidFilter,
+			nullptr};
+
+		OpenXRFbSpatialEntityQueryExtensionWrapper::get_singleton()->query_spatial_entities((XrSpaceQueryInfoBaseHeaderFB*) &queryInfo, callback);
+}
+
 void OpenXRFbSpatialEntityQueryExtensionWrapper::query_spatial_entities(const XrSpaceQueryInfoBaseHeaderFB *info, SpaceQueryCompleteCallback_t callback) {
 	XrAsyncRequestIdFB requestId;
 	const XrResult result = xrQuerySpacesFB(SESSION, info, &requestId);
@@ -154,7 +213,7 @@ void OpenXRFbSpatialEntityQueryExtensionWrapper::on_space_query_results(const Xr
 }
 
 void OpenXRFbSpatialEntityQueryExtensionWrapper::on_space_query_complete(const XrEventDataSpaceQueryCompleteFB *event) {
-	if (query_complete_callbacks.has(event->requestId)) {
+	if (!query_complete_callbacks.has(event->requestId)) {
 		WARN_PRINT("Received unexpected XR_TYPE_EVENT_DATA_SPACE_QUERY_RESULTS_AVAILABLE_FB");
 		return;
 	}

--- a/common/src/main/cpp/extensions/openxr_fb_spatial_entity_storage_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_fb_spatial_entity_storage_extension_wrapper.cpp
@@ -1,0 +1,315 @@
+/**************************************************************************/
+/*  openxr_fb_spatial_entity_storage_extension_wrapper.cpp                */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "extensions/openxr_fb_spatial_entity_storage_extension_wrapper.h"
+#include "extensions/openxr_fb_spatial_entity_query_extension_wrapper.h"
+#include "extensions/openxr_fb_spatial_entity_extension_wrapper.h"
+#include "utils/xr_godot_utils.h"
+
+#include <godot_cpp/variant/utility_functions.hpp>
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
+#include <godot_cpp/classes/object.hpp>
+
+#define LOG_FAIL(EVENT, ERR) if(EVENT) WARN_PRINT(String(ERR) + String(" - ") + get_openxr_api()->get_error_string(EVENT->result)); else WARN_PRINT(String(ERR) + String(" - NULL EVENT"))
+#define FAILED(EVENT) !EVENT || !XR_SUCCEEDED(EVENT->result)
+
+using namespace godot;
+
+static const uint32_t MAX_PERSISTENT_SPACES = 100;
+
+OpenXRFbSpatialEntityStorageExtensionWrapper *OpenXRFbSpatialEntityStorageExtensionWrapper::singleton = nullptr;
+
+OpenXRFbSpatialEntityStorageExtensionWrapper *OpenXRFbSpatialEntityStorageExtensionWrapper::get_singleton() {
+	if (singleton == nullptr) {
+		singleton = memnew(OpenXRFbSpatialEntityStorageExtensionWrapper());
+	}
+	return singleton;
+}
+
+OpenXRFbSpatialEntityStorageExtensionWrapper::OpenXRFbSpatialEntityStorageExtensionWrapper() :
+		OpenXRExtensionWrapperExtension() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "An OpenXRFbSpatialEntityStorageExtensionWrapper singleton already exists.");
+
+	request_extensions[XR_FB_SPATIAL_ENTITY_STORAGE_EXTENSION_NAME] = &fb_spatial_entity_storage_ext;
+	singleton = this;
+}
+
+OpenXRFbSpatialEntityStorageExtensionWrapper::~OpenXRFbSpatialEntityStorageExtensionWrapper() {
+	cleanup();
+}
+
+void OpenXRFbSpatialEntityStorageExtensionWrapper::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_spatial_entity_storage_supported"), &OpenXRFbSpatialEntityStorageExtensionWrapper::is_spatial_entity_storage_supported);
+	ClassDB::bind_method(D_METHOD("create_persistent_anchor"), &OpenXRFbSpatialEntityStorageExtensionWrapper::create_persistent_anchor);
+	ClassDB::bind_method(D_METHOD("delete_persistent_anchor"), &OpenXRFbSpatialEntityStorageExtensionWrapper::delete_persistent_anchor);
+	ClassDB::bind_method(D_METHOD("start_tracking_persistent_anchor"), &OpenXRFbSpatialEntityStorageExtensionWrapper::start_tracking_persistent_anchor);
+	ClassDB::bind_method(D_METHOD("stop_tracking_persistent_anchor"), &OpenXRFbSpatialEntityStorageExtensionWrapper::stop_tracking_persistent_anchor);
+
+	ADD_SIGNAL(MethodInfo("create_persistent_anchor_failed", PropertyInfo(Variant::STRING, "tracker_name")));
+}
+
+void OpenXRFbSpatialEntityStorageExtensionWrapper::cleanup() {
+	fb_spatial_entity_storage_ext = false;
+}
+
+Dictionary OpenXRFbSpatialEntityStorageExtensionWrapper::_get_requested_extensions() {
+	Dictionary result;
+	for (auto ext: request_extensions) {
+		uint64_t value = reinterpret_cast<uint64_t>(ext.value);
+		result[ext.key] = (Variant)value;
+	}
+	return result;
+}
+
+void OpenXRFbSpatialEntityStorageExtensionWrapper::_on_instance_created(uint64_t instance) {
+	if (fb_spatial_entity_storage_ext) {
+		bool result = initialize_fb_spatial_entity_storage_extension((XrInstance)instance);
+		if (!result) {
+			UtilityFunctions::print("Failed to initialize fb_spatial_entity_storage extension");
+			fb_spatial_entity_storage_ext = false;
+		}
+	}
+}
+
+void OpenXRFbSpatialEntityStorageExtensionWrapper::_on_instance_destroyed() {
+	cleanup();
+}
+
+bool OpenXRFbSpatialEntityStorageExtensionWrapper::initialize_fb_spatial_entity_storage_extension(const XrInstance& p_instance) {
+	GDEXTENSION_INIT_XR_FUNC_V(xrSaveSpaceFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrEraseSpaceFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrLocateSpace);
+	return true;
+}
+
+bool OpenXRFbSpatialEntityStorageExtensionWrapper::_on_event_polled(const void *event) {
+	if (static_cast<const XrEventDataBuffer*>(event)->type == XR_TYPE_EVENT_DATA_SPACE_SAVE_COMPLETE_FB) {
+		on_save_complete((const XrEventDataSpaceSaveCompleteFB*) event);
+		return true;
+	}
+
+	if (static_cast<const XrEventDataBuffer*>(event)->type == XR_TYPE_EVENT_DATA_SPACE_ERASE_COMPLETE_FB) {
+		on_erase_complete((const XrEventDataSpaceEraseCompleteFB*) event);
+		return true;
+	}
+
+	return false;
+}
+
+void OpenXRFbSpatialEntityStorageExtensionWrapper::save_spatial_anchor(const XrSpaceSaveInfoFB* info, SaveCompleteCallback_t callback) {
+	XrAsyncRequestIdFB requestId;
+	const XrResult result = xrSaveSpaceFB(SESSION, info, &requestId);
+	if (!XR_SUCCEEDED(result)) {
+		WARN_PRINT("xrSaveSpaceFB failed!");
+		WARN_PRINT(get_openxr_api()->get_error_string(result));
+		callback(nullptr);
+		return;
+	}
+	save_complete_callbacks[requestId] = callback;
+}
+
+void OpenXRFbSpatialEntityStorageExtensionWrapper::erase_spatial_anchor(const XrSpaceEraseInfoFB* info, EraseCompleteCallback_t callback) {
+	XrAsyncRequestIdFB requestId;
+	const XrResult result = xrEraseSpaceFB(SESSION, info, &requestId);
+	if (!XR_SUCCEEDED(result)) {
+		WARN_PRINT("xrEraseSpaceFB failed!");
+		WARN_PRINT(get_openxr_api()->get_error_string(result));
+		callback(nullptr);
+		return;
+	}
+	erase_complete_callbacks[requestId] = callback;
+}
+
+void OpenXRFbSpatialEntityStorageExtensionWrapper::on_save_complete(const XrEventDataSpaceSaveCompleteFB* event) {
+	if (!save_complete_callbacks.has(event->requestId)) {
+		WARN_PRINT("Received unexpected XR_TYPE_EVENT_DATA_SPACE_SAVE_COMPLETE_FB");
+		return;
+	}
+	save_complete_callbacks[event->requestId](event);
+	save_complete_callbacks.erase(event->requestId);
+}
+
+void OpenXRFbSpatialEntityStorageExtensionWrapper::on_erase_complete(const XrEventDataSpaceEraseCompleteFB* event) {
+	if (!erase_complete_callbacks.has(event->requestId)) {
+		WARN_PRINT("Received unexpected XR_TYPE_EVENT_DATA_SPACE_ERASE_COMPLETE_FB");
+		return;
+	}
+	erase_complete_callbacks[event->requestId](event);
+	erase_complete_callbacks.erase(event->requestId);
+}
+
+void OpenXRFbSpatialEntityStorageExtensionWrapper::start_tracking_persistent_anchor(const String& uuid, const String& tracker_name) {
+	OpenXRFbSpatialEntityQueryExtensionWrapper::get_singleton()->query_spatial_entities_by_uuid(uuid,[=](Vector<XrSpaceQueryResultFB> results) {
+		if (results.size() == 1) {
+			anchor_spaces[uuid] = results[0].space;
+
+			Ref<XRPositionalTracker> positional_tracker;
+			positional_tracker.instantiate();
+			positional_tracker->set_tracker_type(XRServer::TRACKER_ANCHOR);
+			positional_tracker->set_tracker_name(tracker_name);
+			positional_tracker->set_input("uuid", uuid);
+
+			XRServer *xr_server = XRServer::get_singleton();
+			xr_server->add_tracker(positional_tracker);
+			trackers[uuid] = positional_tracker;
+		} else {
+			WARN_PRINT("Could not find anchor" + uuid);
+		}
+	});
+}
+
+void OpenXRFbSpatialEntityStorageExtensionWrapper::stop_tracking_persistent_anchor(const String& uuid) {
+	if (trackers.has(uuid)) {
+		XRServer *xr_server = XRServer::get_singleton();
+		xr_server->remove_tracker(trackers[uuid]);
+		trackers.erase(uuid);
+		anchor_spaces.erase(uuid);
+	} else {
+		WARN_PRINT("Trying to delete unknown tracker: " + uuid);
+	}
+}
+
+void OpenXRFbSpatialEntityStorageExtensionWrapper::create_persistent_anchor(const Transform3D &transform, const String& tracker_name) {
+	XrTime display_time = (XrTime) get_openxr_api()->get_next_frame_time();
+	XrSpace play_space = (XrSpace) get_openxr_api()->get_play_space();
+
+	// First create the anchor for this session
+	OpenXRFbSpatialEntityExtensionWrapper::get_singleton()->create_spatial_anchor(
+		play_space, display_time, XrGodotUtils::transformToPose(transform),
+		[tracker_name, this](const XrEventDataSpatialAnchorCreateCompleteFB* createResult) {
+			if (FAILED(createResult)) {
+				LOG_FAIL(createResult, "Unable to create XrSpace");
+				emit_signal("create_persistent_anchor_failed", tracker_name);
+				return;
+			}
+			// Next enable storable
+			OpenXRFbSpatialEntityExtensionWrapper::get_singleton()->set_component_enabled(
+				createResult->space, XR_SPACE_COMPONENT_TYPE_STORABLE_FB, true,
+				[tracker_name, this](const XrEventDataSpaceSetStatusCompleteFB* enableResult) {
+					if (FAILED(enableResult)) {
+						LOG_FAIL(enableResult, "Unable to enable XR_SPACE_COMPONENT_TYPE_STORABLE_FB for XrSpace");
+						emit_signal("create_persistent_anchor_failed", tracker_name);
+						return;
+					}
+
+					// Finally, save the anchor
+					XrSpaceSaveInfoFB saveInfo = {
+						XR_TYPE_SPACE_SAVE_INFO_FB,
+						nullptr,
+						enableResult->space,
+						XR_SPACE_STORAGE_LOCATION_LOCAL_FB,
+						XR_SPACE_PERSISTENCE_MODE_INDEFINITE_FB
+					};
+					OpenXRFbSpatialEntityStorageExtensionWrapper::get_singleton()->save_spatial_anchor(
+						&saveInfo,
+						[tracker_name, this](const XrEventDataSpaceSaveCompleteFB* saveResult) {
+							if (FAILED(saveResult)) {
+								LOG_FAIL(saveResult, "Unable to save XrSpace");
+								emit_signal("create_persistent_anchor_failed", tracker_name);
+								return;
+							}
+							start_tracking_persistent_anchor(String(XrGodotUtils::uuidToString(saveResult->uuid).c_str()), tracker_name);
+					});
+				});
+		}
+	);
+}
+
+void OpenXRFbSpatialEntityStorageExtensionWrapper::delete_persistent_anchor(const String& uuid) {
+	OpenXRFbSpatialEntityQueryExtensionWrapper::get_singleton()->query_spatial_entities_by_uuid(uuid, [=](Vector<XrSpaceQueryResultFB> results) {
+		if (results.size() == 1) {
+			stop_tracking_persistent_anchor(uuid);
+			if (OpenXRFbSpatialEntityExtensionWrapper::get_singleton()->is_component_enabled(
+				results[0].space, XR_SPACE_COMPONENT_TYPE_STORABLE_FB
+			)) {
+				XrSpaceEraseInfoFB info = {
+					XR_TYPE_SPACE_ERASE_INFO_FB,
+					nullptr,
+					results[0].space,
+					XR_SPACE_STORAGE_LOCATION_LOCAL_FB, // TODO: Don't hardcode this
+				};
+
+				erase_spatial_anchor(&info, [](const XrEventDataSpaceEraseCompleteFB* eventData){});
+			} else {
+				// Enable storable so we can delete it
+				OpenXRFbSpatialEntityExtensionWrapper::get_singleton()->set_component_enabled(
+					results[0].space, XR_SPACE_COMPONENT_TYPE_STORABLE_FB, true,
+					[results, this](const XrEventDataSpaceSetStatusCompleteFB* enableResult) {
+						if (FAILED(enableResult)) {
+							LOG_FAIL(enableResult, "Unable to enable XR_SPACE_COMPONENT_TYPE_STORABLE_FB for XrSpace");
+							return;
+						}
+
+						XrSpaceEraseInfoFB info = {
+							XR_TYPE_SPACE_ERASE_INFO_FB,
+							nullptr,
+							results[0].space,
+							XR_SPACE_STORAGE_LOCATION_LOCAL_FB, // TODO: Don't hardcode this
+						};
+
+						erase_spatial_anchor(&info, [](const XrEventDataSpaceEraseCompleteFB* eventData){});
+					});
+			}
+		} else {
+			WARN_PRINT("Could not find anchor: " + uuid);
+		}
+	});
+}
+
+void OpenXRFbSpatialEntityStorageExtensionWrapper::_on_process() {
+	if (!fb_spatial_entity_storage_ext) {
+		return;
+	}
+
+	// Locate every known anchor and update the corresponding tracker's position
+	for (auto space: anchor_spaces) {
+		XrSpaceLocation location = {
+			XR_TYPE_SPACE_LOCATION, // type
+			nullptr, // next
+			0, // locationFlags
+			{
+					{ 0.0, 0.0, 0.0, 0.0 }, // orientation
+					{ 0.0, 0.0, 0.0 } // position
+			} // pose
+		};
+
+		xrLocateSpace(
+			space.value,
+			(XrSpace) get_openxr_api()->get_play_space(),
+			get_openxr_api()->get_next_frame_time(),
+			&location);
+
+		trackers[space.key]->set_pose(
+			"default",
+			XrGodotUtils::poseToTransform(location.pose),
+			Vector3 {},
+			Vector3 {},
+			XRPose::XR_TRACKING_CONFIDENCE_HIGH);
+	}
+}

--- a/common/src/main/cpp/include/extensions/openxr_fb_spatial_entity_extension_wrapper.h
+++ b/common/src/main/cpp/include/extensions/openxr_fb_spatial_entity_extension_wrapper.h
@@ -43,6 +43,7 @@
 using namespace godot;
 
 typedef std::function<void(const XrEventDataSpaceSetStatusCompleteFB *eventData)> SetSpaceComponentStatusCallback_t;
+typedef std::function<void(const XrEventDataSpatialAnchorCreateCompleteFB *eventData)> CreateSpatialAnchorCallback_t;
 
 // Wrapper for the set of Facebook XR spatial entity extension.
 class OpenXRFbSpatialEntityExtensionWrapper : public OpenXRExtensionWrapperExtension {
@@ -59,6 +60,13 @@ public:
 		return fb_spatial_entity_ext;
 	}
 
+	void create_spatial_anchor(
+		const XrSpace &playSpace,
+		const XrTime &frameTime,
+		const XrPosef &poseInSpace,
+		CreateSpatialAnchorCallback_t callback);
+
+	void print_supported_components(const XrSpace &space);
 	bool is_component_supported(const XrSpace &space, XrSpaceComponentTypeFB type);
 	bool is_component_enabled(const XrSpace &space, XrSpaceComponentTypeFB type);
 
@@ -114,6 +122,7 @@ private:
 
 	HashMap<String, bool *> request_extensions;
 	HashMap<XrAsyncRequestIdFB, SetSpaceComponentStatusCallback_t> set_status_callbacks;
+	HashMap<XrAsyncRequestIdFB, CreateSpatialAnchorCallback_t> create_anchor_callbacks;
 
 	void cleanup();
 

--- a/common/src/main/cpp/include/utils/xr_godot_utils.h
+++ b/common/src/main/cpp/include/utils/xr_godot_utils.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <godot_cpp/variant/transform3d.hpp>
+#include <openxr/openxr.h>
+
+namespace godot {
+
+class XrGodotUtils {
+  public:
+    static bool isUuidValid(const XrUuidEXT& uuid);
+    static std::string bytesToHexStr(const uint8_t *data, int len);
+    static std::vector<uint8_t> hexStrToBytes(std::string hexStr);
+    static std::string uuidToString(XrUuidEXT uuid);
+    static XrUuidEXT uuidFromString(std::string uuidStr);
+    static XrPosef transformToPose(const Transform3D& transform);
+    static Transform3D poseToTransform(const XrPosef& pose);
+};
+
+struct XrUuidExtCmp {
+  bool operator()(const XrUuidEXT& a, const XrUuidEXT& b) const {
+      return XrGodotUtils::uuidToString(a) < XrGodotUtils::uuidToString(b);
+  }
+};
+
+} // namespace godot

--- a/common/src/main/cpp/register_types.cpp
+++ b/common/src/main/cpp/register_types.cpp
@@ -53,6 +53,7 @@
 #include "extensions/openxr_fb_spatial_entity_container_extension_wrapper.h"
 #include "extensions/openxr_fb_spatial_entity_extension_wrapper.h"
 #include "extensions/openxr_fb_spatial_entity_query_extension_wrapper.h"
+#include "extensions/openxr_fb_spatial_entity_storage_extension_wrapper.h"
 
 #include "classes/openxr_fb_hand_tracking_mesh.h"
 #include "classes/openxr_fb_render_model.h"
@@ -76,6 +77,9 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 
 			ClassDB::register_class<OpenXRFbSpatialEntityQueryExtensionWrapper>();
 			OpenXRFbSpatialEntityQueryExtensionWrapper::get_singleton()->register_extension_wrapper();
+
+			ClassDB::register_class<OpenXRFbSpatialEntityStorageExtensionWrapper>();
+			OpenXRFbSpatialEntityStorageExtensionWrapper::get_singleton()->register_extension_wrapper();
 
 			ClassDB::register_class<OpenXRFbSpatialEntityContainerExtensionWrapper>();
 			OpenXRFbSpatialEntityContainerExtensionWrapper::get_singleton()->register_extension_wrapper();
@@ -102,6 +106,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			Engine::get_singleton()->register_singleton("OpenXRFbSceneCaptureExtensionWrapper", OpenXRFbSceneCaptureExtensionWrapper::get_singleton());
 			Engine::get_singleton()->register_singleton("OpenXRFbSpatialEntityExtensionWrapper", OpenXRFbSpatialEntityExtensionWrapper::get_singleton());
 			Engine::get_singleton()->register_singleton("OpenXRFbSpatialEntityQueryExtensionWrapper", OpenXRFbSpatialEntityQueryExtensionWrapper::get_singleton());
+			Engine::get_singleton()->register_singleton("OpenXRFbSpatialEntityStorageExtensionWrapper", OpenXRFbSpatialEntityStorageExtensionWrapper::get_singleton());
 			Engine::get_singleton()->register_singleton("OpenXRFbSpatialEntityContainerExtensionWrapper", OpenXRFbSpatialEntityContainerExtensionWrapper::get_singleton());
 			Engine::get_singleton()->register_singleton("OpenXRFbSceneExtensionWrapper", OpenXRFbSceneExtensionWrapper::get_singleton());
 			Engine::get_singleton()->register_singleton("OpenXRFbFaceTrackingExtensionWrapper", OpenXRFbFaceTrackingExtensionWrapper::get_singleton());

--- a/common/src/main/cpp/utils/xr_godot_utils.cpp
+++ b/common/src/main/cpp/utils/xr_godot_utils.cpp
@@ -1,0 +1,73 @@
+#include "utils/xr_godot_utils.h"
+
+#include <iomanip>
+#include <sstream>
+#include <string>
+
+using namespace godot;
+
+bool XrGodotUtils::isUuidValid(const XrUuidEXT& uuid) {
+  for (int i = 0; i < XR_UUID_SIZE_EXT; ++i) {
+    if (uuid.data[i] > 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::string XrGodotUtils::bytesToHexStr(const uint8_t *data, int len) {
+  std::stringstream ss;
+  ss << std::hex;
+  for(int i = 0; i < len; i++) {
+    ss << std::setw(2) << std::setfill('0') << (int)data[i];
+  }
+  return ss.str();
+}
+
+std::vector<uint8_t> XrGodotUtils::hexStrToBytes(std::string data) {
+  std::stringstream ss;
+  ss << data;
+
+  std::vector<uint8_t> resBytes;
+  size_t count = 0;
+  const auto len = data.size();
+  while(ss.good() && count < len) {
+      unsigned short num;
+      char hexNum[2];
+      ss.read(hexNum, 2);
+      sscanf(hexNum, "%2hX", &num);
+      resBytes.push_back(static_cast<uint8_t>(num));
+      count += 2;
+  }
+  return resBytes;
+
+}
+
+std::string XrGodotUtils::uuidToString(XrUuidEXT uuid) {
+  return bytesToHexStr(uuid.data, XR_UUID_SIZE_EXT);
+}
+
+XrUuidEXT XrGodotUtils::uuidFromString(std::string uuidStr) {
+  XrUuidEXT uuid;
+  auto bytes = hexStrToBytes(uuidStr);
+  for (size_t i = 0; i < XR_UUID_SIZE_EXT; i++) {
+    uuid.data[i] = bytes[i];
+  }
+  return uuid;
+}
+
+XrPosef XrGodotUtils::transformToPose(const Transform3D& transform) {
+  auto quat = transform.basis.get_rotation_quaternion();
+  return {
+    { quat.x, quat.y, quat.z, quat.w }, // orientation
+    { transform.origin.x, transform.origin.y, transform.origin.z } // position
+  };
+}
+
+Transform3D XrGodotUtils::poseToTransform(const XrPosef& pose) {
+	Quaternion q(pose.orientation.x, pose.orientation.y, pose.orientation.z, pose.orientation.w);
+	Basis basis(q);
+	Vector3 origin(pose.position.x, pose.position.y, pose.position.z);
+
+	return Transform3D(basis, origin);
+}


### PR DESCRIPTION
This commit adds a way to create, persist, and load spatial anchors. An anchor represents a real world point in stage space and will remain there even if the user recenters. It is created from a Transform3D and represented as an XRPositionalTracker (with a user provided name and runtime provided uuid).

TODO: Add example to demo project