### PR TITLE
Add support for developer-created spatial anchors via XR_FB_spatial_entity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 - Add XR_FB_hand_tracking_aim support
 - Update Meta OpenXR mobile SDK to version 62
 - Add a developer-facing API for interacting with scene anchors
+- Add support for developer-created spatial anchors via XR_FB_spatial_entity
 - Add XR_FB_hand_tracking_capsules extension wrapper
 - Add OpenXRFbPassthroughGeometry node
 - Add OpenXRMetaPassthroughColorLut

--- a/common/src/main/cpp/classes/openxr_fb_spatial_anchor_manager.cpp
+++ b/common/src/main/cpp/classes/openxr_fb_spatial_anchor_manager.cpp
@@ -1,0 +1,407 @@
+/**************************************************************************/
+/*  openxr_fb_spatial_anchor_manager.cpp                                  */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "classes/openxr_fb_spatial_anchor_manager.h"
+
+#include <godot_cpp/classes/open_xr_interface.hpp>
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
+#include <godot_cpp/classes/packed_scene.hpp>
+#include <godot_cpp/classes/xr_origin3d.hpp>
+#include <godot_cpp/classes/xr_anchor3d.hpp>
+#include <godot_cpp/classes/xr_server.hpp>
+
+#include <godot_cpp/variant/utility_functions.hpp>
+
+#include "classes/openxr_fb_spatial_entity_query.h"
+#include "extensions/openxr_fb_spatial_entity_extension_wrapper.h"
+
+using namespace godot;
+
+void OpenXRFbSpatialAnchorManager::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_scene", "scene"), &OpenXRFbSpatialAnchorManager::set_scene);
+	ClassDB::bind_method(D_METHOD("get_scene"), &OpenXRFbSpatialAnchorManager::get_scene);
+
+	ClassDB::bind_method(D_METHOD("set_scene_setup_method", "method_name"), &OpenXRFbSpatialAnchorManager::set_scene_setup_method);
+	ClassDB::bind_method(D_METHOD("get_scene_setup_method"), &OpenXRFbSpatialAnchorManager::get_scene_setup_method);
+
+	ClassDB::bind_method(D_METHOD("set_visible", "visible"), &OpenXRFbSpatialAnchorManager::set_visible);
+	ClassDB::bind_method(D_METHOD("get_visible"), &OpenXRFbSpatialAnchorManager::get_visible);
+	ClassDB::bind_method(D_METHOD("show"), &OpenXRFbSpatialAnchorManager::show);
+	ClassDB::bind_method(D_METHOD("hide"), &OpenXRFbSpatialAnchorManager::hide);
+
+	ClassDB::bind_method(D_METHOD("create_anchor", "transform", "custom_data"), &OpenXRFbSpatialAnchorManager::create_anchor, DEFVAL(Dictionary()));
+	ClassDB::bind_method(D_METHOD("load_anchor", "uuid", "custom_data", "location"), &OpenXRFbSpatialAnchorManager::load_anchor, DEFVAL(Dictionary()), DEFVAL(OpenXRFbSpatialEntity::STORAGE_LOCAL));
+	ClassDB::bind_method(D_METHOD("load_anchors", "uuids", "all_custom_data", "location", "erase_unknown_anchors"), &OpenXRFbSpatialAnchorManager::load_anchors, DEFVAL(Dictionary()), DEFVAL(OpenXRFbSpatialEntity::STORAGE_LOCAL), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("track_anchor", "spatial_entity"), &OpenXRFbSpatialAnchorManager::track_anchor);
+	ClassDB::bind_method(D_METHOD("untrack_anchor", "spatial_entity_or_uuid"), &OpenXRFbSpatialAnchorManager::untrack_anchor);
+
+	ClassDB::bind_method(D_METHOD("get_anchor_uuids"), &OpenXRFbSpatialAnchorManager::get_anchor_uuids);
+	ClassDB::bind_method(D_METHOD("get_anchor_node", "uuid"), &OpenXRFbSpatialAnchorManager::get_anchor_node);
+	ClassDB::bind_method(D_METHOD("get_spatial_entity", "uuid"), &OpenXRFbSpatialAnchorManager::get_spatial_entity);
+
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "scene", PROPERTY_HINT_RESOURCE_TYPE, "PackedScene"), "set_scene", "get_scene");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "scene_setup_method", PROPERTY_HINT_NONE, ""), "set_scene_setup_method", "get_scene_setup_method");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "visible", PROPERTY_HINT_NONE, ""), "set_visible", "get_visible");
+
+	ADD_SIGNAL(MethodInfo("openxr_fb_spatial_anchor_tracked", PropertyInfo(Variant::Type::OBJECT, "anchor_node"), PropertyInfo(Variant::Type::OBJECT, "spatial_entity"), PropertyInfo(Variant::Type::BOOL, "is_new")));
+	ADD_SIGNAL(MethodInfo("openxr_fb_spatial_anchor_untracked", PropertyInfo(Variant::Type::OBJECT, "anchor_node"), PropertyInfo(Variant::Type::OBJECT, "spatial_entity")));
+	ADD_SIGNAL(MethodInfo("openxr_fb_spatial_anchor_create_failed", PropertyInfo(Variant::Type::TRANSFORM3D, "transform"), PropertyInfo(Variant::Type::DICTIONARY, "custom_data")));
+	ADD_SIGNAL(MethodInfo("openxr_fb_spatial_anchor_load_failed", PropertyInfo(Variant::Type::STRING_NAME, "uuid"), PropertyInfo(Variant::Type::DICTIONARY, "custom_data"), PropertyInfo(Variant::Type::INT, "location")));
+	ADD_SIGNAL(MethodInfo("openxr_fb_spatial_anchor_track_failed", PropertyInfo(Variant::Type::OBJECT, "spatial_entity")));
+}
+
+void OpenXRFbSpatialAnchorManager::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			Ref<OpenXRInterface> openxr_interface = XRServer::get_singleton()->find_interface("OpenXR");
+			if (openxr_interface.is_valid()) {
+				openxr_interface->connect("session_stopping", callable_mp(this, &OpenXRFbSpatialAnchorManager::_on_openxr_session_stopping));
+			}
+
+			xr_origin = Object::cast_to<XROrigin3D>(get_parent());
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+			Ref<OpenXRInterface> openxr_interface = XRServer::get_singleton()->find_interface("OpenXR");
+			if (openxr_interface.is_valid()) {
+				openxr_interface->disconnect("session_stopping", callable_mp(this, &OpenXRFbSpatialAnchorManager::_on_openxr_session_stopping));
+			}
+
+			xr_origin = nullptr;
+			_cleanup_anchors();
+		} break;
+	}
+}
+
+void OpenXRFbSpatialAnchorManager::_on_openxr_session_stopping() {
+	_cleanup_anchors();
+}
+
+// Removes anchor nodes and clears the anchor list - but doesn't change the local file.
+void OpenXRFbSpatialAnchorManager::_cleanup_anchors() {
+	for (KeyValue<StringName, Anchor> &E : anchors) {
+		Node3D *node = Object::cast_to<Node3D>(ObjectDB::get_instance(E.value.node));
+		if (node) {
+			Node *parent = node->get_parent();
+			if (parent) {
+				parent->remove_child(node);
+			}
+			node->queue_free();
+		}
+
+		E.value.entity->untrack();
+	}
+	anchors.clear();
+}
+
+PackedStringArray OpenXRFbSpatialAnchorManager::_get_configuration_warnings() const {
+	PackedStringArray warnings = Node::_get_configuration_warnings();
+
+	if (is_inside_tree()) {
+		XROrigin3D *origin = Object::cast_to<XROrigin3D>(get_parent());
+		if (origin == nullptr) {
+			warnings.push_back("Must be a child of XROrigin3D");
+		}
+	}
+
+	return warnings;
+}
+
+void OpenXRFbSpatialAnchorManager::set_scene(const Ref<PackedScene> &p_scene) {
+	scene = p_scene;
+}
+
+Ref<PackedScene> OpenXRFbSpatialAnchorManager::get_scene() const {
+	return scene;
+}
+
+void OpenXRFbSpatialAnchorManager::set_scene_setup_method(const StringName &p_method) {
+	scene_setup_method = p_method;
+}
+
+StringName OpenXRFbSpatialAnchorManager::get_scene_setup_method() const {
+	return scene_setup_method;
+}
+
+void OpenXRFbSpatialAnchorManager::set_visible(bool p_visible) {
+	visible = p_visible;
+
+	for (KeyValue<StringName, Anchor> &E : anchors) {
+		Node3D *node = Object::cast_to<Node3D>(ObjectDB::get_instance(E.value.node));
+		ERR_CONTINUE_MSG(!node, vformat("Cannot find node for anchor %s.", E.key));
+		if (node) {
+			node->set_visible(p_visible);
+		}
+	}
+}
+
+bool OpenXRFbSpatialAnchorManager::get_visible() const {
+	return visible;
+}
+
+void OpenXRFbSpatialAnchorManager::show() {
+	set_visible(true);
+}
+
+void OpenXRFbSpatialAnchorManager::hide() {
+	set_visible(false);
+}
+
+void OpenXRFbSpatialAnchorManager::create_anchor(const Transform3D &p_transform, const Dictionary &p_custom_data) {
+	ERR_FAIL_COND(!xr_origin);
+
+	// Convert transform from global space to be relative to the XROrigin3D node.
+	Transform3D local_transform = xr_origin->get_global_transform().inverse() * p_transform;
+
+	Ref<OpenXRFbSpatialEntity> spatial_entity = OpenXRFbSpatialEntity::create_spatial_anchor(local_transform);
+	spatial_entity->set_custom_data(p_custom_data);
+	spatial_entity->connect("openxr_fb_spatial_entity_created", callable_mp(this, &OpenXRFbSpatialAnchorManager::_on_anchor_created).bind(p_transform, spatial_entity));
+}
+
+void OpenXRFbSpatialAnchorManager::_on_anchor_created(bool p_success, const Transform3D &p_transform, const Ref<OpenXRFbSpatialEntity> &p_spatial_entity) {
+	if (p_success) {
+		_track_anchor(p_spatial_entity, true);
+	} else {
+		emit_signal("openxr_fb_spatial_anchor_create_failed", p_transform, p_spatial_entity->get_custom_data());
+	}
+}
+
+void OpenXRFbSpatialAnchorManager::load_anchor(const StringName &p_uuid, const Dictionary &p_custom_data, OpenXRFbSpatialEntity::StorageLocation p_location) {
+	ERR_FAIL_COND(!xr_origin);
+
+	Array uuids;
+	uuids.push_back(p_uuid);
+
+	Dictionary data;
+	data[p_uuid] = p_custom_data;
+
+	Ref<OpenXRFbSpatialEntityQuery> query;
+	query.instantiate();
+	query->query_by_uuid(uuids, p_location);
+	query->connect("openxr_fb_spatial_entity_query_completed", callable_mp(this, &OpenXRFbSpatialAnchorManager::_on_anchor_load_query_completed).bind(data, p_location, false));
+	query->execute();
+}
+
+void OpenXRFbSpatialAnchorManager::load_anchors(const TypedArray<StringName> &p_uuids, const Dictionary &p_all_custom_data, OpenXRFbSpatialEntity::StorageLocation p_location, bool p_erase_unknown_anchors) {
+	ERR_FAIL_COND(!xr_origin);
+
+	Ref<OpenXRFbSpatialEntityQuery> query;
+	query.instantiate();
+
+	Dictionary all_custom_data;
+
+	if (p_erase_unknown_anchors) {
+		// If we want to clear out unknown anchors, then we need to query everything.
+		query->query_all();
+		query->set_max_results(1000);
+
+		// In order for this to work correctly, we need to make sure that all UUIDs are present
+		// on the custom data dictionary (and no others).
+		for (int i = 0; i < p_uuids.size(); i++) {
+			all_custom_data[p_uuids[i]] = p_all_custom_data.get(p_uuids[i], Dictionary());
+		}
+	} else {
+		// Otherwise, we just query the specific anchors we know about.
+		query->query_by_uuid(p_uuids, p_location);
+		query->set_max_results(p_uuids.size());
+		all_custom_data = p_all_custom_data;
+	}
+
+	query->connect("openxr_fb_spatial_entity_query_completed", callable_mp(this, &OpenXRFbSpatialAnchorManager::_on_anchor_load_query_completed).bind(all_custom_data, p_location, p_erase_unknown_anchors));
+	query->execute();
+}
+
+void OpenXRFbSpatialAnchorManager::_on_anchor_load_query_completed(const Array &p_results, const Dictionary &p_anchors_custom_data, OpenXRFbSpatialEntity::StorageLocation p_location, bool p_erase_unknown_anchors) {
+	Dictionary anchors_custom_data = p_anchors_custom_data.duplicate();
+	for (int i = 0; i < p_results.size(); i++) {
+		Ref<OpenXRFbSpatialEntity> spatial_entity = p_results[i];
+		if (spatial_entity.is_valid()) {
+			StringName uuid = spatial_entity->get_uuid();
+			if (anchors_custom_data.has(uuid)) {
+				spatial_entity->set_custom_data(anchors_custom_data[uuid]);
+				anchors_custom_data.erase(uuid);
+
+				_track_anchor(spatial_entity, false);
+			} else if (p_erase_unknown_anchors) {
+				_untrack_anchor(spatial_entity);
+			}
+		}
+	}
+
+	Array failed_uuids = anchors_custom_data.keys();
+	for (int i = 0; i < failed_uuids.size(); i++) {
+		StringName uuid = failed_uuids[i];
+		emit_signal("openxr_fb_spatial_anchor_load_failed", uuid, anchors_custom_data[uuid], p_location);
+	}
+}
+
+void OpenXRFbSpatialAnchorManager::track_anchor(const Ref<OpenXRFbSpatialEntity> &p_spatial_entity) {
+	ERR_FAIL_COND(!xr_origin);
+	_track_anchor(p_spatial_entity, false);
+}
+
+void OpenXRFbSpatialAnchorManager::_track_anchor(const Ref<OpenXRFbSpatialEntity> &p_spatial_entity, bool p_new_anchor) {
+	if (p_spatial_entity->is_component_enabled(OpenXRFbSpatialEntity::COMPONENT_TYPE_LOCATABLE)) {
+		_on_anchor_track_enable_locatable_completed(true, OpenXRFbSpatialEntity::COMPONENT_TYPE_LOCATABLE, true, p_spatial_entity, p_new_anchor);
+	} else {
+		p_spatial_entity->connect("openxr_fb_spatial_entity_set_component_enabled_completed", callable_mp(this, &OpenXRFbSpatialAnchorManager::_on_anchor_track_enable_locatable_completed).bind(p_spatial_entity, p_new_anchor), CONNECT_ONE_SHOT);
+		p_spatial_entity->set_component_enabled(OpenXRFbSpatialEntity::COMPONENT_TYPE_LOCATABLE, true);
+	}
+}
+
+void OpenXRFbSpatialAnchorManager::_on_anchor_track_enable_locatable_completed(bool p_succeeded, OpenXRFbSpatialEntity::ComponentType p_component, bool p_enabled, const Ref<OpenXRFbSpatialEntity> &p_spatial_entity, bool p_new_anchor) {
+	ERR_FAIL_COND_MSG(!p_succeeded, vformat("Unable to make spatial anchor %s locatable.", p_spatial_entity->get_uuid()));
+
+	if (p_spatial_entity->is_component_enabled(OpenXRFbSpatialEntity::COMPONENT_TYPE_STORABLE)) {
+		_on_anchor_track_enable_storable_completed(true, OpenXRFbSpatialEntity::COMPONENT_TYPE_STORABLE, true, p_spatial_entity, p_new_anchor);
+	} else {
+		p_spatial_entity->connect("openxr_fb_spatial_entity_set_component_enabled_completed", callable_mp(this, &OpenXRFbSpatialAnchorManager::_on_anchor_track_enable_storable_completed).bind(p_spatial_entity, p_new_anchor), CONNECT_ONE_SHOT);
+		p_spatial_entity->set_component_enabled(OpenXRFbSpatialEntity::COMPONENT_TYPE_STORABLE, true);
+	}
+}
+
+void OpenXRFbSpatialAnchorManager::_on_anchor_track_enable_storable_completed(bool p_succeeded, OpenXRFbSpatialEntity::ComponentType p_component, bool p_enabled, const Ref<OpenXRFbSpatialEntity> &p_spatial_entity, bool p_new_anchor) {
+	ERR_FAIL_COND_MSG(!p_succeeded, vformat("Unable to make spatial anchor %s storable.", p_spatial_entity->get_uuid()));
+
+	p_spatial_entity->connect("openxr_fb_spatial_entity_saved", callable_mp(this, &OpenXRFbSpatialAnchorManager::_on_anchor_saved).bind(p_spatial_entity, p_new_anchor), CONNECT_ONE_SHOT);
+	p_spatial_entity->save_to_storage(OpenXRFbSpatialEntity::STORAGE_LOCAL);
+}
+
+void OpenXRFbSpatialAnchorManager::_on_anchor_saved(bool p_succeeded, OpenXRFbSpatialEntity::StorageLocation p_location, const Ref<OpenXRFbSpatialEntity> &p_spatial_entity, bool p_new_anchor) {
+	ERR_FAIL_COND_MSG(!p_succeeded, vformat("Unable to save spatial anchor %s to local storage.", p_spatial_entity->get_uuid()));
+	_complete_anchor_setup(p_spatial_entity, p_new_anchor);
+}
+
+void OpenXRFbSpatialAnchorManager::_complete_anchor_setup(const Ref<OpenXRFbSpatialEntity> &p_entity, bool p_new_anchor) {
+	ERR_FAIL_COND(!xr_origin);
+	ERR_FAIL_COND(anchors.has(p_entity->get_uuid()));
+
+	p_entity->track();
+
+	XRAnchor3D *node = memnew(XRAnchor3D);
+	node->set_name(p_entity->get_uuid());
+	node->set_tracker(p_entity->get_uuid());
+	node->set_visible(visible);
+	xr_origin->add_child(node);
+
+	anchors[p_entity->get_uuid()] = Anchor(node, p_entity);
+
+	if (scene.is_valid()) {
+		Node *scene_node = scene->instantiate();
+		node->add_child(scene_node);
+		scene_node->call(scene_setup_method, p_entity);
+	}
+
+	emit_signal("openxr_fb_spatial_anchor_tracked", node, p_entity, p_new_anchor);
+}
+
+void OpenXRFbSpatialAnchorManager::untrack_anchor(const Variant &p_spatial_entity_or_uuid) {
+	StringName uuid;
+
+	if (p_spatial_entity_or_uuid.get_type() == Variant::OBJECT) {
+		Ref<OpenXRFbSpatialEntity> spatial_entity = p_spatial_entity_or_uuid;
+		ERR_FAIL_COND(spatial_entity.is_null());
+		uuid = spatial_entity->get_uuid();
+	} else if (p_spatial_entity_or_uuid.get_type() == Variant::STRING || p_spatial_entity_or_uuid.get_type() == Variant::STRING_NAME) {
+		uuid = p_spatial_entity_or_uuid;
+	} else {
+		ERR_FAIL_MSG("Invalid argument passed to OpenXRFbSpatialAnchorManager::untrack_anchor().");
+	}
+
+	Anchor *anchor = anchors.getptr(uuid);
+	ERR_FAIL_COND(!anchor);
+
+	Node3D *node = Object::cast_to<Node3D>(ObjectDB::get_instance(anchor->node));
+	if (node) {
+		Node *parent = node->get_parent();
+		if (parent) {
+			parent->remove_child(node);
+		}
+		node->queue_free();
+	}
+
+	Ref<OpenXRFbSpatialEntity> spatial_entity = anchor->entity;
+	spatial_entity->untrack();
+
+	anchors.erase(uuid);
+
+	_untrack_anchor(spatial_entity);
+
+	emit_signal("openxr_fb_spatial_anchor_untracked", node, spatial_entity);
+}
+
+void OpenXRFbSpatialAnchorManager::_untrack_anchor(const Ref<OpenXRFbSpatialEntity> &p_spatial_entity) {
+	if (p_spatial_entity->is_component_enabled(OpenXRFbSpatialEntity::COMPONENT_TYPE_STORABLE)) {
+		_on_anchor_untrack_enable_storable_completed(true, OpenXRFbSpatialEntity::COMPONENT_TYPE_STORABLE, true, p_spatial_entity);
+	} else {
+		p_spatial_entity->connect("openxr_fb_spatial_entity_set_component_enabled_completed", callable_mp(this, &OpenXRFbSpatialAnchorManager::_on_anchor_untrack_enable_storable_completed).bind(p_spatial_entity), CONNECT_ONE_SHOT);
+		p_spatial_entity->set_component_enabled(OpenXRFbSpatialEntity::COMPONENT_TYPE_STORABLE, true);
+	}
+}
+
+void OpenXRFbSpatialAnchorManager::_on_anchor_untrack_enable_storable_completed(bool p_succeeded, OpenXRFbSpatialEntity::ComponentType p_component, bool p_enabled, const Ref<OpenXRFbSpatialEntity> &p_spatial_entity) {
+	if (!p_succeeded) {
+		// If we couldn't make it storable, just exit silently since we were trying to remove it anyway.
+		return;
+	}
+
+	p_spatial_entity->connect("openxr_fb_spatial_entity_erased", callable_mp(this, &OpenXRFbSpatialAnchorManager::_on_anchor_erase_completed).bind(p_spatial_entity), CONNECT_ONE_SHOT);
+	p_spatial_entity->erase_from_storage(OpenXRFbSpatialEntity::STORAGE_LOCAL);
+}
+
+void OpenXRFbSpatialAnchorManager::_on_anchor_erase_completed(bool p_succeeded, OpenXRFbSpatialEntity::StorageLocation p_location, const Ref<OpenXRFbSpatialEntity> &p_spatial_entity) {
+	ERR_FAIL_COND_MSG(!p_succeeded, vformat("Unable to erase spatial anchor %s.", p_spatial_entity->get_uuid()));
+}
+
+Array OpenXRFbSpatialAnchorManager::get_anchor_uuids() const {
+	Array ret;
+	ret.resize(anchors.size());
+	int i = 0;
+	for (const KeyValue<StringName, Anchor> &E : anchors) {
+		ret[i++] = E.key;
+	}
+	return ret;
+}
+
+XRAnchor3D *OpenXRFbSpatialAnchorManager::get_anchor_node(const StringName &p_uuid) const {
+	const Anchor *anchor = anchors.getptr(p_uuid);
+	if (anchor) {
+		return Object::cast_to<XRAnchor3D>(ObjectDB::get_instance(anchor->node));
+	}
+
+	return nullptr;
+}
+
+Ref<OpenXRFbSpatialEntity> OpenXRFbSpatialAnchorManager::get_spatial_entity(const StringName &p_uuid) const {
+	const Anchor *anchor = anchors.getptr(p_uuid);
+	if (anchor) {
+		return anchor->entity;
+	}
+
+	return Ref<OpenXRFbSpatialEntity>();
+}

