### PR TITLE
Implement remaining functionality in XR_FB_passthrough extension wrapper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 - Update Meta OpenXR mobile SDK to version 62
 - Add a developer-facing API for interacting with scene anchors
 - Add XR_FB_hand_tracking_capsules extension wrapper
+- Add OpenXRFbPassthroughGeometry node
 
 ## 2.0.3
 - Migrate the export scripts from gdscript to C++ via gdextension

--- a/common/src/main/cpp/classes/openxr_fb_passthrough_geometry.cpp
+++ b/common/src/main/cpp/classes/openxr_fb_passthrough_geometry.cpp
@@ -1,0 +1,134 @@
+/**************************************************************************/
+/*  openxr_fb_passthrough_geometry.cpp                                    */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "classes/openxr_fb_passthrough_geometry.h"
+
+#include "extensions/openxr_fb_passthrough_extension_wrapper.h"
+
+#include <godot_cpp/classes/engine.hpp>
+#include <godot_cpp/classes/standard_material3d.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+using namespace godot;
+
+void OpenXRFbPassthroughGeometry::set_mesh(const Ref<Mesh> &p_mesh) {
+	if (p_mesh == mesh) {
+		return;
+	}
+
+	if (geometry_instance) {
+		destroy_passthrough_geometry();
+	}
+
+	mesh = p_mesh;
+
+	if (mesh.is_null()) {
+		if (preview_mesh != nullptr) {
+			preview_mesh->queue_free();
+			preview_mesh = nullptr;
+		}
+		return;
+	}
+
+	if (Engine::get_singleton()->is_editor_hint()) {
+		if (preview_mesh == nullptr) {
+			const Color PREVIEW_COLOR = Color(1.0, 0.0, 1.0);
+
+			Ref<StandardMaterial3D> material;
+			material.instantiate();
+			material->set_shading_mode(BaseMaterial3D::SHADING_MODE_UNSHADED);
+			material->set_albedo(PREVIEW_COLOR);
+
+			preview_mesh = memnew(MeshInstance3D);
+			preview_mesh->set_material_override(material);
+			add_child(preview_mesh, false, Node::INTERNAL_MODE_BACK);
+		}
+		preview_mesh->set_mesh(mesh);
+	}
+
+	if (OpenXRFbPassthroughExtensionWrapper::get_singleton()->is_passthrough_started()) {
+		create_passthrough_geometry();
+	}
+}
+
+Ref<Mesh> OpenXRFbPassthroughGeometry::get_mesh() const {
+	return mesh;
+}
+
+void OpenXRFbPassthroughGeometry::create_passthrough_geometry() {
+	geometry_instance = OpenXRFbPassthroughExtensionWrapper::get_singleton()->create_geometry_instance(mesh, get_transform());
+	set_notify_local_transform(true);
+}
+
+void OpenXRFbPassthroughGeometry::destroy_passthrough_geometry() {
+	if (geometry_instance != XR_NULL_HANDLE) {
+		OpenXRFbPassthroughExtensionWrapper::get_singleton()->destroy_geometry_instance(geometry_instance);
+		geometry_instance = XR_NULL_HANDLE;
+	}
+}
+
+void OpenXRFbPassthroughGeometry::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_POSTINITIALIZE: {
+			OpenXRFbPassthroughExtensionWrapper::get_singleton()->connect("openxr_fb_projected_passthrough_layer_created", callable_mp(this, &OpenXRFbPassthroughGeometry::create_passthrough_geometry));
+			OpenXRFbPassthroughExtensionWrapper::get_singleton()->connect("openxr_fb_passthrough_stopped", callable_mp(this, &OpenXRFbPassthroughGeometry::destroy_passthrough_geometry));
+		} break;
+		case NOTIFICATION_ENTER_TREE: {
+			if (is_visible()) {
+				OpenXRFbPassthroughExtensionWrapper::get_singleton()->register_geometry_node(this);
+			}
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+			OpenXRFbPassthroughExtensionWrapper::get_singleton()->unregister_geometry_node(this);
+
+			if (geometry_instance) {
+				destroy_passthrough_geometry();
+			}
+		} break;
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			if (is_visible()) {
+				OpenXRFbPassthroughExtensionWrapper::get_singleton()->register_geometry_node(this);
+			} else {
+				OpenXRFbPassthroughExtensionWrapper::get_singleton()->unregister_geometry_node(this);
+			}
+		} break;
+		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
+			if (geometry_instance) {
+				OpenXRFbPassthroughExtensionWrapper::get_singleton()->set_geometry_instance_transform(geometry_instance, get_transform());
+			}
+		} break;
+	}
+}
+
+void OpenXRFbPassthroughGeometry::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_mesh"), &OpenXRFbPassthroughGeometry::set_mesh);
+	ClassDB::bind_method(D_METHOD("get_mesh"), &OpenXRFbPassthroughGeometry::get_mesh);
+
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "mesh", PROPERTY_HINT_RESOURCE_TYPE, "Mesh"), "set_mesh", "get_mesh");
+}

--- a/common/src/main/cpp/extensions/openxr_fb_passthrough_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_fb_passthrough_extension_wrapper.cpp
@@ -30,12 +30,14 @@
 
 #include "extensions/openxr_fb_passthrough_extension_wrapper.h"
 
+#include <godot_cpp/classes/gradient.hpp>
 #include <godot_cpp/classes/main_loop.hpp>
 #include <godot_cpp/classes/open_xrapi_extension.hpp>
 #include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/classes/scene_tree.hpp>
 #include <godot_cpp/classes/viewport.hpp>
 #include <godot_cpp/classes/xr_server.hpp>
+#include <godot_cpp/templates/local_vector.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 
 using namespace godot;
