### PR TITLE
Add missing changelog entry about API for scene anchors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 - Add XR_FB_hand_tracking_mesh extension wrapper and OpenXRFbHandTrackingMesh node
 - Add XR_FB_hand_tracking_aim support
 - Update Meta OpenXR mobile SDK to version 62
+- Add a developer-facing API for interacting with scene anchors
 
 ## 2.0.3
 - Migrate the export scripts from gdscript to C++ via gdextension


### PR DESCRIPTION
This a follow-up to PR https://github.com/GodotVR/godot_openxr_vendors/pull/107, adding the changelog entry that I should have included in that PR