--- a/common/src/main/cpp/classes/openxr_fb_spatial_entity.cpp
+++ b/common/src/main/cpp/classes/openxr_fb_spatial_entity.cpp
@@ -39,6 +39,7 @@
 
 #include "extensions/openxr_fb_spatial_entity_extension_wrapper.h"
 #include "extensions/openxr_fb_spatial_entity_container_extension_wrapper.h"
+#include "extensions/openxr_fb_spatial_entity_storage_extension_wrapper.h"
 #include "extensions/openxr_fb_scene_extension_wrapper.h"
 #include "extensions/openxr_meta_spatial_entity_mesh_extension_wrapper.h"
 
@@ -46,6 +47,8 @@ using namespace godot;
 
 void OpenXRFbSpatialEntity::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_uuid"), &OpenXRFbSpatialEntity::get_uuid);
+	ClassDB::bind_method(D_METHOD("set_custom_data"), &OpenXRFbSpatialEntity::set_custom_data);
+	ClassDB::bind_method(D_METHOD("get_custom_data"), &OpenXRFbSpatialEntity::get_custom_data);
 
 	ClassDB::bind_method(D_METHOD("get_supported_components"), &OpenXRFbSpatialEntity::get_supported_components);
 	ClassDB::bind_method(D_METHOD("is_component_supported", "component"), &OpenXRFbSpatialEntity::is_component_supported);
