### PR TITLE
Fix project cmake configuration

### DIFF
--- a/common/common.cmake
+++ b/common/common.cmake
@@ -68,8 +68,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 
-project(common LANGUAGES CXX)
-
 add_definitions(-DANDROID)
 
 set(GODOT_COMPILE_FLAGS)
@@ -99,7 +97,7 @@ else ()
 endif (CMAKE_BUILD_TYPE MATCHES Debug)
 
 ## godot-cpp library
-set(GODOT_CPP_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../thirdparty/godot-cpp")
+set(GODOT_CPP_DIR "${CMAKE_CURRENT_LIST_DIR}/../thirdparty/godot-cpp")
 set(GODOT-CPP "godot-cpp")
 
 # Use the godot-cpp prebuilt static binary
@@ -118,11 +116,11 @@ set_target_properties(${GODOT-CPP} PROPERTIES IMPORTED_LOCATION ${GODOT_CPP_STAT
 
 
 ## OpenXR headers
-set(OPENXR_HEADERS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../thirdparty/openxr/include")
+set(OPENXR_HEADERS_DIR "${CMAKE_CURRENT_LIST_DIR}/../thirdparty/openxr/include")
 
 
 # Common lib
-set(COMMON_LIB_HEADERS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../common/src/main/cpp/include)
+set(COMMON_LIB_HEADERS_DIR ${CMAKE_CURRENT_LIST_DIR}/../common/src/main/cpp/include)
 
-file(GLOB_RECURSE COMMON_LIB_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../common/src/main/cpp/*.c**)
-file(GLOB_RECURSE COMMON_LIB_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/../common/src/main/cpp/*.h**)
+file(GLOB_RECURSE COMMON_LIB_SOURCES ${CMAKE_CURRENT_LIST_DIR}/../common/src/main/cpp/*.c**)
+file(GLOB_RECURSE COMMON_LIB_HEADERS ${CMAKE_CURRENT_LIST_DIR}/../common/src/main/cpp/*.h**)

--- a/godotopenxrkhronos/CMakeLists.txt
+++ b/godotopenxrkhronos/CMakeLists.txt
@@ -1,14 +1,13 @@
 cmake_minimum_required(VERSION 3.22.1)
 
-## Common dependencies
-include(${CMAKE_SOURCE_DIR}/../common/CMakeLists.txt)
-
-
 ## Project definition
 project(godotopenxrvendors LANGUAGES CXX)
 
+## Common dependencies
+include(${PROJECT_SOURCE_DIR}/../common/common.cmake)
+
 ## khronos OpenXR loader library
-set(KHRONOS_OPENXR_LIB_PATH "${CMAKE_SOURCE_DIR}/../thirdparty/khronos_openxr_sdk/${ANDROID_ABI}/libopenxr_loader.so")
+set(KHRONOS_OPENXR_LIB_PATH "${PROJECT_SOURCE_DIR}/../thirdparty/khronos_openxr_sdk/${ANDROID_ABI}/libopenxr_loader.so")
 add_library(openxr_loader
         SHARED
         IMPORTED GLOBAL
@@ -16,10 +15,10 @@ add_library(openxr_loader
 set_target_properties(openxr_loader PROPERTIES IMPORTED_LOCATION ${KHRONOS_OPENXR_LIB_PATH})
 
 ## Setup the project sources
-file(GLOB_RECURSE ANDROID_SOURCES ${CMAKE_SOURCE_DIR}/src/main/cpp/*.c**)
-file(GLOB_RECURSE ANDROID_HEADERS ${CMAKE_SOURCE_DIR}/src/main/cpp/*.h**)
+file(GLOB_RECURSE ANDROID_SOURCES ${PROJECT_SOURCE_DIR}/src/main/cpp/*.c**)
+file(GLOB_RECURSE ANDROID_HEADERS ${PROJECT_SOURCE_DIR}/src/main/cpp/*.h**)
 
-add_library(${CMAKE_PROJECT_NAME}
+add_library(${PROJECT_NAME}
         SHARED
         ${ANDROID_SOURCES}
         ${ANDROID_HEADERS}
@@ -27,14 +26,14 @@ add_library(${CMAKE_PROJECT_NAME}
         ${COMMON_LIB_HEADERS}
         )
 
-target_include_directories(${CMAKE_PROJECT_NAME}
+target_include_directories(${PROJECT_NAME}
         SYSTEM PUBLIC
         ${GODOT_CPP_INCLUDE_DIRECTORIES}
         ${OPENXR_HEADERS_DIR}
         ${COMMON_LIB_HEADERS_DIR}
         )
 
-target_link_libraries(${CMAKE_PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME}
         android
         log
         ${GODOT-CPP}
@@ -42,7 +41,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
         )
 
 # Add the compile flags
-set_property(TARGET ${CMAKE_PROJECT_NAME} APPEND_STRING PROPERTY COMPILE_FLAGS ${GODOT_COMPILE_FLAGS})
-set_property(TARGET ${CMAKE_PROJECT_NAME} APPEND_STRING PROPERTY LINK_FLAGS ${GODOT_LINKER_FLAGS})
+set_property(TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY COMPILE_FLAGS ${GODOT_COMPILE_FLAGS})
+set_property(TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY LINK_FLAGS ${GODOT_LINKER_FLAGS})
 
 add_definitions(-DKHRONOS_VENDOR_ENABLED)

--- a/godotopenxrlynx/CMakeLists.txt
+++ b/godotopenxrlynx/CMakeLists.txt
@@ -1,14 +1,13 @@
 cmake_minimum_required(VERSION 3.22.1)
 
-## Common dependencies
-include(${CMAKE_SOURCE_DIR}/../common/CMakeLists.txt)
-
-
 ## Project definition
 project(godotopenxrvendors LANGUAGES CXX)
 
+## Common dependencies
+include(${PROJECT_SOURCE_DIR}/../common/common.cmake)
+
 ## lynx OpenXR loader library
-set(LYNX_OPENXR_LIB_PATH "${CMAKE_SOURCE_DIR}/../thirdparty/lynx_openxr_sdk/${ANDROID_ABI}/libopenxr_loader.so")
+set(LYNX_OPENXR_LIB_PATH "${PROJECT_SOURCE_DIR}/../thirdparty/lynx_openxr_sdk/${ANDROID_ABI}/libopenxr_loader.so")
 add_library(openxr_loader
         SHARED
         IMPORTED GLOBAL
@@ -16,10 +15,10 @@ add_library(openxr_loader
 set_target_properties(openxr_loader PROPERTIES IMPORTED_LOCATION ${LYNX_OPENXR_LIB_PATH})
 
 ## Setup the project sources
-file(GLOB_RECURSE ANDROID_SOURCES ${CMAKE_SOURCE_DIR}/src/main/cpp/*.c**)
-file(GLOB_RECURSE ANDROID_HEADERS ${CMAKE_SOURCE_DIR}/src/main/cpp/*.h**)
+file(GLOB_RECURSE ANDROID_SOURCES ${PROJECT_SOURCE_DIR}/src/main/cpp/*.c**)
+file(GLOB_RECURSE ANDROID_HEADERS ${PROJECT_SOURCE_DIR}/src/main/cpp/*.h**)
 
-add_library(${CMAKE_PROJECT_NAME}
+add_library(${PROJECT_NAME}
         SHARED
         ${ANDROID_SOURCES}
         ${ANDROID_HEADERS}
@@ -27,14 +26,14 @@ add_library(${CMAKE_PROJECT_NAME}
         ${COMMON_LIB_HEADERS}
         )
 
-target_include_directories(${CMAKE_PROJECT_NAME}
+target_include_directories(${PROJECT_NAME}
         SYSTEM PUBLIC
         ${GODOT_CPP_INCLUDE_DIRECTORIES}
         ${OPENXR_HEADERS_DIR}
         ${COMMON_LIB_HEADERS_DIR}
         )
 
-target_link_libraries(${CMAKE_PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME}
         android
         log
         ${GODOT-CPP}
@@ -42,7 +41,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
         )
 
 # Add the compile flags
-set_property(TARGET ${CMAKE_PROJECT_NAME} APPEND_STRING PROPERTY COMPILE_FLAGS ${GODOT_COMPILE_FLAGS})
-set_property(TARGET ${CMAKE_PROJECT_NAME} APPEND_STRING PROPERTY LINK_FLAGS ${GODOT_LINKER_FLAGS})
+set_property(TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY COMPILE_FLAGS ${GODOT_COMPILE_FLAGS})
+set_property(TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY LINK_FLAGS ${GODOT_LINKER_FLAGS})
 
 add_definitions(-DLYNX_VENDOR_ENABLED)

--- a/godotopenxrmeta/CMakeLists.txt
+++ b/godotopenxrmeta/CMakeLists.txt
@@ -1,15 +1,14 @@
 cmake_minimum_required(VERSION 3.22.1)
 
-## Common dependencies
-include(${CMAKE_SOURCE_DIR}/../common/CMakeLists.txt)
-
-
 ## Project definition
 project(godotopenxrvendors LANGUAGES CXX)
 
+## Common dependencies
+include(${PROJECT_SOURCE_DIR}/../common/common.cmake)
+
 ## OpenXR Mobile loader library
 # Sets the path to the OpenXR mobile library directory.
-set(OPENXR_MOBILE_ROOT_DIR "${CMAKE_SOURCE_DIR}/../thirdparty/ovr_openxr_mobile_sdk/OpenXR")
+set(OPENXR_MOBILE_ROOT_DIR "${PROJECT_SOURCE_DIR}/../thirdparty/ovr_openxr_mobile_sdk/OpenXR")
 set(OPENXR_MOBILE_HEADERS_DIR "${OPENXR_MOBILE_ROOT_DIR}/Include" CACHE STRING "")
 
 set(OPENXR_MOBILE_LIB_PATH "${OPENXR_MOBILE_ROOT_DIR}/Libs/Android/${ANDROID_ABI}/${OPENXR_MOBILE_LIB_BUILD_TYPE}/libopenxr_loader.so")
@@ -21,10 +20,10 @@ set_target_properties(openxr_loader PROPERTIES IMPORTED_LOCATION ${OPENXR_MOBILE
 
 
 ## Setup the project sources
-file(GLOB_RECURSE ANDROID_SOURCES ${CMAKE_SOURCE_DIR}/src/main/cpp/*.c**)
-file(GLOB_RECURSE ANDROID_HEADERS ${CMAKE_SOURCE_DIR}/src/main/cpp/*.h**)
+file(GLOB_RECURSE ANDROID_SOURCES ${PROJECT_SOURCE_DIR}/src/main/cpp/*.c**)
+file(GLOB_RECURSE ANDROID_HEADERS ${PROJECT_SOURCE_DIR}/src/main/cpp/*.h**)
 
-add_library(${CMAKE_PROJECT_NAME}
+add_library(${PROJECT_NAME}
         SHARED
         ${ANDROID_SOURCES}
         ${ANDROID_HEADERS}
@@ -32,7 +31,7 @@ add_library(${CMAKE_PROJECT_NAME}
         ${COMMON_LIB_HEADERS}
         )
 
-target_include_directories(${CMAKE_PROJECT_NAME}
+target_include_directories(${PROJECT_NAME}
         SYSTEM PUBLIC
         ${GODOT_CPP_INCLUDE_DIRECTORIES}
         ${OPENXR_HEADERS_DIR}
@@ -40,7 +39,7 @@ target_include_directories(${CMAKE_PROJECT_NAME}
         ${COMMON_LIB_HEADERS_DIR}
         )
 
-target_link_libraries(${CMAKE_PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME}
         android
         log
         ${GODOT-CPP}
@@ -48,7 +47,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
         )
 
 # Add the compile flags
-set_property(TARGET ${CMAKE_PROJECT_NAME} APPEND_STRING PROPERTY COMPILE_FLAGS ${GODOT_COMPILE_FLAGS})
-set_property(TARGET ${CMAKE_PROJECT_NAME} APPEND_STRING PROPERTY LINK_FLAGS ${GODOT_LINKER_FLAGS})
+set_property(TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY COMPILE_FLAGS ${GODOT_COMPILE_FLAGS})
+set_property(TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY LINK_FLAGS ${GODOT_LINKER_FLAGS})
 
 add_definitions(-DMETA_VENDOR_ENABLED)

--- a/godotopenxrpico/CMakeLists.txt
+++ b/godotopenxrpico/CMakeLists.txt
@@ -1,14 +1,13 @@
 cmake_minimum_required(VERSION 3.22.1)
 
-## Common dependencies
-include(${CMAKE_SOURCE_DIR}/../common/CMakeLists.txt)
-
-
 ## Project definition
 project(godotopenxrvendors LANGUAGES CXX)
 
+## Common dependencies
+include(${PROJECT_SOURCE_DIR}/../common/common.cmake)
+
 ## Pico OpenXR loader library
-set(PICO_OPENXR_LIB_PATH "${CMAKE_SOURCE_DIR}/../thirdparty/pico_openxr_sdk/${ANDROID_ABI}/libopenxr_loader.so")
+set(PICO_OPENXR_LIB_PATH "${PROJECT_SOURCE_DIR}/../thirdparty/pico_openxr_sdk/${ANDROID_ABI}/libopenxr_loader.so")
 add_library(openxr_loader
         SHARED
         IMPORTED GLOBAL
@@ -16,10 +15,10 @@ add_library(openxr_loader
 set_target_properties(openxr_loader PROPERTIES IMPORTED_LOCATION ${PICO_OPENXR_LIB_PATH})
 
 ## Setup the project sources
-file(GLOB_RECURSE ANDROID_SOURCES ${CMAKE_SOURCE_DIR}/src/main/cpp/*.c**)
-file(GLOB_RECURSE ANDROID_HEADERS ${CMAKE_SOURCE_DIR}/src/main/cpp/*.h**)
+file(GLOB_RECURSE ANDROID_SOURCES ${PROJECT_SOURCE_DIR}/src/main/cpp/*.c**)
+file(GLOB_RECURSE ANDROID_HEADERS ${PROJECT_SOURCE_DIR}/src/main/cpp/*.h**)
 
-add_library(${CMAKE_PROJECT_NAME}
+add_library(${PROJECT_NAME}
         SHARED
         ${ANDROID_SOURCES}
         ${ANDROID_HEADERS}
@@ -27,14 +26,14 @@ add_library(${CMAKE_PROJECT_NAME}
         ${COMMON_LIB_HEADERS}
         )
 
-target_include_directories(${CMAKE_PROJECT_NAME}
+target_include_directories(${PROJECT_NAME}
         SYSTEM PUBLIC
         ${GODOT_CPP_INCLUDE_DIRECTORIES}
         ${OPENXR_HEADERS_DIR}
         ${COMMON_LIB_HEADERS_DIR}
         )
 
-target_link_libraries(${CMAKE_PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME}
         android
         log
         ${GODOT-CPP}
@@ -42,7 +41,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
         )
 
 # Add the compile flags
-set_property(TARGET ${CMAKE_PROJECT_NAME} APPEND_STRING PROPERTY COMPILE_FLAGS ${GODOT_COMPILE_FLAGS})
-set_property(TARGET ${CMAKE_PROJECT_NAME} APPEND_STRING PROPERTY LINK_FLAGS ${GODOT_LINKER_FLAGS})
+set_property(TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY COMPILE_FLAGS ${GODOT_COMPILE_FLAGS})
+set_property(TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY LINK_FLAGS ${GODOT_LINKER_FLAGS})
 
 add_definitions(-DPICO_VENDOR_ENABLED)


### PR DESCRIPTION
The current cmake configuration (used for the `gradle` build) happens to work because vendors subdirectories have a similar layout to each other and relative to the `common` subdirectory, and the `gradle` build is always executed  from the same location.
However, attempt to execute the `gradle` build from another location and you'll notice that things fall apart as the specified cmake variables are now pointing to invalid locations.

This PR fixes this issue through the following changes:
- In the vendors' cmake configuration (`CMakeLists.txt`):
  - Swap the use of `CMAKE_SOURCE_DIR` with `PROJECT_SOURCE_DIR` to make the paths relative to the current cmake project directory instead of the root cmake definition directory
  - Swap the use of `CMAKE_PROJECT_NAME` with `PROJECT_NAME` to refer to the current project name instead of the project name from the root cmake definition
- Refactor `common/CMakeLists.txt` to `common/common.cmake` to better reflect its role: does not contain any cmake project and is instead included in vendors' `CMakeLists.txt` definition to bring in common paths and dependencies.
  - Swap the use of `CMAKE_CURRENT_SOURCE_DIR` with `CMAKE_CURRENT_LIST_DIR` to make the common paths relative to  `common/common.cmake` 