@@ -65,12 +67,47 @@ OpenXRFbPassthroughExtensionWrapper::~OpenXRFbPassthroughExtensionWrapper() {
 
 void OpenXRFbPassthroughExtensionWrapper::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_passthrough_supported"), &OpenXRFbPassthroughExtensionWrapper::is_passthrough_supported);
-	ClassDB::bind_method(D_METHOD("is_passthrough_enabled"), &OpenXRFbPassthroughExtensionWrapper::is_passthrough_enabled);
+	ClassDB::bind_method(D_METHOD("is_passthrough_started"), &OpenXRFbPassthroughExtensionWrapper::is_passthrough_started);
+
+	ClassDB::bind_method(D_METHOD("set_texture_opacity_factor"), &OpenXRFbPassthroughExtensionWrapper::set_texture_opacity_factor);
+	ClassDB::bind_method(D_METHOD("get_texture_opacity_factor"), &OpenXRFbPassthroughExtensionWrapper::get_texture_opacity_factor);
+
+	ClassDB::bind_method(D_METHOD("get_current_layer_purpose"), &OpenXRFbPassthroughExtensionWrapper::get_current_layer_purpose);
+
+	ClassDB::bind_method(D_METHOD("set_edge_color"), &OpenXRFbPassthroughExtensionWrapper::set_edge_color);
+	ClassDB::bind_method(D_METHOD("get_edge_color"), &OpenXRFbPassthroughExtensionWrapper::get_edge_color);
+
+	ClassDB::bind_method(D_METHOD("set_passthrough_filter"), &OpenXRFbPassthroughExtensionWrapper::set_passthrough_filter);
+	ClassDB::bind_method(D_METHOD("get_current_passthrough_filter"), &OpenXRFbPassthroughExtensionWrapper::get_current_passthrough_filter);
+	ClassDB::bind_method(D_METHOD("set_color_map"), &OpenXRFbPassthroughExtensionWrapper::set_color_map);
+	ClassDB::bind_method(D_METHOD("set_mono_map"), &OpenXRFbPassthroughExtensionWrapper::set_mono_map);
+	ClassDB::bind_method(D_METHOD("set_brightness_contrast_saturation"), &OpenXRFbPassthroughExtensionWrapper::set_brightness_contrast_saturation);
+
+	ClassDB::bind_method(D_METHOD("has_passthrough_capability"), &OpenXRFbPassthroughExtensionWrapper::has_passthrough_capability);
+	ClassDB::bind_method(D_METHOD("has_color_passthrough_capability"), &OpenXRFbPassthroughExtensionWrapper::has_color_passthrough_capability);
+	ClassDB::bind_method(D_METHOD("has_layer_depth_passthrough_capability"), &OpenXRFbPassthroughExtensionWrapper::has_layer_depth_passthrough_capability);
+
+	ADD_SIGNAL(MethodInfo("openxr_fb_projected_passthrough_layer_created"));
+	ADD_SIGNAL(MethodInfo("openxr_fb_passthrough_stopped"));
+	ADD_SIGNAL(MethodInfo("openxr_fb_passthrough_state_changed", PropertyInfo(Variant::INT, "event_type")));
+
+	BIND_ENUM_CONSTANT(LAYER_PURPOSE_NONE);
+	BIND_ENUM_CONSTANT(LAYER_PURPOSE_RECONSTRUCTION);
+	BIND_ENUM_CONSTANT(LAYER_PURPOSE_PROJECTED);
+
+	BIND_ENUM_CONSTANT(PASSTHROUGH_FILTER_DISABLED);
+	BIND_ENUM_CONSTANT(PASSTHROUGH_FILTER_COLOR_MAP);
+	BIND_ENUM_CONSTANT(PASSTHROUGH_FILTER_MONO_MAP);
+	BIND_ENUM_CONSTANT(PASSTHROUGH_FILTER_BRIGHTNESS_CONTRAST_SATURATION);
+
+	BIND_ENUM_CONSTANT(PASSTHROUGH_ERROR_NON_RECOVERABLE);
+	BIND_ENUM_CONSTANT(PASSTHROUGH_ERROR_RECOVERABLE);
+	BIND_ENUM_CONSTANT(PASSTHROUGH_ERROR_RESTORED);
 }
 
 godot::Dictionary OpenXRFbPassthroughExtensionWrapper::_get_requested_extensions() {
 	godot::Dictionary result;
-	for (auto ext: request_extensions) {
+	for (auto ext : request_extensions) {
 		godot::String key = ext.first;
 		uint64_t value = reinterpret_cast<uint64_t>(ext.second);
 		result[key] = (godot::Variant)value;
@@ -81,6 +118,10 @@ godot::Dictionary OpenXRFbPassthroughExtensionWrapper::_get_requested_extensions
 void OpenXRFbPassthroughExtensionWrapper::cleanup() {
 	fb_passthrough_ext = false;
 	fb_triangle_mesh_ext = false;
+}
+
+uint64_t OpenXRFbPassthroughExtensionWrapper::_set_system_properties_and_get_next_pointer(void *p_next_pointer) {
+	return reinterpret_cast<uint64_t>(&system_passthrough_properties);
 }
 
 void OpenXRFbPassthroughExtensionWrapper::_on_instance_created(uint64_t p_instance) {
@@ -112,9 +153,9 @@ void OpenXRFbPassthroughExtensionWrapper::_on_session_created(uint64_t p_session
 
 		// Create the passthrough feature and start it.
 		XrPassthroughCreateInfoFB passthrough_create_info = {
-			XR_TYPE_PASSTHROUGH_CREATE_INFO_FB,
-			nullptr,
-			0,
+			XR_TYPE_PASSTHROUGH_CREATE_INFO_FB, // type
+			nullptr, // next
+			0, // flags
 		};
 
 		XrResult result = xrCreatePassthroughFB(session, &passthrough_create_info, &passthrough_handle);
@@ -132,21 +173,44 @@ void OpenXRFbPassthroughExtensionWrapper::_on_session_created(uint64_t p_session
 void OpenXRFbPassthroughExtensionWrapper::_on_state_ready() {
 	XRInterface::EnvironmentBlendMode blend_mode = get_blend_mode();
 	if (blend_mode == XRInterface::XR_ENV_BLEND_MODE_ALPHA_BLEND) {
-		start_passthrough();
+		start_passthrough_layer(LAYER_PURPOSE_RECONSTRUCTION);
 	}
-	previous_blend_mode = blend_mode;
 }
 
 void OpenXRFbPassthroughExtensionWrapper::_on_process() {
 	XRInterface::EnvironmentBlendMode blend_mode = get_blend_mode();
 
-	if (previous_blend_mode != XRInterface::XR_ENV_BLEND_MODE_ALPHA_BLEND && blend_mode == XRInterface::XR_ENV_BLEND_MODE_ALPHA_BLEND) {
-		start_passthrough();
-	} else if (previous_blend_mode == XRInterface::XR_ENV_BLEND_MODE_ALPHA_BLEND && blend_mode != XRInterface::XR_ENV_BLEND_MODE_ALPHA_BLEND) {
+	// Reconstruction layer will always take priority
+	if (blend_mode == XRInterface::XR_ENV_BLEND_MODE_ALPHA_BLEND && current_passthrough_layer != LAYER_PURPOSE_RECONSTRUCTION) {
+		start_passthrough_layer(LAYER_PURPOSE_RECONSTRUCTION);
+	} else if (blend_mode != XRInterface::XR_ENV_BLEND_MODE_ALPHA_BLEND && passthrough_geometry_nodes.size() > 0 && current_passthrough_layer != LAYER_PURPOSE_PROJECTED) {
+		start_passthrough_layer(LAYER_PURPOSE_PROJECTED);
+	} else if (blend_mode != XRInterface::XR_ENV_BLEND_MODE_ALPHA_BLEND && passthrough_geometry_nodes.size() == 0 && current_passthrough_layer != LAYER_PURPOSE_NONE) {
 		stop_passthrough();
 	}
+}
 
-	previous_blend_mode = blend_mode;
+bool OpenXRFbPassthroughExtensionWrapper::_on_event_polled(const void *p_event) {
+	if (static_cast<const XrEventDataBuffer *>(p_event)->type == XR_TYPE_EVENT_DATA_PASSTHROUGH_STATE_CHANGED_FB) {
+		XrEventDataPassthroughStateChangedFB *passthrough_event = (XrEventDataPassthroughStateChangedFB *)p_event;
+		switch (passthrough_event->flags) {
+			case XR_PASSTHROUGH_STATE_CHANGED_REINIT_REQUIRED_BIT_FB: {
+				stop_passthrough();
+			} break;
+			case XR_PASSTHROUGH_STATE_CHANGED_NON_RECOVERABLE_ERROR_BIT_FB: {
+				emit_signal("openxr_fb_passthrough_state_changed", PASSTHROUGH_ERROR_NON_RECOVERABLE);
+			} break;
+			case XR_PASSTHROUGH_STATE_CHANGED_RECOVERABLE_ERROR_BIT_FB: {
+				emit_signal("openxr_fb_passthrough_state_changed", PASSTHROUGH_ERROR_RECOVERABLE);
+			} break;
+			case XR_PASSTHROUGH_STATE_CHANGED_RESTORED_ERROR_BIT_FB: {
+				emit_signal("openxr_fb_passthrough_state_changed", PASSTHROUGH_ERROR_RESTORED);
+			} break;
+		}
+		return true;
+	}
+
+	return false;
 }
 
 void OpenXRFbPassthroughExtensionWrapper::_on_session_destroyed() {
@@ -171,52 +235,105 @@ void OpenXRFbPassthroughExtensionWrapper::_on_instance_destroyed() {
 	cleanup();
 }
 
-bool OpenXRFbPassthroughExtensionWrapper::is_passthrough_enabled() {
-	return fb_passthrough_ext && passthrough_handle != XR_NULL_HANDLE && passthrough_layer != XR_NULL_HANDLE;
+void OpenXRFbPassthroughExtensionWrapper::register_geometry_node(OpenXRFbPassthroughGeometry *p_node) {
+	passthrough_geometry_nodes.append(p_node);
 }
 
-bool OpenXRFbPassthroughExtensionWrapper::start_passthrough() {
+void OpenXRFbPassthroughExtensionWrapper::unregister_geometry_node(OpenXRFbPassthroughGeometry *p_node) {
+	passthrough_geometry_nodes.erase(p_node);
+}
+
+void OpenXRFbPassthroughExtensionWrapper::start_passthrough() {
 	if (passthrough_handle == XR_NULL_HANDLE) {
-		return false;
+		UtilityFunctions::print("Cannot start passthrough before passthrough handle is created");
+		return;
 	}
 
-	if (is_passthrough_enabled()) {
-		return true;
-	}
-
-	// Start the passthrough feature
 	XrResult result = xrPassthroughStartFB(passthrough_handle);
 	if (XR_FAILED(result)) {
-		UtilityFunctions::print("Failed to start passthrough");
+		UtilityFunctions::print("Failed to start passthrough, error code: ", result);
 		stop_passthrough();
-		return false;
+		return;
 	}
 
-	// Create the passthrough layer
-	XrPassthroughLayerCreateInfoFB passthrough_layer_config = {
-		XR_TYPE_PASSTHROUGH_LAYER_CREATE_INFO_FB,
-		nullptr,
-		passthrough_handle,
-		XR_PASSTHROUGH_IS_RUNNING_AT_CREATION_BIT_FB,
-		XR_PASSTHROUGH_LAYER_PURPOSE_RECONSTRUCTION_FB,
-	};
-	result = xrCreatePassthroughLayerFB(SESSION, &passthrough_layer_config, &passthrough_layer);
+	passthrough_started = true;
+}
+
+void OpenXRFbPassthroughExtensionWrapper::start_passthrough_layer(LayerPurpose p_layer_purpose) {
+	XrPassthroughLayerPurposeFB xr_layer_purpose;
+	switch (p_layer_purpose) {
+		case LAYER_PURPOSE_RECONSTRUCTION:
+			xr_layer_purpose = XR_PASSTHROUGH_LAYER_PURPOSE_RECONSTRUCTION_FB;
+			break;
+		case LAYER_PURPOSE_PROJECTED:
+			xr_layer_purpose = XR_PASSTHROUGH_LAYER_PURPOSE_PROJECTED_FB;
+			break;
+		default:
+			UtilityFunctions::print("Corresponding XrPassthroughLayerPurposeFB not found for LayerPurpose: ", p_layer_purpose);
+			return;
+	}
+
+	// If passthrough hasn't started, start it.
+	if (!is_passthrough_started()) {
+		start_passthrough();
+		if (!is_passthrough_started()) {
+			return;
+		}
+	}
+
+	// If a different layer is active, pause it.
+	if (current_passthrough_layer >= 0 && current_passthrough_layer != p_layer_purpose) {
+		XrResult result = xrPassthroughLayerPauseFB(passthrough_layer[current_passthrough_layer]);
+		if (XR_FAILED(result)) {
+			UtilityFunctions::print("Failed to pause current passthrough layer, error code: ", result);
+			return;
+		}
+	}
+
+	// If layer does not exist, create it.
+	if (passthrough_layer[p_layer_purpose] == XR_NULL_HANDLE) {
+		XrPassthroughLayerCreateInfoFB passthrough_layer_config = {
+			XR_TYPE_PASSTHROUGH_LAYER_CREATE_INFO_FB, // type
+			nullptr, // next
+			passthrough_handle, // passthrough
+			XR_PASSTHROUGH_IS_RUNNING_AT_CREATION_BIT_FB, // flags
+			xr_layer_purpose, // purpose
+		};
+
+		XrResult result = xrCreatePassthroughLayerFB(SESSION, &passthrough_layer_config, &passthrough_layer[p_layer_purpose]);
+		if (XR_FAILED(result)) {
+			UtilityFunctions::print("Failed to create passthrough layer ", p_layer_purpose, ", error code: ", result);
+			stop_passthrough();
+			return;
+		}
+
+		if (p_layer_purpose == LAYER_PURPOSE_PROJECTED) {
+			emit_signal("openxr_fb_projected_passthrough_layer_created");
+		}
+	} else { // Else resume already created layer.
+		XrResult result = xrPassthroughLayerResumeFB(passthrough_layer[p_layer_purpose]);
+		if (XR_FAILED(result)) {
+			UtilityFunctions::print("Failed to resume passthrough layer ", p_layer_purpose, ", error code: ", result);
+			return;
+		}
+	}
+
+	current_passthrough_layer = p_layer_purpose;
+
+	// Apply passthrough style to layer
+	XrResult result = xrPassthroughLayerSetStyleFB(passthrough_layer[current_passthrough_layer], &passthrough_style);
 	if (XR_FAILED(result)) {
-		UtilityFunctions::print("Failed to create the passthrough layer");
-		stop_passthrough();
-		return false;
+		UtilityFunctions::print("Failed to set passthrough style, error code: ", result);
 	}
-
-	return true;
 }
 
 int OpenXRFbPassthroughExtensionWrapper::_get_composition_layer_count() {
-	return is_passthrough_enabled() ? 1 : 0;
+	return is_passthrough_started() ? 1 : 0;
 }
 
 uint64_t OpenXRFbPassthroughExtensionWrapper::_get_composition_layer(int p_index) {
 	if (p_index == 0) {
-		composition_passthrough_layer.layerHandle = passthrough_layer;
+		composition_passthrough_layer.layerHandle = passthrough_layer[current_passthrough_layer];
 		return reinterpret_cast<uint64_t>(&composition_passthrough_layer);
 	} else {
 		return 0;
@@ -234,21 +351,260 @@ void OpenXRFbPassthroughExtensionWrapper::stop_passthrough() {
 	}
 
 	XrResult result;
-	if (passthrough_layer != XR_NULL_HANDLE) {
-		// Destroy the layer
-		result = xrDestroyPassthroughLayerFB(passthrough_layer);
-		if (XR_FAILED(result)) {
-			UtilityFunctions::print("Unable to destroy passthrough layer");
+	for (int i = 0; i < LAYER_PURPOSE_MAX; i++) {
+		if (passthrough_layer[i] != XR_NULL_HANDLE) {
+			result = xrDestroyPassthroughLayerFB(passthrough_layer[i]);
+			if (XR_FAILED(result)) {
+				UtilityFunctions::print("Unable to destroy passthrough layer, error code: ", result);
+			}
+			passthrough_layer[i] = XR_NULL_HANDLE;
 		}
-		passthrough_layer = XR_NULL_HANDLE;
 	}
 
 	if (passthrough_handle != XR_NULL_HANDLE) {
 		result = xrPassthroughPauseFB(passthrough_handle);
 		if (XR_FAILED(result)) {
-			UtilityFunctions::print("Unable to stop passthrough feature");
+			UtilityFunctions::print("Unable to stop passthrough feature, error code: ", result);
+			return;
 		}
 	}
+
+	current_passthrough_layer = LAYER_PURPOSE_NONE;
+	passthrough_started = false;
+	emit_signal("openxr_fb_passthrough_stopped");
+}
+
+XrGeometryInstanceFB OpenXRFbPassthroughExtensionWrapper::create_geometry_instance(const Ref<Mesh> &p_mesh, const Transform3D &p_transform) {
+	ERR_FAIL_COND_V(p_mesh.is_null(), XR_NULL_HANDLE);
+
+	if (!is_passthrough_started()) {
+		UtilityFunctions::print("Tried to create geometry instance, but passthrough isn't started!");
+		return XR_NULL_HANDLE;
+	}
+
+	Array surface_arrays = p_mesh->surface_get_arrays(0);
+
+	Array vertex_array = surface_arrays[Mesh::ARRAY_VERTEX];
+	LocalVector<XrVector3f> vertices;
+	vertices.resize(vertex_array.size());
+	for (int j = 0; j < vertex_array.size(); j++) {
+		Vector3 vertex = vertex_array[j];
+		vertices[j] = { vertex.x, vertex.y, vertex.z };
+	}
+
+	Array index_array = surface_arrays[Mesh::ARRAY_INDEX];
+	LocalVector<uint32_t> indices;
+	indices.resize(index_array.size());
+	for (int j = 0; j < index_array.size(); j++) {
+		indices[j] = index_array[j];
+	}
+
+	XrTriangleMeshFB mesh = XR_NULL_HANDLE;
+	XrTriangleMeshCreateInfoFB triangle_mesh_info = {
+		XR_TYPE_TRIANGLE_MESH_CREATE_INFO_FB, // type
+		nullptr, // next
+		0, // flags
+		XR_WINDING_ORDER_CW_FB, // windingOrder
+		(uint32_t)vertex_array.size(), // vertexCount
+		vertices.ptr(), // vertexBuffer
+		(uint32_t)index_array.size(), // triangleCount
+		indices.ptr(), // indexBuffer
+	};
+
+	XrResult result = xrCreateTriangleMeshFB(SESSION, &triangle_mesh_info, &mesh);
+	if (XR_FAILED(result)) {
+		UtilityFunctions::print("Failed to create triangle mesh, error code: ", result);
+		return XR_NULL_HANDLE;
+	}
+
+	Quaternion quat = p_transform.basis.get_rotation_quaternion();
+	Vector3 scale = p_transform.basis.get_scale();
+
+	XrQuaternionf xr_orientation = { quat.x, quat.y, quat.z, quat.w };
+	XrVector3f xr_position = { p_transform.origin.x, p_transform.origin.y, p_transform.origin.z };
+	XrPosef xr_pose = { xr_orientation, xr_position };
+	XrVector3f xr_scale = { scale.x, scale.y, scale.z };
+
+	XrGeometryInstanceFB geometry_instance = XR_NULL_HANDLE;
+	XrGeometryInstanceCreateInfoFB geometry_instance_info = {
+		XR_TYPE_GEOMETRY_INSTANCE_CREATE_INFO_FB, // type
+		nullptr, // next
+		passthrough_layer[LAYER_PURPOSE_PROJECTED], // layer
+		mesh, // mesh
+		(XrSpace)get_openxr_api()->get_play_space(), // baseSpace
+		xr_pose, // pose
+		xr_scale, // scale
+	};
+
+	result = xrCreateGeometryInstanceFB(SESSION, &geometry_instance_info, &geometry_instance);
+	if (XR_FAILED(result)) {
+		UtilityFunctions::print("Failed to create geometry instance, error code: ", result);
+		return XR_NULL_HANDLE;
+	}
+
+	return geometry_instance;
+}
+
+void OpenXRFbPassthroughExtensionWrapper::set_geometry_instance_transform(XrGeometryInstanceFB p_geometry_instance, const Transform3D &p_transform) {
+	Quaternion quat = p_transform.basis.get_rotation_quaternion();
+	Vector3 scale = p_transform.basis.get_scale();
+
+	XrQuaternionf xr_orientation = { quat.x, quat.y, quat.z, quat.w };
+	XrVector3f xr_position = { p_transform.origin.x, p_transform.origin.y, p_transform.origin.z };
+	XrPosef xr_pose = { xr_orientation, xr_position };
+	XrVector3f xr_scale = { scale.x, scale.y, scale.z };
+
+	XrGeometryInstanceTransformFB xr_transform = {
+		XR_TYPE_GEOMETRY_INSTANCE_TRANSFORM_FB, // type
+		nullptr, // next
+		(XrSpace)get_openxr_api()->get_play_space(), // baseSpace
+		(XrTime)get_openxr_api()->get_next_frame_time(), // time
+		xr_pose, // pose
+		xr_scale, // scale
+	};
+
+	XrResult result = xrGeometryInstanceSetTransformFB(p_geometry_instance, &xr_transform);
+	if (XR_FAILED(result)) {
+		UtilityFunctions::print("Failed to set geometry instance transform, error code: ", result);
+	}
+}
+
+void OpenXRFbPassthroughExtensionWrapper::destroy_geometry_instance(XrGeometryInstanceFB p_geometry_instance) {
+	XrResult result = xrDestroyGeometryInstanceFB(p_geometry_instance);
+	if (XR_FAILED(result)) {
+		UtilityFunctions::print("Failed to destroy geometry instance, error code: ", result);
+	}
+}
+
+void OpenXRFbPassthroughExtensionWrapper::set_texture_opacity_factor(float p_value) {
+	passthrough_style.textureOpacityFactor = p_value;
+
+	if (is_passthrough_started()) {
+		XrResult result = xrPassthroughLayerSetStyleFB(passthrough_layer[current_passthrough_layer], &passthrough_style);
+		if (XR_FAILED(result)) {
+			UtilityFunctions::print("Failed to set passthrough style, error code: ", result);
+		}
+	}
+}
+
+float OpenXRFbPassthroughExtensionWrapper::get_texture_opacity_factor() {
+	return passthrough_style.textureOpacityFactor;
+}
+
+void OpenXRFbPassthroughExtensionWrapper::set_edge_color(Color p_color) {
+	passthrough_style.edgeColor = { p_color.r, p_color.g, p_color.b, p_color.a };
+
+	if (is_passthrough_started()) {
+		XrResult result = xrPassthroughLayerSetStyleFB(passthrough_layer[current_passthrough_layer], &passthrough_style);
+		if (XR_FAILED(result)) {
+			UtilityFunctions::print("Failed to set passthrough style, error code: ", result);
+		}
+	}
+}
+
+Color OpenXRFbPassthroughExtensionWrapper::get_edge_color() {
+	return { passthrough_style.edgeColor.r, passthrough_style.edgeColor.g, passthrough_style.edgeColor.b, passthrough_style.edgeColor.a };
+}
+
+void OpenXRFbPassthroughExtensionWrapper::set_passthrough_filter(PassthroughFilter p_filter) {
+	current_passthrough_filter = p_filter;
+
+	switch (current_passthrough_filter) {
+		case PASSTHROUGH_FILTER_DISABLED: {
+			passthrough_style.next = nullptr;
+		} break;
+		case PASSTHROUGH_FILTER_COLOR_MAP: {
+			passthrough_style.next = &color_map;
+		} break;
+		case PASSTHROUGH_FILTER_MONO_MAP: {
+			passthrough_style.next = &mono_map;
+		} break;
+		case PASSTHROUGH_FILTER_BRIGHTNESS_CONTRAST_SATURATION: {
+			passthrough_style.next = &brightness_contrast_saturation;
+		} break;
+	}
+
+	if (is_passthrough_started()) {
+		XrResult result = xrPassthroughLayerSetStyleFB(passthrough_layer[current_passthrough_layer], &passthrough_style);
+		if (XR_FAILED(result)) {
+			UtilityFunctions::print("Failed to set passthrough style, error code: ", result);
+		}
+	}
+}
+
+void OpenXRFbPassthroughExtensionWrapper::set_color_map(const Ref<GradientTexture1D> &p_gradient) {
+	if (p_gradient.is_null()) {
+		return;
+	}
+
+	for (int i = 0; i < XR_PASSTHROUGH_COLOR_MAP_MONO_SIZE_FB; i++) {
+		Color sample_color = p_gradient->get_gradient()->sample((double)i / (double)XR_PASSTHROUGH_COLOR_MAP_MONO_SIZE_FB);
+		color_map.textureColorMap[i] = { sample_color.r, sample_color.g, sample_color.b, sample_color.a };
+	}
+
+	current_passthrough_filter = PASSTHROUGH_FILTER_COLOR_MAP;
+	passthrough_style.next = &color_map;
+
+	if (is_passthrough_started()) {
+		XrResult result = xrPassthroughLayerSetStyleFB(passthrough_layer[current_passthrough_layer], &passthrough_style);
+		if (XR_FAILED(result)) {
+			UtilityFunctions::print("Failed to set passthrough style, error code: ", result);
+		}
+	}
+}
+
+void OpenXRFbPassthroughExtensionWrapper::set_mono_map(const Ref<Curve> &p_curve) {
+	if (p_curve.is_null()) {
+		return;
+	}
+
+	for (int i = 0; i < XR_PASSTHROUGH_COLOR_MAP_MONO_SIZE_FB; i++) {
+		mono_map.textureColorMap[i] = p_curve->sample((double)i / (double)XR_PASSTHROUGH_COLOR_MAP_MONO_SIZE_FB) * XR_PASSTHROUGH_COLOR_MAP_MONO_SIZE_FB;
+	}
+
+	current_passthrough_filter = PASSTHROUGH_FILTER_MONO_MAP;
+	passthrough_style.next = &mono_map;
+
+	if (is_passthrough_started()) {
+		XrResult result = xrPassthroughLayerSetStyleFB(passthrough_layer[current_passthrough_layer], &passthrough_style);
+		if (XR_FAILED(result)) {
+			UtilityFunctions::print("Failed to set passthrough style, error code: ", result);
+		}
+	}
+}
+
+void OpenXRFbPassthroughExtensionWrapper::set_brightness_contrast_saturation(float p_brightness, float p_contrast, float p_saturation) {
+	const float BRIGHT_MIN = -100.0;
+	const float BRIGHT_MAX = 100.0;
+	ERR_FAIL_COND_MSG(p_brightness < BRIGHT_MIN || p_brightness > BRIGHT_MAX, vformat("Brighness value %d is not within bounds of %d and %d", p_brightness, BRIGHT_MIN, BRIGHT_MAX));
+	ERR_FAIL_COND_MSG(p_contrast < 0.0, vformat("Contrast value %d is not greater than or equal to zero", p_contrast));
+	ERR_FAIL_COND_MSG(p_saturation < 0.0, vformat("Saturation value %d is not greater than or equal to zero", p_saturation));
+
+	brightness_contrast_saturation.brightness = p_brightness;
+	brightness_contrast_saturation.contrast = p_contrast;
+	brightness_contrast_saturation.saturation = p_saturation;
+
+	current_passthrough_filter = PASSTHROUGH_FILTER_BRIGHTNESS_CONTRAST_SATURATION;
+	passthrough_style.next = &brightness_contrast_saturation;
+
+	if (is_passthrough_started()) {
+		XrResult result = xrPassthroughLayerSetStyleFB(passthrough_layer[current_passthrough_layer], &passthrough_style);
+		if (XR_FAILED(result)) {
+			UtilityFunctions::print("Failed to set passthrough style, error code: ", result);
+		}
+	}
+}
+
+bool OpenXRFbPassthroughExtensionWrapper::has_passthrough_capability() {
+	return system_passthrough_properties.capabilities & XR_PASSTHROUGH_CAPABILITY_BIT_FB;
+}
+
+bool OpenXRFbPassthroughExtensionWrapper::has_color_passthrough_capability() {
+	return (system_passthrough_properties.capabilities & XR_PASSTHROUGH_CAPABILITY_BIT_FB) && (system_passthrough_properties.capabilities & XR_PASSTHROUGH_CAPABILITY_COLOR_BIT_FB);
+}
+
+bool OpenXRFbPassthroughExtensionWrapper::has_layer_depth_passthrough_capability() {
+	return (system_passthrough_properties.capabilities & XR_PASSTHROUGH_CAPABILITY_BIT_FB) && (system_passthrough_properties.capabilities & XR_PASSTHROUGH_CAPABILITY_LAYER_DEPTH_BIT_FB);
 }
 
 XRInterface::EnvironmentBlendMode OpenXRFbPassthroughExtensionWrapper::get_blend_mode() {

--- a/common/src/main/cpp/include/classes/openxr_fb_passthrough_geometry.h
+++ b/common/src/main/cpp/include/classes/openxr_fb_passthrough_geometry.h
@@ -1,0 +1,62 @@
+/**************************************************************************/
+/*  openxr_fb_passthrough_geometry.h                                      */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef OPENXR_FB_PASSTHROUGH_GEOMETRY_H
+#define OPENXR_FB_PASSTHROUGH_GEOMETRY_H
+
+#include <godot_cpp/classes/mesh.hpp>
+#include <godot_cpp/classes/mesh_instance3d.hpp>
+#include <godot_cpp/classes/node3d.hpp>
+
+#include <openxr/openxr.h>
+
+namespace godot {
+class OpenXRFbPassthroughGeometry : public Node3D {
+	GDCLASS(OpenXRFbPassthroughGeometry, Node3D)
+
+private:
+	void create_passthrough_geometry();
+	void destroy_passthrough_geometry();
+
+	XrGeometryInstanceFB geometry_instance = XR_NULL_HANDLE;
+	Ref<Mesh> mesh;
+	MeshInstance3D *preview_mesh = nullptr;
+
+protected:
+	void _notification(int p_what);
+
+	static void _bind_methods();
+
+public:
+	void set_mesh(const Ref<Mesh> &p_mesh);
+	Ref<Mesh> get_mesh() const;
+};
+} //namespace godot
+
+#endif

--- a/common/src/main/cpp/include/extensions/openxr_fb_passthrough_extension_wrapper.h
+++ b/common/src/main/cpp/include/extensions/openxr_fb_passthrough_extension_wrapper.h
@@ -31,6 +31,11 @@
 #ifndef OPENXR_FB_PASSTHROUGH_EXTENSION_WRAPPER_H
 #define OPENXR_FB_PASSTHROUGH_EXTENSION_WRAPPER_H
 
+#include "classes/openxr_fb_passthrough_geometry.h"
+
+#include <godot_cpp/classes/curve.hpp>
+#include <godot_cpp/classes/gradient_texture1_d.hpp>
+#include <godot_cpp/classes/mesh.hpp>
 #include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
 #include <godot_cpp/classes/xr_interface.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
@@ -48,17 +53,39 @@ class OpenXRFbPassthroughExtensionWrapper : public OpenXRExtensionWrapperExtensi
 	GDCLASS(OpenXRFbPassthroughExtensionWrapper, OpenXRExtensionWrapperExtension);
 
 public:
+	enum LayerPurpose {
+		LAYER_PURPOSE_NONE = -1,
+		LAYER_PURPOSE_RECONSTRUCTION,
+		LAYER_PURPOSE_PROJECTED,
+		LAYER_PURPOSE_MAX,
+	};
+
+	enum PassthroughFilter {
+		PASSTHROUGH_FILTER_DISABLED,
+		PASSTHROUGH_FILTER_COLOR_MAP,
+		PASSTHROUGH_FILTER_MONO_MAP,
+		PASSTHROUGH_FILTER_BRIGHTNESS_CONTRAST_SATURATION,
+	};
+
+	enum PassthroughStateChangedEvent {
+		PASSTHROUGH_ERROR_NON_RECOVERABLE,
+		PASSTHROUGH_ERROR_RECOVERABLE,
+		PASSTHROUGH_ERROR_RESTORED,
+	};
+
 	OpenXRFbPassthroughExtensionWrapper();
 	~OpenXRFbPassthroughExtensionWrapper();
 
 	godot::Dictionary _get_requested_extensions() override;
 
+	uint64_t _set_system_properties_and_get_next_pointer(void *p_next_pointer) override;
 	void _on_instance_created(uint64_t p_instance) override;
 	void _on_session_created(uint64_t p_session) override;
 	void _on_session_destroyed() override;
 	void _on_instance_destroyed() override;
 	void _on_state_ready() override;
 	void _on_process() override;
+	bool _on_event_polled(const void *p_event) override;
 
 	int _get_composition_layer_count() override;
 	uint64_t _get_composition_layer(int p_index) override;
@@ -68,10 +95,38 @@ public:
 		return fb_passthrough_ext;
 	}
 
-	bool is_passthrough_enabled();
+	bool is_passthrough_started() {
+		return passthrough_started;
+	}
 
-	bool start_passthrough();
+	void start_passthrough();
 	void stop_passthrough();
+
+	void start_passthrough_layer(LayerPurpose p_layer_purpose);
+	LayerPurpose get_current_layer_purpose() { return current_passthrough_layer; }
+
+	void register_geometry_node(OpenXRFbPassthroughGeometry *p_node);
+	void unregister_geometry_node(OpenXRFbPassthroughGeometry *p_node);
+
+	XrGeometryInstanceFB create_geometry_instance(const Ref<Mesh> &p_mesh, const Transform3D &p_transform);
+	void set_geometry_instance_transform(XrGeometryInstanceFB p_geometry_instance, const Transform3D &p_transform);
+	void destroy_geometry_instance(XrGeometryInstanceFB p_geometry_instance);
+
+	void set_texture_opacity_factor(float p_value);
+	float get_texture_opacity_factor();
+
+	void set_edge_color(Color p_color);
+	Color get_edge_color();
+
+	void set_passthrough_filter(PassthroughFilter p_filter);
+	PassthroughFilter get_current_passthrough_filter() { return current_passthrough_filter; }
+	void set_color_map(const Ref<GradientTexture1D> &p_gradient);
+	void set_mono_map(const Ref<Curve> &p_curve);
+	void set_brightness_contrast_saturation(float p_brightness, float p_contrast, float p_saturation);
+
+	bool has_passthrough_capability();
+	bool has_color_passthrough_capability();
+	bool has_layer_depth_passthrough_capability();
 
 	static OpenXRFbPassthroughExtensionWrapper *get_singleton();
 
@@ -205,9 +260,9 @@ private:
 
 	XRInterface::EnvironmentBlendMode get_blend_mode();
 
-	bool initialize_fb_passthrough_extension(const XrInstance instance);
+	bool initialize_fb_passthrough_extension(const XrInstance p_instance);
 
-	bool initialize_fb_triangle_mesh_extension(const XrInstance instance);
+	bool initialize_fb_triangle_mesh_extension(const XrInstance p_instance);
 
 	void cleanup();
 
@@ -218,18 +273,56 @@ private:
 	bool fb_passthrough_ext = false; // required for any passthrough functionality
 	bool fb_triangle_mesh_ext = false; // only use for projected passthrough
 
-	XRInterface::EnvironmentBlendMode previous_blend_mode = XRInterface::XR_ENV_BLEND_MODE_OPAQUE;
-
 	XrPassthroughFB passthrough_handle = XR_NULL_HANDLE;
-	XrPassthroughLayerFB passthrough_layer = XR_NULL_HANDLE;
+	XrPassthroughLayerFB passthrough_layer[LAYER_PURPOSE_MAX] = { XR_NULL_HANDLE };
+
+	XrSystemPassthroughProperties2FB system_passthrough_properties = {
+		XR_TYPE_SYSTEM_PASSTHROUGH_PROPERTIES2_FB, // type
+		nullptr, // next
+		0, // capabilities
+	};
+
+	XrPassthroughStyleFB passthrough_style = {
+		XR_TYPE_PASSTHROUGH_STYLE_FB, // type
+		nullptr, // next
+		1.0, // textureOpacityFactor
+		{ 0.0, 0.0, 0.0, 0.0 }, // edgeColor
+	};
+
+	XrPassthroughColorMapMonoToRgbaFB color_map = {
+		XR_TYPE_PASSTHROUGH_COLOR_MAP_MONO_TO_RGBA_FB, // type
+		nullptr, // next
+	};
+
+	XrPassthroughColorMapMonoToMonoFB mono_map = {
+		XR_TYPE_PASSTHROUGH_COLOR_MAP_MONO_TO_MONO_FB, // type
+		nullptr, // next
+	};
+
+	XrPassthroughBrightnessContrastSaturationFB brightness_contrast_saturation = {
+		XR_TYPE_PASSTHROUGH_BRIGHTNESS_CONTRAST_SATURATION_FB, // type
+		nullptr, // next
+		0.0, // brightness
+		1.0, // contrast
+		1.0, // saturation
+	};
 
 	XrCompositionLayerPassthroughFB composition_passthrough_layer = {
-		XR_TYPE_COMPOSITION_LAYER_PASSTHROUGH_FB,
-		nullptr,
-		XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT,
-		XR_NULL_HANDLE,
-		XR_NULL_HANDLE,
+		XR_TYPE_COMPOSITION_LAYER_PASSTHROUGH_FB, // type
+		nullptr, // next
+		XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT, // flags
+		XR_NULL_HANDLE, // space
+		XR_NULL_HANDLE, // layerHandle
 	};
+
+	bool passthrough_started = false;
+	LayerPurpose current_passthrough_layer = LAYER_PURPOSE_NONE;
+	PassthroughFilter current_passthrough_filter = PASSTHROUGH_FILTER_DISABLED;
+	Vector<OpenXRFbPassthroughGeometry *> passthrough_geometry_nodes;
 };
+
+VARIANT_ENUM_CAST(OpenXRFbPassthroughExtensionWrapper::LayerPurpose);
+VARIANT_ENUM_CAST(OpenXRFbPassthroughExtensionWrapper::PassthroughFilter);
+VARIANT_ENUM_CAST(OpenXRFbPassthroughExtensionWrapper::PassthroughStateChangedEvent);
 
 #endif // OPENXR_FB_PASSTHROUGH_EXTENSION_WRAPPER_H

--- a/common/src/main/cpp/register_types.cpp
+++ b/common/src/main/cpp/register_types.cpp
@@ -51,12 +51,13 @@
 #include "extensions/openxr_fb_render_model_extension_wrapper.h"
 #include "extensions/openxr_fb_scene_capture_extension_wrapper.h"
 #include "extensions/openxr_fb_scene_extension_wrapper.h"
-#include "extensions/openxr_fb_spatial_entity_extension_wrapper.h"
-#include "extensions/openxr_fb_spatial_entity_storage_extension_wrapper.h"
 #include "extensions/openxr_fb_spatial_entity_container_extension_wrapper.h"
+#include "extensions/openxr_fb_spatial_entity_extension_wrapper.h"
 #include "extensions/openxr_fb_spatial_entity_query_extension_wrapper.h"
+#include "extensions/openxr_fb_spatial_entity_storage_extension_wrapper.h"
 
 #include "classes/openxr_fb_hand_tracking_mesh.h"
+#include "classes/openxr_fb_passthrough_geometry.h"
 #include "classes/openxr_fb_render_model.h"
 #include "classes/openxr_fb_scene_manager.h"
 #include "classes/openxr_fb_spatial_entity.h"
@@ -125,6 +126,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			ClassDB::register_class<OpenXRFbSceneManager>();
 			ClassDB::register_class<OpenXRFbSpatialEntity>();
 			ClassDB::register_class<OpenXRFbSpatialEntityQuery>();
+			ClassDB::register_class<OpenXRFbPassthroughGeometry>();
 
 			OpenXRFbHandTrackingAimExtensionWrapper::get_singleton()->add_project_setting();
 		} break;

--- a/demo/main.gd
+++ b/demo/main.gd
@@ -1,5 +1,13 @@
 extends Node3D
 
+@export var passthrough_gradient: GradientTexture1D
+@export var passthrough_curve: Curve
+@export var bcs: Vector3
+
+var xr_interface: XRInterface = null
+var hand_tracking_source: Array[OpenXRInterface.HandTrackedSource]
+var passthrough_enabled: bool = false
+
 @onready var left_hand: XRController3D = $XROrigin3D/LeftHand
 @onready var right_hand: XRController3D = $XROrigin3D/RightHand
 @onready var left_hand_mesh: MeshInstance3D = $XROrigin3D/LeftHand/LeftHandMesh
@@ -9,10 +17,9 @@ extends Node3D
 @onready var floor_mesh: MeshInstance3D = $Floor
 @onready var world_environment: WorldEnvironment = $WorldEnvironment
 @onready var scene_manager: OpenXRFbSceneManager = $XROrigin3D/OpenXRFbSceneManager
-
-var xr_interface : XRInterface = null
-var hand_tracking_source: Array[OpenXRInterface.HandTrackedSource]
-var passthrough_enabled: bool = false
+@onready var open_xr_fb_passthrough_geometry: OpenXRFbPassthroughGeometry = %OpenXRFbPassthroughGeometry
+@onready var passthrough_mode_info: Label3D = $XROrigin3D/RightHand/PassthroughModeInfo
+@onready var passthrough_filter_info: Label3D = $XROrigin3D/RightHand/PassthroughFilterInfo
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
@@ -25,15 +32,14 @@ func _ready():
 	for hand in OpenXRInterface.HAND_MAX:
 		hand_tracking_source[hand] = xr_interface.get_hand_tracking_source(hand)
 
-
 func enable_passthrough(enable: bool) -> void:
 	if passthrough_enabled == enable:
 		return
 
 	var supported_blend_modes = xr_interface.get_supported_environment_blend_modes()
-	print ("Supported blend modes: ", supported_blend_modes)
+	print("Supported blend modes: ", supported_blend_modes)
 	if XRInterface.XR_ENV_BLEND_MODE_ALPHA_BLEND in supported_blend_modes and XRInterface.XR_ENV_BLEND_MODE_OPAQUE in supported_blend_modes:
-		print ("Passthrough supported.")
+		print("Passthrough supported.")
 		if enable:
 			# Switch to passthrough.
 			xr_interface.environment_blend_mode = XRInterface.XR_ENV_BLEND_MODE_ALPHA_BLEND
@@ -54,7 +60,6 @@ func enable_passthrough(enable: bool) -> void:
 		passthrough_enabled = enable
 	else:
 		print("Switching to/from passthrough not supported.")
-
 
 func _physics_process(_delta: float) -> void:
 	for hand in OpenXRInterface.HAND_MAX:
@@ -82,7 +87,6 @@ func _physics_process(_delta: float) -> void:
 
 		hand_tracking_source[hand] = source
 
-
 func _on_left_hand_button_pressed(name):
 	if name == "menu_button":
 		print("Triggering scene capture")
@@ -91,16 +95,21 @@ func _on_left_hand_button_pressed(name):
 	elif name == "by_button":
 		enable_passthrough(not passthrough_enabled)
 
+func _on_right_hand_button_pressed(name: String) -> void:
+	match name:
+		"by_button":
+			update_passthrough_mode()
+		"ax_button":
+			update_passthrough_filter()
 
 func _on_left_controller_fb_render_model_render_model_loaded() -> void:
 	left_hand_mesh.hide()
-
 
 func _on_right_controller_fb_render_model_render_model_loaded() -> void:
 	right_hand_mesh.hide()
 
 func _on_scene_manager_scene_capture_completed(success: bool) -> void:
-	print ("Scene Capture Complete: ", success)
+	print("Scene Capture Complete: ", success)
 	if success:
 		# Recreate scene anchors since the user may have changed them.
 		if scene_manager.are_scene_anchors_created():
@@ -112,3 +121,47 @@ func _on_scene_manager_scene_capture_completed(success: bool) -> void:
 
 func _on_scene_manager_scene_data_missing() -> void:
 	scene_manager.request_scene_capture()
+
+func update_passthrough_mode() -> void:
+	const STRING_BASE = "[B] Passthrough Mode: "
+
+	var fb_passthrough = Engine.get_singleton("OpenXRFbPassthroughExtensionWrapper")
+	match fb_passthrough.get_current_layer_purpose():
+		OpenXRFbPassthroughExtensionWrapper.LAYER_PURPOSE_NONE:
+			enable_passthrough_environment(true)
+			xr_interface.environment_blend_mode = XRInterface.XR_ENV_BLEND_MODE_ALPHA_BLEND
+			passthrough_mode_info.text = STRING_BASE + "Full"
+		OpenXRFbPassthroughExtensionWrapper.LAYER_PURPOSE_RECONSTRUCTION:
+			xr_interface.environment_blend_mode = XRInterface.XR_ENV_BLEND_MODE_OPAQUE
+			open_xr_fb_passthrough_geometry.show()
+			passthrough_mode_info.text = STRING_BASE + "Geometry"
+		OpenXRFbPassthroughExtensionWrapper.LAYER_PURPOSE_PROJECTED:
+			enable_passthrough_environment(false)
+			open_xr_fb_passthrough_geometry.hide()
+			passthrough_mode_info.text = STRING_BASE + "None"
+
+func enable_passthrough_environment(enable: bool) -> void:
+	if enable:
+		get_viewport().transparent_bg = true
+		world_environment.environment.background_mode = Environment.BG_COLOR
+	else:
+		get_viewport().transparent_bg = false
+		world_environment.environment.background_mode = Environment.BG_SKY
+
+func update_passthrough_filter() -> void:
+	const STRING_BASE = "[A] Passthrough Filter: "
+
+	var fb_passthrough = Engine.get_singleton("OpenXRFbPassthroughExtensionWrapper")
+	match fb_passthrough.get_current_passthrough_filter():
+		OpenXRFbPassthroughExtensionWrapper.PASSTHROUGH_FILTER_DISABLED:
+			fb_passthrough.set_color_map(passthrough_gradient)
+			passthrough_filter_info.text = STRING_BASE + "Color Map"
+		OpenXRFbPassthroughExtensionWrapper.PASSTHROUGH_FILTER_COLOR_MAP:
+			fb_passthrough.set_mono_map(passthrough_curve)
+			passthrough_filter_info.text = STRING_BASE + "Mono Map"
+		OpenXRFbPassthroughExtensionWrapper.PASSTHROUGH_FILTER_MONO_MAP:
+			fb_passthrough.set_brightness_contrast_saturation(bcs.x, bcs.y, bcs.z)
+			passthrough_filter_info.text = STRING_BASE + "Brightness Contrast Saturation"
+		OpenXRFbPassthroughExtensionWrapper.PASSTHROUGH_FILTER_BRIGHTNESS_CONTRAST_SATURATION:
+			fb_passthrough.set_passthrough_filter(OpenXRFbPassthroughExtensionWrapper.PASSTHROUGH_FILTER_DISABLED)
+			passthrough_filter_info.text = STRING_BASE + "Disabled"

--- a/demo/main.tscn
+++ b/demo/main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=17 format=3 uid="uid://cqsodpswgup8w"]
+[gd_scene load_steps=21 format=3 uid="uid://cqsodpswgup8w"]
 
 [ext_resource type="Script" path="res://main.gd" id="1_fsva1"]
 [ext_resource type="PackedScene" uid="uid://c0uv4eu2yjm3b" path="res://viewport_2d_in_3d.tscn" id="2_7whgo"]
@@ -6,6 +6,17 @@
 [ext_resource type="PackedScene" uid="uid://bcjp8kcgde4cs" path="res://scene_anchor.tscn" id="4_3u3ah"]
 [ext_resource type="PackedScene" uid="uid://ikxieb2fyavg" path="res://assets/face/Face.gltf" id="4_wrwst"]
 [ext_resource type="PackedScene" uid="uid://bwfyi8pgigune" path="res://xr_fb_hand_tracking_aim_demo.tscn" id="5_6bxyh"]
+
+[sub_resource type="Gradient" id="Gradient_yvg3n"]
+offsets = PackedFloat32Array(0, 0.484615, 1)
+colors = PackedColorArray(0.989632, 1, 0, 1, 0, 0.117083, 1, 1, 1, 0, 0.89539, 1)
+
+[sub_resource type="GradientTexture1D" id="GradientTexture1D_syqxs"]
+gradient = SubResource("Gradient_yvg3n")
+
+[sub_resource type="Curve" id="Curve_ykaux"]
+_data = [Vector2(0, 0), 0.0, 0.0, 0, 0, Vector2(0.240642, 1), 0.0, 0.0, 0, 0, Vector2(0.502674, 0), 0.0, 0.0, 0, 0, Vector2(0.759358, 1), 0.0, 0.0, 0, 0, Vector2(1, 0), 0.0, 0.0, 0, 0]
+point_count = 5
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_0x6cv"]
 sky_horizon_color = Color(0.64625, 0.65575, 0.67075, 1)
@@ -16,6 +27,7 @@ sky_material = SubResource("ProceduralSkyMaterial_0x6cv")
 
 [sub_resource type="Environment" id="Environment_m0xew"]
 background_mode = 2
+background_color = Color(0, 0, 0, 0)
 sky = SubResource("Sky_dqyx0")
 ambient_light_source = 2
 ambient_light_color = Color(0.270588, 0.270588, 0.270588, 1)
@@ -34,6 +46,8 @@ albedo_color = Color(0.203922, 0.203922, 0.203922, 1)
 [sub_resource type="BoxMesh" id="BoxMesh_ey3x4"]
 size = Vector3(0.1, 0.1, 0.1)
 
+[sub_resource type="BoxMesh" id="BoxMesh_u0g4q"]
+
 [sub_resource type="SphereMesh" id="SphereMesh_5gcab"]
 radius = 0.025
 height = 0.05
@@ -46,6 +60,9 @@ size = Vector2(10, 10)
 
 [node name="Main" type="Node3D"]
 script = ExtResource("1_fsva1")
+passthrough_gradient = SubResource("GradientTexture1D_syqxs")
+passthrough_curve = SubResource("Curve_ykaux")
+bcs = Vector3(-10, 50, 0)
 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="."]
 environment = SubResource("Environment_m0xew")
@@ -94,6 +111,26 @@ mesh = SubResource("BoxMesh_ey3x4")
 [node name="RightControllerFbRenderModel" type="OpenXRFbRenderModel" parent="XROrigin3D/RightHand"]
 render_model_type = 1
 
+[node name="PassthroughModeInfo" type="Label3D" parent="XROrigin3D/RightHand"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, -0.25)
+pixel_size = 0.001
+text = "[B] Passthrough Mode: None"
+
+[node name="PassthroughFilterInfo" type="Label3D" parent="XROrigin3D/RightHand"]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 2.73026e-09, -0.187539)
+pixel_size = 0.001
+text = "[A] Passthrough Filter: Disabled"
+
+[node name="RemoteTransform3D" type="RemoteTransform3D" parent="XROrigin3D/RightHand"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1, 0)
+remote_path = NodePath("../../OpenXRFbPassthroughGeometry")
+
+[node name="OpenXRFbPassthroughGeometry" type="OpenXRFbPassthroughGeometry" parent="XROrigin3D"]
+mesh = SubResource("BoxMesh_u0g4q")
+unique_name_in_owner = true
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.478861, -0.531708, -0.241097)
+visible = false
+
 [node name="EyeGaze" type="XRController3D" parent="XROrigin3D"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.977669, 0)
 tracker = &"/user/eyes_ext"
@@ -136,6 +173,7 @@ transform = Transform3D(0.707107, 0, 0.707107, 0, 1, 0, -0.707107, 0, 0.707107, 
 [connection signal="button_pressed" from="XROrigin3D/LeftHand" to="XRFbHandTrackingAimDemo" method="_on_left_hand_button_pressed"]
 [connection signal="button_released" from="XROrigin3D/LeftHand" to="XRFbHandTrackingAimDemo" method="_on_left_hand_button_released"]
 [connection signal="openxr_fb_render_model_loaded" from="XROrigin3D/LeftHand/LeftControllerFbRenderModel" to="." method="_on_left_controller_fb_render_model_render_model_loaded"]
+[connection signal="button_pressed" from="XROrigin3D/RightHand" to="." method="_on_right_hand_button_pressed"]
 [connection signal="button_pressed" from="XROrigin3D/RightHand" to="XRFbHandTrackingAimDemo" method="_on_right_hand_button_pressed"]
 [connection signal="button_released" from="XROrigin3D/RightHand" to="XRFbHandTrackingAimDemo" method="_on_right_hand_button_released"]
 [connection signal="openxr_fb_render_model_loaded" from="XROrigin3D/RightHand/RightControllerFbRenderModel" to="." method="_on_right_controller_fb_render_model_render_model_loaded"]


### PR DESCRIPTION
This PR adds all of the remaining passthrough functionality that we're currently missing for the XR_FB_passthrough extension. Quick video showing some of the features:


https://github.com/GodotVR/godot_openxr_vendors/assets/95497005/0649d152-5e1e-45c9-9111-202ffee8883c



### Geometry Passthrough
I've added a new `OpenXRFbPassthroughGeometry` node, when visible, these nodes will register themselves with `OpenXRFbPassthroughExtensionWrapper` and begin geometry passthrough. If the `blend_mode` of `XRInterface` is set to `XR_ENV_BLEND_MODE_ALPHA_BLEND`, then "full passthrough" should always take place instead. These nodes can be moved and scaled, and their passthrough geometry will update accordingly.

### Passthrough Style
Some functions have been added to `OpenXRFbPassthroughExtensionWrapper` to update passthrough styles. Note that edge color is available in all styles, while the other three are mutually exclusive and will automatically enable when set.
- Edge Color: Pass a `Color` into the `set_edge_color()` function
- Color Map: Pass a `GradientTexture1D` into the `set_color_map()` function
- Mono Map: Pass a `Curve` into the `set_mono_map()` function
- Brightness/Contrast/Saturation: Pass three corresponding floats into the `set_brightness_contrast_saturation()` function.

### Passthrough Capabilities
`OpenXRFbPassthroughExtensionWrapper` also now has some functions that can be called to check the capabilities of the headset.

I've also added a signal that should fire if there are any `XrEventDataPassthroughStateChangedFB` events passed through, though I'm unsure at the moment if there's a way to test these.