@@ -67,7 +70,14 @@ void OpenXRFbSpatialEntity::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create_mesh_instance"), &OpenXRFbSpatialEntity::create_mesh_instance);
 	ClassDB::bind_method(D_METHOD("create_collision_shape"), &OpenXRFbSpatialEntity::create_collision_shape);
 
+	ClassDB::bind_static_method("OpenXRFbSpatialEntity", D_METHOD("create_spatial_anchor", "transform"), &OpenXRFbSpatialEntity::create_spatial_anchor);
+
+	ClassDB::bind_method(D_METHOD("save_to_storage", "location"), &OpenXRFbSpatialEntity::save_to_storage, DEFVAL(STORAGE_LOCAL));
+	ClassDB::bind_method(D_METHOD("erase_from_storage", "location"), &OpenXRFbSpatialEntity::erase_from_storage, DEFVAL(STORAGE_LOCAL));
+	ClassDB::bind_method(D_METHOD("destroy"), &OpenXRFbSpatialEntity::destroy);
+
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "uuid", PROPERTY_HINT_NONE, ""), "", "get_uuid");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "custom_data", PROPERTY_HINT_NONE, ""), "set_custom_data", "get_custom_data");
 
 	BIND_ENUM_CONSTANT(STORAGE_LOCAL);
 	BIND_ENUM_CONSTANT(STORAGE_CLOUD);
