### PR TITLE
Add support for XR_FB_composition_layer_secure_content

### DIFF
--- a/common/src/main/cpp/extensions/openxr_fb_composition_layer_secure_content_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_fb_composition_layer_secure_content_extension_wrapper.cpp
@@ -1,0 +1,134 @@
+/**************************************************************************/
+/*  openxr_fb_composition_layer_secure_content_extension_wrapper.cpp      */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "extensions/openxr_fb_composition_layer_secure_content_extension_wrapper.h"
+
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+using namespace godot;
+
+static const char *EXTERNAL_OUTPUT_PROPERTY_NAME = "XR_FB_composition_layer_secure_content/external_output";
+
+OpenXRFbCompositionLayerSecureContentExtensionWrapper *OpenXRFbCompositionLayerSecureContentExtensionWrapper::singleton = nullptr;
+
+OpenXRFbCompositionLayerSecureContentExtensionWrapper *OpenXRFbCompositionLayerSecureContentExtensionWrapper::get_singleton() {
+	if (singleton == nullptr) {
+		singleton = memnew(OpenXRFbCompositionLayerSecureContentExtensionWrapper());
+	}
+	return singleton;
+}
+
+OpenXRFbCompositionLayerSecureContentExtensionWrapper::OpenXRFbCompositionLayerSecureContentExtensionWrapper() :
+		OpenXRExtensionWrapperExtension() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "An OpenXRFbCompositionLayerSecureContentExtensionWrapper singleton already exists.");
+
+	request_extensions[XR_FB_COMPOSITION_LAYER_SECURE_CONTENT_EXTENSION_NAME] = &fb_composition_layer_secure_content;
+	singleton = this;
+}
+
+OpenXRFbCompositionLayerSecureContentExtensionWrapper::~OpenXRFbCompositionLayerSecureContentExtensionWrapper() {
+	cleanup();
+}
+
+void OpenXRFbCompositionLayerSecureContentExtensionWrapper::_bind_methods() {
+}
+
+void OpenXRFbCompositionLayerSecureContentExtensionWrapper::cleanup() {
+	fb_composition_layer_secure_content = false;
+}
+
+Dictionary OpenXRFbCompositionLayerSecureContentExtensionWrapper::_get_requested_extensions() {
+	Dictionary result;
+	for (auto ext : request_extensions) {
+		uint64_t value = reinterpret_cast<uint64_t>(ext.value);
+		result[ext.key] = (Variant)value;
+	}
+	return result;
+}
+
+uint64_t OpenXRFbCompositionLayerSecureContentExtensionWrapper::_set_viewport_composition_layer_and_get_next_pointer(const void *p_layer, const Dictionary &p_property_values, void *p_next_pointer) {
+	if (!fb_composition_layer_secure_content) {
+		return reinterpret_cast<uint64_t>(p_next_pointer);
+	}
+
+	const XrCompositionLayerBaseHeader *layer = reinterpret_cast<const XrCompositionLayerBaseHeader *>(p_layer);
+
+	if (!layer_structs.has(layer)) {
+		layer_structs[layer] = {
+			XR_TYPE_COMPOSITION_LAYER_SECURE_CONTENT_FB, // type
+			p_next_pointer, // next
+			0, // flags
+		};
+	}
+
+	XrCompositionLayerSecureContentFB *secure_content = layer_structs.getptr(layer);
+
+	switch ((ExternalOutput)(int)p_property_values.get(EXTERNAL_OUTPUT_PROPERTY_NAME, EXTERNAL_OUTPUT_DISPLAY)) {
+		case EXTERNAL_OUTPUT_DISPLAY: {
+			secure_content->flags = 0;
+		} break;
+		case EXTERNAL_OUTPUT_EXCLUDE: {
+			secure_content->flags = XR_COMPOSITION_LAYER_SECURE_CONTENT_EXCLUDE_LAYER_BIT_FB;
+		} break;
+		case EXTERNAL_OUTPUT_REPLACE: {
+			secure_content->flags = XR_COMPOSITION_LAYER_SECURE_CONTENT_REPLACE_LAYER_BIT_FB;
+		} break;
+	};
+
+	return reinterpret_cast<uint64_t>(secure_content);
+}
+
+void OpenXRFbCompositionLayerSecureContentExtensionWrapper::_on_viewport_composition_layer_destroyed(const void *p_layer) {
+	if (fb_composition_layer_secure_content) {
+		const XrCompositionLayerBaseHeader *layer = reinterpret_cast<const XrCompositionLayerBaseHeader *>(p_layer);
+		layer_structs.erase(layer);
+	}
+}
+
+TypedArray<Dictionary> OpenXRFbCompositionLayerSecureContentExtensionWrapper::_get_viewport_composition_layer_extension_properties() {
+	TypedArray<Dictionary> properties;
+
+	{
+		Dictionary external_output;
+		external_output["name"] = EXTERNAL_OUTPUT_PROPERTY_NAME;
+		external_output["type"] = Variant::INT;
+		external_output["hint"] = PROPERTY_HINT_ENUM;
+		external_output["hint_string"] = "Display,Exclude,Replace";
+		properties.push_back(external_output);
+	}
+
+	return properties;
+}
+
+Dictionary OpenXRFbCompositionLayerSecureContentExtensionWrapper::_get_viewport_composition_layer_extension_property_defaults() {
+	Dictionary defaults;
+	defaults[EXTERNAL_OUTPUT_PROPERTY_NAME] = (int)EXTERNAL_OUTPUT_DISPLAY;
+	return defaults;
+}