@@ -83,6 +93,9 @@ void OpenXRFbSpatialEntity::_bind_methods() {
 	BIND_ENUM_CONSTANT(COMPONENT_TYPE_TRIANGLE_MESH);
 
 	ADD_SIGNAL(MethodInfo("openxr_fb_spatial_entity_set_component_enabled_completed", PropertyInfo(Variant::Type::BOOL, "succeeded"), PropertyInfo(Variant::Type::INT, "component"), PropertyInfo(Variant::Type::BOOL, "enabled")));
+	ADD_SIGNAL(MethodInfo("openxr_fb_spatial_entity_created", PropertyInfo(Variant::Type::BOOL, "succeeded")));
+	ADD_SIGNAL(MethodInfo("openxr_fb_spatial_entity_saved", PropertyInfo(Variant::Type::BOOL, "succeeded"), PropertyInfo(Variant::Type::INT, "location")));
+	ADD_SIGNAL(MethodInfo("openxr_fb_spatial_entity_erased", PropertyInfo(Variant::Type::BOOL, "succeeded"), PropertyInfo(Variant::Type::INT, "location")));
 }
 
 String OpenXRFbSpatialEntity::_to_string() const {
@@ -93,8 +106,18 @@ StringName OpenXRFbSpatialEntity::get_uuid() const {
 	return uuid;
 }
 
+void OpenXRFbSpatialEntity::set_custom_data(const Dictionary &p_custom_data) {
+	custom_data = p_custom_data;
+}
+
+Dictionary OpenXRFbSpatialEntity::get_custom_data() const {
+	return custom_data;
+}
+
 Array OpenXRFbSpatialEntity::get_supported_components() const {
 	Array ret;
+
+	ERR_FAIL_COND_V_MSG(space == XR_NULL_HANDLE, ret, "Underlying spatial entity doesn't exist (yet) or has been destroyed.");
 
 	Vector<XrSpaceComponentTypeFB> components = OpenXRFbSpatialEntityExtensionWrapper::get_singleton()->get_support_components(space);
 	ret.resize(components.size());
@@ -106,16 +129,22 @@ Array OpenXRFbSpatialEntity::get_supported_components() const {
 }
 
 bool OpenXRFbSpatialEntity::is_component_supported(ComponentType p_component) const {
+	ERR_FAIL_COND_V_MSG(space == XR_NULL_HANDLE, false, "Underlying spatial entity doesn't exist (yet) or has been destroyed.");
+	ERR_FAIL_COND_V(p_component == COMPONENT_TYPE_UNKNOWN, false);
 	return get_supported_components().has(p_component);
 }
 
 bool OpenXRFbSpatialEntity::is_component_enabled(ComponentType p_component) const {
+	ERR_FAIL_COND_V_MSG(space == XR_NULL_HANDLE, false, "Underlying spatial entity doesn't exist (yet) or has been destroyed.");
+	ERR_FAIL_COND_V(p_component == COMPONENT_TYPE_UNKNOWN, false);
 	return OpenXRFbSpatialEntityExtensionWrapper::get_singleton()->is_component_enabled(space, to_openxr_component_type(p_component));
 }
 
 void OpenXRFbSpatialEntity::set_component_enabled(ComponentType p_component, bool p_enabled) {
+	ERR_FAIL_COND_MSG(space == XR_NULL_HANDLE, "Underlying spatial entity doesn't exist (yet) or has been destroyed.");
+	ERR_FAIL_COND(p_component == COMPONENT_TYPE_UNKNOWN);
 	Ref<OpenXRFbSpatialEntity> *userdata = memnew(Ref<OpenXRFbSpatialEntity>(this));
-	XrAsyncRequestIdFB request_id = OpenXRFbSpatialEntityExtensionWrapper::get_singleton()->set_component_enabled(space, to_openxr_component_type(p_component), p_enabled, OpenXRFbSpatialEntity::_on_set_component_enabled_completed, userdata);
+	OpenXRFbSpatialEntityExtensionWrapper::get_singleton()->set_component_enabled(space, to_openxr_component_type(p_component), p_enabled, OpenXRFbSpatialEntity::_on_set_component_enabled_completed, userdata);
 }
 
 void OpenXRFbSpatialEntity::_on_set_component_enabled_completed(XrResult p_result, XrSpaceComponentTypeFB p_component, bool p_enabled, void *p_userdata) {
@@ -125,10 +154,13 @@ void OpenXRFbSpatialEntity::_on_set_component_enabled_completed(XrResult p_resul
 }
 
 PackedStringArray OpenXRFbSpatialEntity::get_semantic_labels() const {
+	ERR_FAIL_COND_V_MSG(space == XR_NULL_HANDLE, PackedStringArray(), "Underlying spatial entity doesn't exist (yet) or has been destroyed.");
 	return OpenXRFbSceneExtensionWrapper::get_singleton()->get_semantic_labels(space);
 }
 
 Dictionary OpenXRFbSpatialEntity::get_room_layout() const {
+	ERR_FAIL_COND_V_MSG(space == XR_NULL_HANDLE, Dictionary(), "Underlying spatial entity doesn't exist (yet) or has been destroyed.");
+
 	OpenXRFbSceneExtensionWrapper::RoomLayout room_layout;
 	if (!OpenXRFbSceneExtensionWrapper::get_singleton()->get_room_layout(space, room_layout)) {
 		return Dictionary();
@@ -149,6 +181,8 @@ Dictionary OpenXRFbSpatialEntity::get_room_layout() const {
 }
 
 Array OpenXRFbSpatialEntity::get_contained_uuids() const {
+	ERR_FAIL_COND_V_MSG(space == XR_NULL_HANDLE, Array(), "Underlying spatial entity doesn't exist (yet) or has been destroyed.");
+
 	Vector<XrUuidEXT> uuids = OpenXRFbSpatialEntityContainerExtensionWrapper::get_singleton()->get_contained_uuids(space);
 
 	Array ret;
@@ -160,27 +194,33 @@ Array OpenXRFbSpatialEntity::get_contained_uuids() const {
 }
 
 Rect2 OpenXRFbSpatialEntity::get_bounding_box_2d() const {
+	ERR_FAIL_COND_V_MSG(space == XR_NULL_HANDLE, Rect2(), "Underlying spatial entity doesn't exist (yet) or has been destroyed.");
 	return OpenXRFbSceneExtensionWrapper::get_singleton()->get_bounding_box_2d(space);
 }
 
 AABB OpenXRFbSpatialEntity::get_bounding_box_3d() const {
+	ERR_FAIL_COND_V_MSG(space == XR_NULL_HANDLE, AABB(), "Underlying spatial entity doesn't exist (yet) or has been destroyed.");
 	return OpenXRFbSceneExtensionWrapper::get_singleton()->get_bounding_box_3d(space);
 }
 
 PackedVector2Array OpenXRFbSpatialEntity::get_boundary_2d() const {
+	ERR_FAIL_COND_V_MSG(space == XR_NULL_HANDLE, PackedVector2Array(), "Underlying spatial entity doesn't exist (yet) or has been destroyed.");
 	return OpenXRFbSceneExtensionWrapper::get_singleton()->get_boundary_2d(space);
 }
 
 void OpenXRFbSpatialEntity::track() {
+	ERR_FAIL_COND_MSG(space == XR_NULL_HANDLE, "Underlying spatial entity doesn't exist (yet) or has been destroyed.");
 	ERR_FAIL_COND_MSG(!is_component_enabled(COMPONENT_TYPE_LOCATABLE), vformat("Cannot track spatial entity %s because COMPONENT_TYPE_LOCATABLE isn't enabled.", uuid));
 	OpenXRFbSpatialEntityExtensionWrapper::get_singleton()->track_entity(uuid, space);
 }
 
 void OpenXRFbSpatialEntity::untrack() {
+	ERR_FAIL_COND_MSG(space == XR_NULL_HANDLE, "Underlying spatial entity doesn't exist (yet) or has been destroyed.");
 	OpenXRFbSpatialEntityExtensionWrapper::get_singleton()->untrack_entity(uuid);
 }
 
 bool OpenXRFbSpatialEntity::is_tracked() const {
+	ERR_FAIL_COND_V_MSG(space == XR_NULL_HANDLE, false, "Underlying spatial entity doesn't exist (yet) or has been destroyed.");
 	return OpenXRFbSpatialEntityExtensionWrapper::get_singleton()->is_entity_tracked(uuid);
 }
 
@@ -214,6 +254,8 @@ Array OpenXRFbSpatialEntity::get_triangle_mesh() const {
 }
 
 MeshInstance3D *OpenXRFbSpatialEntity::create_mesh_instance() const {
+	ERR_FAIL_COND_V_MSG(space == XR_NULL_HANDLE, nullptr, "Underlying spatial entity doesn't exist (yet) or has been destroyed.");
+
 	MeshInstance3D *mesh_instance = nullptr;
 
 	if (is_component_enabled(COMPONENT_TYPE_TRIANGLE_MESH)) {
@@ -254,6 +296,8 @@ MeshInstance3D *OpenXRFbSpatialEntity::create_mesh_instance() const {
 }
 
 Node3D *OpenXRFbSpatialEntity::create_collision_shape() const {
+	ERR_FAIL_COND_V_MSG(space == XR_NULL_HANDLE, nullptr, "Underlying spatial entity doesn't exist (yet) or has been destroyed.");
+
 	if (is_component_enabled(COMPONENT_TYPE_TRIANGLE_MESH)) {
 		OpenXRMetaSpatialEntityMeshExtensionWrapper::TriangleMesh mesh_data;
 		if (!OpenXRMetaSpatialEntityMeshExtensionWrapper::get_singleton()->get_triangle_mesh(space, mesh_data)) {
@@ -314,6 +358,75 @@ Node3D *OpenXRFbSpatialEntity::create_collision_shape() const {
 	return nullptr;
 }
 
+Ref<OpenXRFbSpatialEntity> OpenXRFbSpatialEntity::create_spatial_anchor(const Transform3D &p_transform) {
+	Ref<OpenXRFbSpatialEntity> *userdata = memnew(Ref<OpenXRFbSpatialEntity>());
+	(*userdata).instantiate();
+	OpenXRFbSpatialEntityExtensionWrapper::get_singleton()->create_spatial_anchor(p_transform, &OpenXRFbSpatialEntity::_on_spatial_anchor_created, userdata);
+	return *userdata;
+}
+
+void OpenXRFbSpatialEntity::_on_spatial_anchor_created(XrResult p_result, XrSpace p_space, const XrUuidEXT *p_uuid, void *p_userdata) {
+	Ref<OpenXRFbSpatialEntity> *userdata = (Ref<OpenXRFbSpatialEntity> *)p_userdata;
+	bool success = XR_SUCCEEDED(p_result);
+	if (success) {
+		(*userdata)->space = p_space;
+		(*userdata)->uuid = OpenXRUtilities::uuid_to_string_name(*p_uuid);
+	}
+	(*userdata)->emit_signal("openxr_fb_spatial_entity_created", success);
+	memdelete(userdata);
+}
+
+void OpenXRFbSpatialEntity::save_to_storage(StorageLocation p_location) {
+	ERR_FAIL_COND_MSG(space == XR_NULL_HANDLE, "Underlying spatial entity doesn't exist (yet) or has been destroyed.");
+
+	XrSpaceSaveInfoFB save_info = {
+		XR_TYPE_SPACE_SAVE_INFO_FB, // type
+		nullptr, // next
+		space, // space
+		to_openxr_storage_location(p_location), // location
+		XR_SPACE_PERSISTENCE_MODE_INDEFINITE_FB, // persistenceMode
+	};
+
+	Ref<OpenXRFbSpatialEntity> *userdata = memnew(Ref<OpenXRFbSpatialEntity>(this));
+	OpenXRFbSpatialEntityStorageExtensionWrapper::get_singleton()->save_space(&save_info, OpenXRFbSpatialEntity::_on_save_to_storage, userdata);
+}
+
+void OpenXRFbSpatialEntity::_on_save_to_storage(XrResult p_result, XrSpaceStorageLocationFB p_location, void *p_userdata) {
+	Ref<OpenXRFbSpatialEntity> *userdata = (Ref<OpenXRFbSpatialEntity> *)p_userdata;
+	(*userdata)->emit_signal("openxr_fb_spatial_entity_saved", XR_SUCCEEDED(p_result), from_openxr_storage_location(p_location));
+	memdelete(userdata);
+}
+
+void OpenXRFbSpatialEntity::erase_from_storage(StorageLocation p_location) {
+	ERR_FAIL_COND_MSG(space == XR_NULL_HANDLE, "Underlying spatial entity doesn't exist (yet) or has been destroyed.");
+
+	XrSpaceEraseInfoFB erase_info = {
+		XR_TYPE_SPACE_ERASE_INFO_FB, // type
+		nullptr, // next
+		space, // space
+		to_openxr_storage_location(p_location), // location
+	};
+
+	Ref<OpenXRFbSpatialEntity> *userdata = memnew(Ref<OpenXRFbSpatialEntity>(this));
+	OpenXRFbSpatialEntityStorageExtensionWrapper::get_singleton()->erase_space(&erase_info, OpenXRFbSpatialEntity::_on_save_to_storage, userdata);
+}
+
+void OpenXRFbSpatialEntity::_on_erase_from_storage(XrResult p_result, XrSpaceStorageLocationFB p_location, void *p_userdata) {
+	Ref<OpenXRFbSpatialEntity> *userdata = (Ref<OpenXRFbSpatialEntity> *)p_userdata;
+	(*userdata)->emit_signal("openxr_fb_spatial_entity_erased", XR_SUCCEEDED(p_result), from_openxr_storage_location(p_location));
+	memdelete(userdata);
+}
+
+void OpenXRFbSpatialEntity::destroy() {
+	ERR_FAIL_COND_MSG(space == XR_NULL_HANDLE, "Underlying spatial entity doesn't exist (yet) or has been destroyed.");
+	OpenXRFbSpatialEntityExtensionWrapper *spatial_entity_extension_wrapper = OpenXRFbSpatialEntityExtensionWrapper::get_singleton();
+	if (spatial_entity_extension_wrapper) {
+		spatial_entity_extension_wrapper->untrack_entity(uuid);
+		spatial_entity_extension_wrapper->destroy_space(space);
+		space = XR_NULL_HANDLE;
+	}
+}
+
 XrSpaceStorageLocationFB OpenXRFbSpatialEntity::to_openxr_storage_location(StorageLocation p_location) {
 	switch (p_location) {
 		case OpenXRFbSpatialEntity::STORAGE_LOCAL: {
@@ -324,6 +437,23 @@ XrSpaceStorageLocationFB OpenXRFbSpatialEntity::to_openxr_storage_location(Stora
 		} break;
 		default: {
 			return XR_SPACE_STORAGE_LOCATION_INVALID_FB;
+		}
+	}
+}
+
+OpenXRFbSpatialEntity::StorageLocation OpenXRFbSpatialEntity::from_openxr_storage_location(XrSpaceStorageLocationFB p_location) {
+	switch (p_location) {
+		case XR_SPACE_STORAGE_LOCATION_LOCAL_FB: {
+			return STORAGE_LOCAL;
+		} break;
+		case XR_SPACE_STORAGE_LOCATION_CLOUD_FB: {
+			return STORAGE_CLOUD;
+		} break;
+		case XR_SPACE_STORAGE_LOCATION_INVALID_FB:
+		case XR_SPACE_STORAGE_LOCATION_MAX_ENUM_FB:
+		default: {
+			WARN_PRINT_ONCE(vformat("Received invalid XrSpaceStorageLocationFB: %s.", (int)p_location));
+			return STORAGE_LOCAL;
 		}
 	}
 }
@@ -357,6 +487,7 @@ XrSpaceComponentTypeFB OpenXRFbSpatialEntity::to_openxr_component_type(Component
 		case COMPONENT_TYPE_TRIANGLE_MESH: {
 			return XR_SPACE_COMPONENT_TYPE_TRIANGLE_MESH_META;
 		} break;
+		case COMPONENT_TYPE_UNKNOWN:
 		default: {
 			ERR_FAIL_V_MSG(XR_SPACE_COMPONENT_TYPE_LOCATABLE_FB, vformat("Unknown component type: %s", p_component));
 		}
@@ -394,7 +525,7 @@ OpenXRFbSpatialEntity::ComponentType OpenXRFbSpatialEntity::from_openxr_componen
 		} break;
 		case XR_SPACE_COMPONENT_TYPE_MAX_ENUM_FB:
 		default: {
-			ERR_FAIL_V_MSG(COMPONENT_TYPE_LOCATABLE, vformat("Unknown OpenXR component type: %s", p_component));
+			ERR_FAIL_V_MSG(COMPONENT_TYPE_UNKNOWN, vformat("Unknown OpenXR component type: %s", p_component));
 		}
 	}
 }

--- a/common/src/main/cpp/extensions/openxr_fb_spatial_entity_storage_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_fb_spatial_entity_storage_extension_wrapper.cpp
@@ -108,34 +108,34 @@ bool OpenXRFbSpatialEntityStorageExtensionWrapper::_on_event_polled(const void *
 	return false;
 }
 
-XrAsyncRequestIdFB OpenXRFbSpatialEntityStorageExtensionWrapper::save_space(const XrSpaceSaveInfoFB *p_info, StorageRequestCompleteCallback p_callback, void *p_userdata) {
+bool OpenXRFbSpatialEntityStorageExtensionWrapper::save_space(const XrSpaceSaveInfoFB *p_info, StorageRequestCompleteCallback p_callback, void *p_userdata) {
 	XrAsyncRequestIdFB request_id;
 
 	const XrResult result = xrSaveSpaceFB(SESSION, p_info, &request_id);
 	if (!XR_SUCCEEDED(result)) {
 		WARN_PRINT("xrSaveSpaceFB failed!");
 		WARN_PRINT(get_openxr_api()->get_error_string(result));
-		p_callback(result, p_userdata);
-		return 0;
+		p_callback(result, p_info->location, p_userdata);
+		return false;
 	}
 
 	requests[request_id] = RequestInfo(p_callback, p_userdata);
-	return request_id;
+	return true;
 }
 
-XrAsyncRequestIdFB OpenXRFbSpatialEntityStorageExtensionWrapper::erase_space(const XrSpaceEraseInfoFB *p_info, StorageRequestCompleteCallback p_callback, void *p_userdata) {
+bool OpenXRFbSpatialEntityStorageExtensionWrapper::erase_space(const XrSpaceEraseInfoFB *p_info, StorageRequestCompleteCallback p_callback, void *p_userdata) {
 	XrAsyncRequestIdFB request_id;
 
 	const XrResult result = xrEraseSpaceFB(SESSION, p_info, &request_id);
 	if (!XR_SUCCEEDED(result)) {
 		WARN_PRINT("xrEraseSpaceFB failed!");
 		WARN_PRINT(get_openxr_api()->get_error_string(result));
-		p_callback(result, p_userdata);
-		return 0;
+		p_callback(result, p_info->location, p_userdata);
+		return false;
 	}
 
 	requests[request_id] = RequestInfo(p_callback, p_userdata);
-	return request_id;
+	return true;
 }
 
 void OpenXRFbSpatialEntityStorageExtensionWrapper::on_space_save_complete(const XrEventDataSpaceSaveCompleteFB *event) {
@@ -145,7 +145,7 @@ void OpenXRFbSpatialEntityStorageExtensionWrapper::on_space_save_complete(const 
 	}
 
 	RequestInfo *request = requests.getptr(event->requestId);
-	request->callback(event->result, request->userdata);
+	request->callback(event->result, event->location, request->userdata);
 	requests.erase(event->requestId);
 }
 
@@ -156,6 +156,6 @@ void OpenXRFbSpatialEntityStorageExtensionWrapper::on_space_erase_complete(const
 	}
 
 	RequestInfo *request = requests.getptr(event->requestId);
-	request->callback(event->result, request->userdata);
+	request->callback(event->result, event->location, request->userdata);
 	requests.erase(event->requestId);
 }

--- a/common/src/main/cpp/include/classes/openxr_fb_spatial_anchor_manager.h
+++ b/common/src/main/cpp/include/classes/openxr_fb_spatial_anchor_manager.h
@@ -1,0 +1,115 @@
+/**************************************************************************/
+/*  openxr_fb_spatial_anchor_manager.h                                    */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef OPENXR_FB_SPATIAL_ANCHOR_MANAGER_H
+#define OPENXR_FB_SPATIAL_ANCHOR_MANAGER_H
+
+#include <openxr/openxr.h>
+
+#include <godot_cpp/classes/node.hpp>
+#include <godot_cpp/templates/hash_map.hpp>
+
+#include "classes/openxr_fb_spatial_entity.h"
+
+namespace godot {
+class PackedScene;
+class XROrigin3D;
+class XRAnchor3D;
+
+class OpenXRFbSpatialAnchorManager : public Node {
+	GDCLASS(OpenXRFbSpatialAnchorManager, Node);
+
+	Ref<PackedScene> scene;
+	StringName scene_setup_method = "setup_scene";
+	bool visible = true;
+
+	XROrigin3D *xr_origin = nullptr;
+
+	struct Anchor {
+		ObjectID node;
+		Ref<OpenXRFbSpatialEntity> entity;
+
+		Anchor(Node *p_node, const Ref<OpenXRFbSpatialEntity> &p_entity) {
+			node = p_node->get_instance_id();
+			entity = p_entity;
+		}
+		Anchor() { }
+	};
+	HashMap<StringName, Anchor> anchors;
+
+	void _cleanup_anchors();
+
+	void _track_anchor(const Ref<OpenXRFbSpatialEntity> &p_spatial_entity, bool p_new_anchor);
+
+	void _on_anchor_created(bool p_success, const Transform3D &p_transform, const Ref<OpenXRFbSpatialEntity> &p_spatial_entity);
+	void _on_anchor_load_query_completed(const Array &p_results, const Dictionary &p_anchors_custom_data, OpenXRFbSpatialEntity::StorageLocation p_location, bool p_erase_unknown_anchors);
+	void _on_anchor_track_enable_locatable_completed(bool p_succeeded, OpenXRFbSpatialEntity::ComponentType p_component, bool p_enabled, const Ref<OpenXRFbSpatialEntity> &p_entity, bool p_new_anchor);
+	void _on_anchor_track_enable_storable_completed(bool p_succeeded, OpenXRFbSpatialEntity::ComponentType p_component, bool p_enabled, const Ref<OpenXRFbSpatialEntity> &p_entity, bool p_new_anchor);
+	void _on_anchor_saved(bool p_succeeded, OpenXRFbSpatialEntity::StorageLocation p_location, const Ref<OpenXRFbSpatialEntity> &p_spatial_entity, bool p_new_anchor);
+	void _complete_anchor_setup(const Ref<OpenXRFbSpatialEntity> &p_spatial_entity, bool p_new_anchor);
+
+	void _untrack_anchor(const Ref<OpenXRFbSpatialEntity> &p_spatial_entity);
+
+	void _on_anchor_untrack_enable_storable_completed(bool p_succeeded, OpenXRFbSpatialEntity::ComponentType p_component, bool p_enabled, const Ref<OpenXRFbSpatialEntity> &p_entity);
+	void _on_anchor_erase_completed(bool p_succeeded, OpenXRFbSpatialEntity::StorageLocation p_location, const Ref<OpenXRFbSpatialEntity> &p_entity);
+
+protected:
+	void _notification(int p_what);
+
+	void _on_openxr_session_stopping();
+
+	static void _bind_methods();
+
+public:
+	PackedStringArray _get_configuration_warnings() const override;
+
+	void set_scene(const Ref<PackedScene> &p_scene);
+	Ref<PackedScene> get_scene() const;
+
+	void set_scene_setup_method(const StringName &p_method);
+	StringName get_scene_setup_method() const;
+
+	void set_visible(bool p_visible);
+	bool get_visible() const;
+	void show();
+	void hide();
+
+	void create_anchor(const Transform3D &p_transform, const Dictionary &p_custom_data);
+	void load_anchor(const StringName &p_uuid, const Dictionary &p_custom_data, OpenXRFbSpatialEntity::StorageLocation p_location);
+	void load_anchors(const TypedArray<StringName> &p_uuids, const Dictionary &p_all_custom_data, OpenXRFbSpatialEntity::StorageLocation p_location, bool p_erase_unknown_anchors = false);
+	void track_anchor(const Ref<OpenXRFbSpatialEntity> &p_spatial_entity);
+	void untrack_anchor(const Variant &p_spatial_entity_or_uuid);
+
+	Array get_anchor_uuids() const;
+	XRAnchor3D *get_anchor_node(const StringName &p_uuid) const;
+	Ref<OpenXRFbSpatialEntity> get_spatial_entity(const StringName &p_uuids) const;
+};
+} // namespace godot
+
+#endif

--- a/common/src/main/cpp/include/classes/openxr_fb_spatial_entity.h
+++ b/common/src/main/cpp/include/classes/openxr_fb_spatial_entity.h
@@ -50,6 +50,7 @@ public:
 	};
 
 	enum ComponentType {
+		COMPONENT_TYPE_UNKNOWN = -1,
 		COMPONENT_TYPE_LOCATABLE,
 		COMPONENT_TYPE_STORABLE,
 		COMPONENT_TYPE_SHARABLE,
@@ -64,16 +65,23 @@ public:
 private:
 	XrSpace space = XR_NULL_HANDLE;
 	StringName uuid;
+	Dictionary custom_data;
 
 protected:
 	static void _bind_methods();
 
-	static void _on_set_component_enabled_completed(XrResult p_result, XrSpaceComponentTypeFB p_component, bool p_enabled, void *userdata);
+	static void _on_spatial_anchor_created(XrResult p_result, XrSpace p_space, const XrUuidEXT *p_uuid, void *p_userdata);
+	static void _on_set_component_enabled_completed(XrResult p_result, XrSpaceComponentTypeFB p_component, bool p_enabled, void *p_userdata);
+	static void _on_save_to_storage(XrResult p_result, XrSpaceStorageLocationFB p_location, void *p_userdata);
+	static void _on_erase_from_storage(XrResult p_result, XrSpaceStorageLocationFB p_location, void *p_userdata);
 
 	String _to_string() const;
 
 public:
 	StringName get_uuid() const;
+
+	void set_custom_data(const Dictionary &p_custom_data);
+	Dictionary get_custom_data() const;
 
 	Array get_supported_components() const;
 	bool is_component_supported(ComponentType p_component) const;
@@ -95,7 +103,14 @@ public:
 	MeshInstance3D *create_mesh_instance() const;
 	Node3D *create_collision_shape() const;
 
+	static Ref<OpenXRFbSpatialEntity> create_spatial_anchor(const Transform3D &p_transform);
+
+	void save_to_storage(StorageLocation p_location = STORAGE_LOCAL);
+	void erase_from_storage(StorageLocation p_location = STORAGE_LOCAL);
+	void destroy();
+
 	static XrSpaceStorageLocationFB to_openxr_storage_location(StorageLocation p_location);
+	static StorageLocation from_openxr_storage_location(XrSpaceStorageLocationFB p_location);
 	static XrSpaceComponentTypeFB to_openxr_component_type(ComponentType p_component);
 	static ComponentType from_openxr_component_type(XrSpaceComponentTypeFB p_component);
 

--- a/common/src/main/cpp/include/extensions/openxr_fb_spatial_entity_extension_wrapper.h
+++ b/common/src/main/cpp/include/extensions/openxr_fb_spatial_entity_extension_wrapper.h
@@ -53,7 +53,11 @@ public:
 		return fb_spatial_entity_ext;
 	}
 
+	typedef void (*SpatialAnchorCreatedCallback)(XrResult p_result, XrSpace p_space, const XrUuidEXT *p_uuid, void *p_userdata);
 	typedef void (*SetComponentEnabledCallback)(XrResult p_result, XrSpaceComponentTypeFB p_component, bool p_enabled, void *p_userdata);
+
+	bool create_spatial_anchor(const Transform3D &p_transform, SpatialAnchorCreatedCallback p_callback, void *p_userdata);
+	bool destroy_space(const XrSpace &p_space);
 
 	Vector<XrSpaceComponentTypeFB> get_support_components(const XrSpace &p_space);
 	bool is_component_enabled(const XrSpace &p_space, XrSpaceComponentTypeFB p_component);
@@ -99,6 +103,9 @@ private:
 			(XrSpaceComponentTypeFB), componentType,
 			(XrSpaceComponentStatusFB *), status)
 
+	EXT_PROTO_XRRESULT_FUNC1(xrDestroySpace,
+			(XrSpace), space);
+
 	EXT_PROTO_XRRESULT_FUNC4(xrLocateSpace,
 		(XrSpace), space,
 		(XrSpace), baseSpace,
@@ -106,9 +113,23 @@ private:
 		(XrSpaceLocation *), location)
 
 	bool initialize_fb_spatial_entity_extension(const XrInstance &instance);
+	void on_spatial_anchor_created(const XrEventDataSpatialAnchorCreateCompleteFB *event);
 	void on_set_component_enabled_complete(const XrEventDataSpaceSetStatusCompleteFB *event);
 
 	HashMap<String, bool *> request_extensions;
+
+	struct SpatialAnchorCreationInfo {
+		SpatialAnchorCreatedCallback callback = nullptr;
+		void *userdata = nullptr;
+
+		SpatialAnchorCreationInfo() { }
+
+		SpatialAnchorCreationInfo(SpatialAnchorCreatedCallback p_callback, void *p_userdata) {
+			callback = p_callback;
+			userdata = p_userdata;
+		}
+	};
+	HashMap<XrAsyncRequestIdFB, SpatialAnchorCreationInfo> spatial_anchor_creation_info;
 
 	struct SetComponentEnabledInfo {
 		SetComponentEnabledCallback callback = nullptr;

--- a/common/src/main/cpp/include/extensions/openxr_fb_spatial_entity_storage_extension_wrapper.h
+++ b/common/src/main/cpp/include/extensions/openxr_fb_spatial_entity_storage_extension_wrapper.h
@@ -54,10 +54,10 @@ public:
 
 	static OpenXRFbSpatialEntityStorageExtensionWrapper *get_singleton();
 
-	typedef void (*StorageRequestCompleteCallback)(XrResult p_result, void *p_userdata);
+	typedef void (*StorageRequestCompleteCallback)(XrResult p_result, XrSpaceStorageLocationFB p_location, void *p_userdata);
 
-	XrAsyncRequestIdFB save_space(const XrSpaceSaveInfoFB *p_info, StorageRequestCompleteCallback p_callback, void *p_userdata);
-	XrAsyncRequestIdFB erase_space(const XrSpaceEraseInfoFB *p_info, StorageRequestCompleteCallback p_callback, void *p_userdata);
+	bool save_space(const XrSpaceSaveInfoFB *p_info, StorageRequestCompleteCallback p_callback, void *p_userdata);
+	bool erase_space(const XrSpaceEraseInfoFB *p_info, StorageRequestCompleteCallback p_callback, void *p_userdata);
 
 	OpenXRFbSpatialEntityStorageExtensionWrapper();
 	~OpenXRFbSpatialEntityStorageExtensionWrapper();

--- a/common/src/main/cpp/register_types.cpp
+++ b/common/src/main/cpp/register_types.cpp
@@ -64,6 +64,7 @@
 #include "classes/openxr_fb_passthrough_geometry.h"
 #include "classes/openxr_fb_render_model.h"
 #include "classes/openxr_fb_scene_manager.h"
+#include "classes/openxr_fb_spatial_anchor_manager.h"
 #include "classes/openxr_fb_spatial_entity.h"
 #include "classes/openxr_fb_spatial_entity_query.h"
 #include "classes/openxr_meta_passthrough_color_lut.h"
@@ -142,6 +143,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			ClassDB::register_class<OpenXRFbRenderModel>();
 			ClassDB::register_class<OpenXRFbHandTrackingMesh>();
 			ClassDB::register_class<OpenXRFbSceneManager>();
+			ClassDB::register_class<OpenXRFbSpatialAnchorManager>();
 			ClassDB::register_class<OpenXRFbSpatialEntity>();
 			ClassDB::register_class<OpenXRFbSpatialEntityQuery>();
 			ClassDB::register_class<OpenXRFbPassthroughGeometry>();

--- a/demo/assets/cross-grid-material.tres
+++ b/demo/assets/cross-grid-material.tres
@@ -1,4 +1,4 @@
-[gd_resource type="StandardMaterial3D" load_steps=2 format=4 uid="uid://c2552u4qmlssh"]
+[gd_resource type="StandardMaterial3D" load_steps=2 format=3 uid="uid://c2552u4qmlssh"]
 
 [ext_resource type="Texture2D" uid="uid://br1vofjd2kxhv" path="res://assets/cross-grid.png" id="1_1d3mh"]
 

--- a/demo/assets/wireframe-material.tres
+++ b/demo/assets/wireframe-material.tres
@@ -1,4 +1,4 @@
-[gd_resource type="ShaderMaterial" load_steps=2 format=4 uid="uid://cl3ucly7cjhvy"]
+[gd_resource type="ShaderMaterial" load_steps=2 format=3 uid="uid://cl3ucly7cjhvy"]
 
 [ext_resource type="Shader" path="res://assets/wireframe-material.gdshader" id="1_f1auu"]
 

--- a/demo/main.gd
+++ b/demo/main.gd
@@ -13,6 +13,7 @@ var fb_passthrough
 var meta_color_lut: OpenXRMetaPassthroughColorLut
 var meta_color_lut2: OpenXRMetaPassthroughColorLut
 var lut_tween: Tween
+var selected_spatial_anchor_node: Node3D = null
 
 @onready var left_hand: XRController3D = $XROrigin3D/LeftHand
 @onready var right_hand: XRController3D = $XROrigin3D/RightHand
@@ -20,17 +21,37 @@ var lut_tween: Tween
 @onready var right_hand_mesh: MeshInstance3D = $XROrigin3D/RightHand/RightHandMesh
 @onready var left_controller_model: OpenXRFbRenderModel = $XROrigin3D/LeftHand/LeftControllerFbRenderModel
 @onready var right_controller_model: OpenXRFbRenderModel = $XROrigin3D/RightHand/RightControllerFbRenderModel
+@onready var left_hand_pointer: XRController3D = $XROrigin3D/LeftHandPointer
+@onready var left_hand_pointer_raycast: RayCast3D = $XROrigin3D/LeftHandPointer/RayCast3D
+@onready var scene_pointer_mesh: MeshInstance3D = $XROrigin3D/LeftHandPointer/ScenePointerMesh
+@onready var scene_colliding_mesh: MeshInstance3D = $XROrigin3D/LeftHandPointer/SceneCollidingMesh
 @onready var floor_mesh: MeshInstance3D = $Floor
 @onready var world_environment: WorldEnvironment = $WorldEnvironment
 @onready var scene_manager: OpenXRFbSceneManager = $XROrigin3D/OpenXRFbSceneManager
+@onready var spatial_anchor_manager: OpenXRFbSpatialAnchorManager = $XROrigin3D/OpenXRFbSpatialAnchorManager
 @onready var open_xr_fb_passthrough_geometry: OpenXRFbPassthroughGeometry = %OpenXRFbPassthroughGeometry
 @onready var passthrough_mode_info: Label3D = $XROrigin3D/RightHand/PassthroughModeInfo
 @onready var passthrough_filter_info: Label3D = $XROrigin3D/RightHand/PassthroughFilterInfo
+
+const SPATIAL_ANCHORS_FILE = "user://openxr_fb_spatial_anchors.json"
+const SpatialAnchor = preload("res://spatial_anchor.tscn")
+
+const COLORS = [
+	"#FF0000", # Red
+	"#00FF00", # Green
+	"#0000FF", # Blue
+	"#FFFF00", # Yellow
+	"#00FFFF", # Cyan
+	"#FF00FF", # Magenta
+	"#FF8000", # Orange
+	"#800080", # Purple
+]
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	xr_interface = XRServer.find_interface("OpenXR")
 	if xr_interface and xr_interface.is_initialized():
+		xr_interface.session_begun.connect(self.load_spatial_anchors_from_file)
 		var vp: Viewport = get_viewport()
 		vp.use_xr = true
 
@@ -41,6 +62,53 @@ func _ready():
 	fb_passthrough = Engine.get_singleton("OpenXRFbPassthroughExtensionWrapper")
 	meta_color_lut = OpenXRMetaPassthroughColorLut.create_from_image(color_lut, OpenXRMetaPassthroughColorLut.COLOR_LUT_CHANNELS_RGB)
 	meta_color_lut2 = OpenXRMetaPassthroughColorLut.create_from_image(color_lut2, OpenXRMetaPassthroughColorLut.COLOR_LUT_CHANNELS_RGB)
+
+	randomize()
+
+
+func load_spatial_anchors_from_file() -> void:
+	var file := FileAccess.open(SPATIAL_ANCHORS_FILE, FileAccess.READ)
+	if not file:
+		print ("no file")
+		return
+
+	var json := JSON.new()
+	if json.parse(file.get_as_text()) != OK:
+		print("ERROR: Unable to parse ", SPATIAL_ANCHORS_FILE)
+		return
+
+	if not json.data is Dictionary:
+		print("ERROR: ", SPATIAL_ANCHORS_FILE, " contains invalid data")
+		return
+
+	var anchor_data: Dictionary = json.data
+	if anchor_data.size() > 0:
+		spatial_anchor_manager.load_anchors(anchor_data.keys(), anchor_data, OpenXRFbSpatialEntity.STORAGE_LOCAL, true)
+
+
+func save_spatial_anchors_to_file() -> void:
+	var file := FileAccess.open(SPATIAL_ANCHORS_FILE, FileAccess.WRITE)
+	if not file:
+		print("ERROR: Unable to open file for writing: ", SPATIAL_ANCHORS_FILE)
+		return
+
+	var anchor_data := {}
+	for uuid in spatial_anchor_manager.get_anchor_uuids():
+		var entity: OpenXRFbSpatialEntity = spatial_anchor_manager.get_spatial_entity(uuid)
+		anchor_data[uuid] = entity.custom_data
+
+	file.store_string(JSON.stringify(anchor_data))
+	file.close()
+
+
+func _on_spatial_anchor_tracked(_anchor_node: XRAnchor3D, _spatial_entity: OpenXRFbSpatialEntity, is_new: bool) -> void:
+	if is_new:
+		save_spatial_anchors_to_file()
+
+
+func _on_spatial_anchor_untracked(_anchor_node: XRAnchor3D, _spatial_entity: OpenXRFbSpatialEntity) -> void:
+	save_spatial_anchors_to_file()
+
 
 func enable_passthrough(enable: bool) -> void:
 	if passthrough_enabled == enable:
@@ -58,6 +126,9 @@ func enable_passthrough(enable: bool) -> void:
 			world_environment.environment.background_color = Color(0.0, 0.0, 0.0, 0.0)
 			floor_mesh.visible = false
 			scene_manager.visible = true
+			spatial_anchor_manager.visible = true
+			left_hand_pointer.visible = true
+			left_hand_pointer_raycast.enabled = true
 			if not scene_manager.are_scene_anchors_created():
 				scene_manager.create_scene_anchors()
 		else:
@@ -67,9 +138,13 @@ func enable_passthrough(enable: bool) -> void:
 			world_environment.environment.background_mode = Environment.BG_SKY
 			floor_mesh.visible = true
 			scene_manager.visible = false
+			spatial_anchor_manager.visible = false
+			left_hand_pointer.visible = false
+			left_hand_pointer_raycast.enabled = false
 		passthrough_enabled = enable
 	else:
 		print("Switching to/from passthrough not supported.")
+
 
 func _physics_process(_delta: float) -> void:
 	for hand in OpenXRInterface.HAND_MAX:
@@ -97,6 +172,37 @@ func _physics_process(_delta: float) -> void:
 
 		hand_tracking_source[hand] = source
 
+	if left_hand_pointer.visible:
+		var previous_selected_spatial_anchor_node = selected_spatial_anchor_node
+
+		if left_hand_pointer_raycast.is_colliding():
+			var collision_point: Vector3 = left_hand_pointer_raycast.get_collision_point()
+			scene_colliding_mesh.global_position = collision_point
+
+			var pointer_length: float = (collision_point - left_hand_pointer.global_position).length()
+			scene_pointer_mesh.mesh.size.z = pointer_length
+			scene_pointer_mesh.position.z = -pointer_length / 2.0
+
+			var collider: CollisionObject3D = left_hand_pointer_raycast.get_collider()
+			if collider and collider.get_collision_layer_value(3):
+				selected_spatial_anchor_node = collider
+			else:
+				selected_spatial_anchor_node = null
+		else:
+			scene_pointer_mesh.mesh.size.z = 5
+			scene_pointer_mesh.position.z = -2.5
+			selected_spatial_anchor_node = null
+
+		if previous_selected_spatial_anchor_node != selected_spatial_anchor_node:
+			if previous_selected_spatial_anchor_node:
+				previous_selected_spatial_anchor_node.set_selected(false)
+			if selected_spatial_anchor_node:
+				selected_spatial_anchor_node.set_selected(true)
+				scene_colliding_mesh.visible = false
+			else:
+				scene_colliding_mesh.visible = true
+
+
 func _on_left_hand_button_pressed(name):
 	if name == "menu_button":
 		print("Triggering scene capture")
@@ -105,12 +211,35 @@ func _on_left_hand_button_pressed(name):
 	elif name == "by_button":
 		enable_passthrough(not passthrough_enabled)
 
+	elif name == "trigger_click" and left_hand_pointer.visible:
+		if left_hand_pointer_raycast.is_colliding():
+			if selected_spatial_anchor_node:
+				var anchor_parent = selected_spatial_anchor_node.get_parent()
+				if anchor_parent is XRAnchor3D:
+					spatial_anchor_manager.untrack_anchor(anchor_parent.tracker)
+			else:
+				var anchor_transform := Transform3D()
+				anchor_transform.origin = left_hand_pointer_raycast.get_collision_point()
+
+				var collision_normal: Vector3 = left_hand_pointer_raycast.get_collision_normal()
+				if collision_normal.is_equal_approx(Vector3.UP):
+					anchor_transform.basis = anchor_transform.basis.rotated(Vector3(1.0, 0.0, 0.0), PI / 2.0)
+				elif collision_normal.is_equal_approx(Vector3.DOWN):
+					anchor_transform.basis = anchor_transform.basis.rotated(Vector3(1.0, 0.0, 0.0), -PI / 2.0)
+				else:
+					anchor_transform.basis = Basis.looking_at(left_hand_pointer_raycast.get_collision_normal())
+
+				print ("Attempting to create spatial anchor at: ", anchor_transform)
+				spatial_anchor_manager.create_anchor(anchor_transform, { color = COLORS[randi() % COLORS.size()] })
+
+
 func _on_right_hand_button_pressed(name: String) -> void:
 	match name:
 		"by_button":
 			update_passthrough_mode()
 		"ax_button":
 			update_passthrough_filter()
+
 
 func _on_left_controller_fb_render_model_render_model_loaded() -> void:
 	left_hand_mesh.hide()

--- a/demo/main.tscn
+++ b/demo/main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=24 format=3 uid="uid://cqsodpswgup8w"]
+[gd_scene load_steps=28 format=3 uid="uid://cqsodpswgup8w"]
 
 [ext_resource type="Script" path="res://main.gd" id="1_fsva1"]
 [ext_resource type="PackedScene" uid="uid://c0uv4eu2yjm3b" path="res://viewport_2d_in_3d.tscn" id="2_7whgo"]
@@ -8,6 +8,8 @@
 [ext_resource type="PackedScene" uid="uid://cay8oh2ll7yxi" path="res://assets/test_kun/Test-Kun.fbx" id="4_b317s"]
 [ext_resource type="Image" uid="uid://dqxb16d1fqtrw" path="res://assets/color-lut-inverted-32.png" id="4_pv7hh"]
 [ext_resource type="PackedScene" uid="uid://bwfyi8pgigune" path="res://xr_fb_hand_tracking_aim_demo.tscn" id="5_6bxyh"]
+[ext_resource type="PackedScene" uid="uid://bwo5nq0clfe3c" path="res://scene_global_mesh.tscn" id="5_7ikgf"]
+[ext_resource type="PackedScene" uid="uid://dsfd7xrm6o50p" path="res://spatial_anchor.tscn" id="5_g7mio"]
 [ext_resource type="Material" uid="uid://bdwh0vc86hsdb" path="res://assets/hand_silhouette_outline_mat.tres" id="7_tpkib"]
 
 [sub_resource type="Gradient" id="Gradient_yvg3n"]
@@ -54,6 +56,13 @@ size = Vector3(0.1, 0.1, 0.1)
 [sub_resource type="SphereMesh" id="SphereMesh_5gcab"]
 radius = 0.025
 height = 0.05
+
+[sub_resource type="BoxMesh" id="BoxMesh_d27jm"]
+size = Vector3(0.01, 0.01, 5)
+
+[sub_resource type="SphereMesh" id="SphereMesh_kdpqm"]
+radius = 0.01
+height = 0.02
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_k604q"]
 
@@ -144,10 +153,23 @@ tracker = &"/user/eyes_ext"
 transform = Transform3D(1, 0, 0, 0, -0.0133513, 0.999911, 0, -0.999911, -0.0133513, 0, 0, -1.18886)
 mesh = SubResource("SphereMesh_5gcab")
 
-[node name="OpenXRFbSceneManager" type="OpenXRFbSceneManager" parent="XROrigin3D"]
-default_scene = ExtResource("4_3u3ah")
-auto_create = false
+[node name="LeftHandPointer" type="XRController3D" parent="XROrigin3D"]
 visible = false
+tracker = &"left_hand"
+pose = &"aim"
+
+[node name="ScenePointerMesh" type="MeshInstance3D" parent="XROrigin3D/LeftHandPointer"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -2.5)
+mesh = SubResource("BoxMesh_d27jm")
+
+[node name="SceneCollidingMesh" type="MeshInstance3D" parent="XROrigin3D/LeftHandPointer"]
+mesh = SubResource("SphereMesh_kdpqm")
+
+[node name="RayCast3D" type="RayCast3D" parent="XROrigin3D/LeftHandPointer"]
+enabled = false
+target_position = Vector3(0, 0, -10)
+collision_mask = 6
+collide_with_areas = true
 
 [node name="LeftHandTracker" type="XRNode3D" parent="XROrigin3D"]
 tracker = &"/user/hand_tracker/left"
@@ -162,6 +184,8 @@ tracker = &"/user/hand_tracker/right"
 
 [node name="RightHandModel" type="OpenXRFbHandTrackingMesh" parent="XROrigin3D/RightHandTracker"]
 hand = 1
+material = ExtResource("7_tpkib")
+use_scale_override = false
 bones/0/name = "RightPalm"
 bones/1/name = "RightHand"
 bones/2/name = "RightThumbMetacarpal"
@@ -188,10 +212,19 @@ bones/22/name = "RightLittleProximal"
 bones/23/name = "RightLittleIntermediate"
 bones/24/name = "RightLittleDistal"
 bones/25/name = "RightLittleTip"
-material = ExtResource("7_tpkib")
 
 [node name="RightXRHandModifier3D" type="XRHandModifier3D" parent="XROrigin3D/RightHandTracker/RightHandModel"]
 hand_tracker = &"/user/hand_tracker/right"
+
+[node name="OpenXRFbSceneManager" type="OpenXRFbSceneManager" parent="XROrigin3D"]
+default_scene = ExtResource("4_3u3ah")
+auto_create = false
+visible = false
+scenes/global_mesh = ExtResource("5_7ikgf")
+
+[node name="OpenXRFbSpatialAnchorManager" type="OpenXRFbSpatialAnchorManager" parent="XROrigin3D"]
+scene = ExtResource("5_g7mio")
+visible = false
 
 [node name="Floor" type="MeshInstance3D" parent="."]
 mesh = SubResource("PlaneMesh_mjcgt")
@@ -205,7 +238,7 @@ tracker = &"/user/body_tracker"
 [node name="Test-Kun" parent="Floor/AvatarOffset/Avatar" instance=ExtResource("4_b317s")]
 transform = Transform3D(-1, 0, 8.74228e-08, 0, 1, 0, -8.74228e-08, 0, -1, 0, 0, 0)
 
-[node name="XRBodyModifier3D" type="XRBodyModifier3D" parent="Floor/AvatarOffset/Avatar/Test-Kun/Armature/GeneralSkeleton" index="3"]
+[node name="XRBodyModifier3D" type="XRBodyModifier3D" parent="Floor/AvatarOffset/Avatar/Test-Kun/Armature/GeneralSkeleton" index="2"]
 transform = Transform3D(1, 0, 1.74846e-07, 0, 1, 0, -1.74846e-07, 0, 1, -8.74228e-08, 0, -1)
 bone_update = 1
 
@@ -225,5 +258,7 @@ transform = Transform3D(0.707107, 0, 0.707107, 0, 1, 0, -0.707107, 0, 0.707107, 
 [connection signal="openxr_fb_render_model_loaded" from="XROrigin3D/RightHand/RightControllerFbRenderModel" to="." method="_on_right_controller_fb_render_model_render_model_loaded"]
 [connection signal="openxr_fb_scene_capture_completed" from="XROrigin3D/OpenXRFbSceneManager" to="." method="_on_scene_manager_scene_capture_completed"]
 [connection signal="openxr_fb_scene_data_missing" from="XROrigin3D/OpenXRFbSceneManager" to="." method="_on_scene_manager_scene_data_missing"]
+[connection signal="openxr_fb_spatial_anchor_tracked" from="XROrigin3D/OpenXRFbSpatialAnchorManager" to="." method="_on_spatial_anchor_tracked"]
+[connection signal="openxr_fb_spatial_anchor_untracked" from="XROrigin3D/OpenXRFbSpatialAnchorManager" to="." method="_on_spatial_anchor_untracked"]
 
 [editable path="Floor/AvatarOffset/Avatar/Test-Kun"]

--- a/demo/project.godot
+++ b/demo/project.godot
@@ -19,6 +19,12 @@ config/icon="res://icon.svg"
 
 settings/stdout/verbose_stdout=true
 
+[layer_names]
+
+3d_physics/layer_1="Virtual Environment"
+3d_physics/layer_2="Scene Understanding"
+3d_physics/layer_3="Spatial Anchors"
+
 [rendering]
 
 renderer/rendering_method="gl_compatibility"
@@ -28,6 +34,7 @@ textures/vram_compression/import_etc2_astc=true
 [xr]
 
 openxr/enabled=true
+openxr/reference_space=1
 openxr/extensions/eye_gaze_interaction=true
 shaders/enabled=true
 openxr/extensions/hand_tracking_aim=true

--- a/demo/scene_anchor.tscn
+++ b/demo/scene_anchor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=2 format=4 uid="uid://bcjp8kcgde4cs"]
+[gd_scene load_steps=2 format=3 uid="uid://bcjp8kcgde4cs"]
 
 [ext_resource type="Script" path="res://scene_anchor.gd" id="1_l6xwj"]
 
@@ -10,3 +10,4 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0.01)
 text = "Label"
 
 [node name="StaticBody3D" type="StaticBody3D" parent="."]
+collision_layer = 2

--- a/demo/scene_global_mesh.tscn
+++ b/demo/scene_global_mesh.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=2 format=4 uid="uid://bwo5nq0clfe3c"]
+[gd_scene load_steps=2 format=3 uid="uid://bwo5nq0clfe3c"]
 
 [ext_resource type="Script" path="res://scene_global_mesh.gd" id="1_bmuti"]
 
@@ -6,3 +6,4 @@
 script = ExtResource("1_bmuti")
 
 [node name="StaticBody3D" type="StaticBody3D" parent="."]
+collision_layer = 2

--- a/demo/spatial_anchor.gd
+++ b/demo/spatial_anchor.gd
@@ -1,0 +1,25 @@
+extends Area3D
+
+@onready var mesh_instance: MeshInstance3D = $MeshInstance3D
+
+var color: Color
+var selected := false
+
+func setup_scene(spatial_entity: OpenXRFbSpatialEntity) -> void:
+	var data: Dictionary = spatial_entity.custom_data
+
+	color = Color(data.get('color', '#FFFFFF'))
+
+	var material: StandardMaterial3D = mesh_instance.get_surface_override_material(0)
+	material.albedo_color = color
+	mesh_instance.set_surface_override_material(0, material)
+
+func set_selected(p_selected: bool) -> void:
+	selected = p_selected
+
+	var material: StandardMaterial3D = mesh_instance.get_surface_override_material(0)
+	if selected:
+		material.albedo_color = Color(0.5, 0.5, 0.5)
+	else:
+		material.albedo_color = color
+	mesh_instance.set_surface_override_material(0, material)

--- a/demo/spatial_anchor.tscn
+++ b/demo/spatial_anchor.tscn
@@ -1,0 +1,30 @@
+[gd_scene load_steps=5 format=3 uid="uid://dsfd7xrm6o50p"]
+
+[ext_resource type="Script" path="res://spatial_anchor.gd" id="1_dengx"]
+
+[sub_resource type="CylinderMesh" id="CylinderMesh_gayi3"]
+top_radius = 0.0
+bottom_radius = 0.1
+height = 0.2
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_bat7g"]
+resource_local_to_scene = true
+albedo_color = Color(0, 0, 1, 1)
+
+[sub_resource type="CylinderShape3D" id="CylinderShape3D_d2ows"]
+height = 0.2
+radius = 0.1
+
+[node name="SpatialAnchor" type="Area3D"]
+collision_layer = 4
+collision_mask = 0
+script = ExtResource("1_dengx")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, -0.1)
+mesh = SubResource("CylinderMesh_gayi3")
+surface_material_override/0 = SubResource("StandardMaterial3D_bat7g")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, -0.1)
+shape = SubResource("CylinderShape3D_d2ows")


### PR DESCRIPTION
This is a follow-up to PR https://github.com/GodotVR/godot_openxr_vendors/pull/107 which added support for scene anchors (aka the data from Meta's scene understanding).

This PR adds the ability for the developer to create and manage their own spatial anchors.

Here's a screenshot from the demo:

![org godotengine openxr vendors demo-20240415-165709](https://github.com/GodotVR/godot_openxr_vendors/assets/191561/2b4da7cd-4c7a-48dd-b82f-ff3ef7f29327)

When you switch into passthrough mode, you can press the trigger on a surface from scene understanding (aka a scene anchor) and place a spatial anchor, which is represented by a colored cone (the color is selected randomly). If you point at an existing spatial anchor, pressing the trigger will remove it. If you close and open the app again, the spatial anchors will be restored with the same colors they had previously.

This is done via a new node called `OpenXRFbSpatialAnchorManager` which works a lot like the `OpenXRFbSceneManager` which was added in PR https://github.com/GodotVR/godot_openxr_vendors/pull/107

Here's how it works:

- You can create an anchor by calling `create_anchor(transform: Transform3D, custom_data: Dictionary)` on the node. It won't be created immediately - it's an asynchronous operation. But when it is, the `openxr_fb_spatial_anchor_tracked` signal will be emitted, which will give the developer an `XRAnchor3D` and the `OpenXRFbSpatialEntity` object (with the `custom_data` stashed in it). The `custom_data` can be used to store application-specific data about what the anchor actually is, ie what object the player is actually placing in the world (on the OpenXR side it only has a UUID and a location).
- I suspect a very common case will be creating an instance of a particular scene as a child of the `XRAnchor3D`. So, rather than connecting to the `openxr_fb_spatial_anchor_tracked` signal and instantiating the scene manually, the developer can optionally set the `scene` property, which will be automatically instantiated, and have a method called on it with the `OpenXRFbSpatialEntity`. (This is very similar to how `OpenXRFbSceneManager` works!) Here they can grab the `custom_data` and use it to initialize the scene - the demo uses this to setup the anchor with the correct color.
- ~~By using the `persist_in_local_file` and `local_file_path`, the `OpenXRFbSpatialAnchorManager` node will save the anchors to a JSON file (along with their `custom_data`), and then automatically load them from the file when the application starts up again. While it's possible to query OpenXR for all pre-existing anchors, all you get is the UUIDs and positions, you don't get any information about what the anchor is meant to be in the application. That's why we need to also store these in a JSON file along with the `custom_data`, which is where the developer would put that information.~~
- The `openxr_fb_spatial_anchor_tracked` signal is also emitted for anchors that are loaded (not just created), which allows the developer to handle new and existing anchors at the same time.
- ~~If the developer doesn't want any of the automatic file saving/loading or other automatic features, they can disable those via properties on the node, which gives them the freedom to do something more custom if they want.~~

 **UPDATE:** _The saving/loading from file functionality was removed from the node, and moved into the demo project. Developers will need to implement their own loading/saving, but once they hand the data off to the node, it should take care of everything else._

Here's the properties in the editor:

![Selection_149](https://github.com/GodotVR/godot_openxr_vendors/assets/191561/031036fe-8463-4d1c-ac9c-8ef495436e00)