--- a/common/src/main/cpp/include/extensions/openxr_fb_composition_layer_secure_content_extension_wrapper.h
+++ b/common/src/main/cpp/include/extensions/openxr_fb_composition_layer_secure_content_extension_wrapper.h
@@ -1,0 +1,80 @@
+/**************************************************************************/
+/*  openxr_fb_composition_layer_secure_content_extension_wrapper.h        */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef OPENXR_FB_COMPOSITION_LAYER_SECURE_CONTENT_EXTENSION_WRAPPER_H
+#define OPENXR_FB_COMPOSITION_LAYER_SECURE_CONTENT_EXTENSION_WRAPPER_H
+
+#include <openxr/openxr.h>
+
+#include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
+#include <godot_cpp/templates/hash_map.hpp>
+
+using namespace godot;
+
+// Wrapper for XR_FB_composition_layer_secure_content extension.
+class OpenXRFbCompositionLayerSecureContentExtensionWrapper : public OpenXRExtensionWrapperExtension {
+	GDCLASS(OpenXRFbCompositionLayerSecureContentExtensionWrapper, OpenXRExtensionWrapperExtension);
+
+public:
+	godot::Dictionary _get_requested_extensions() override;
+
+	static OpenXRFbCompositionLayerSecureContentExtensionWrapper *get_singleton();
+
+	enum ExternalOutput {
+		EXTERNAL_OUTPUT_DISPLAY,
+		EXTERNAL_OUTPUT_EXCLUDE,
+		EXTERNAL_OUTPUT_REPLACE,
+	};
+
+	virtual uint64_t _set_viewport_composition_layer_and_get_next_pointer(const void *p_layer, const Dictionary &p_property_values, void *p_next_pointer) override;
+	virtual void _on_viewport_composition_layer_destroyed(const void *p_layer) override;
+	virtual TypedArray<Dictionary> _get_viewport_composition_layer_extension_properties() override;
+	virtual Dictionary _get_viewport_composition_layer_extension_property_defaults() override;
+
+	bool is_enabled() const;
+
+	OpenXRFbCompositionLayerSecureContentExtensionWrapper();
+	~OpenXRFbCompositionLayerSecureContentExtensionWrapper();
+
+protected:
+	static void _bind_methods();
+
+private:
+	void cleanup();
+
+	static OpenXRFbCompositionLayerSecureContentExtensionWrapper *singleton;
+
+	HashMap<String, bool *> request_extensions;
+
+	bool fb_composition_layer_secure_content = false;
+
+	HashMap<const XrCompositionLayerBaseHeader *, XrCompositionLayerSecureContentFB> layer_structs;
+};
+
+#endif // OPENXR_FB_COMPOSITION_LAYER_SECURE_CONTENT_EXTENSION_WRAPPER_H

--- a/common/src/main/cpp/register_types.cpp
+++ b/common/src/main/cpp/register_types.cpp
@@ -43,6 +43,7 @@
 #include "export/meta_export_plugin.h"
 #include "export/pico_export_plugin.h"
 
+#include "extensions/openxr_fb_composition_layer_secure_content_extension_wrapper.h"
 #include "extensions/openxr_fb_face_tracking_extension_wrapper.h"
 #include "extensions/openxr_fb_hand_tracking_aim_extension_wrapper.h"
 #include "extensions/openxr_fb_hand_tracking_capsules_extension_wrapper.h"
@@ -102,6 +103,9 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 
 			ClassDB::register_class<OpenXRFbHandTrackingCapsulesExtensionWrapper>();
 			OpenXRFbHandTrackingCapsulesExtensionWrapper::get_singleton()->register_extension_wrapper();
+
+			ClassDB::register_class<OpenXRFbCompositionLayerSecureContentExtensionWrapper>();
+			OpenXRFbCompositionLayerSecureContentExtensionWrapper::get_singleton()->register_extension_wrapper();
 		} break;
 
 		case MODULE_INITIALIZATION_LEVEL_SERVERS:


### PR DESCRIPTION
This depends on PR https://github.com/godotengine/godot/pull/90237

It adds a new "External Output" property to `OpenXRCompositionLayer` nodes, which can be used to set the flags used by XR_FB_composition_layer_secure_content to configure the given composition layer:

![Selection_138](https://github.com/GodotVR/godot_openxr_vendors/assets/191561/9e0d8204-7b4b-4484-94e4-08a4cce9980e)

I've tested this on the Meta Quest 3 and it works!

When casting to the web, setting the composition layer to "Replace" will display it blacked out in the cast, and setting to "Exclude" will remove it from the cast entirely. As expected, the setting has no effect in the headset.

Marking as draft until the Godot PR is merged.