### PR TITLE
Simplify the plugin's build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,28 @@ the `godot-cpp` submodule:
 git submodule update --init
 ```
 
-### Building the Godot-CPP bindings
+### Short build instructions
+
+The following build command run all the build commands mentioned in the 'Expanded build instructions' section below.
+
+#### Linux / MacOS
+Run the following command from the root directory to build the plugin artifacts:
+```
+./gradlew buildPlugin
+```
+
+#### Windows
+Run the following command from the root directory to build the plugin artifacts:
+```
+gradlew.bat buildPlugin
+```
+
+### Expanded build instructions
+
+These are all the build commands that are being run by the `gradlew buildPlugin` command.
+They are detailed here for those needing to customize / troubleshoot their build process.
+
+#### Building the Godot-CPP bindings
 Build the Android C++ bindings using the following commands.
 ```
 cd thirdparty/godot-cpp
@@ -30,22 +51,20 @@ scons platform=android target=template_release arch=x86_64 custom_api_file=../go
 When the command is completed, you should have static libraries stored in `thirdparty/godot-cpp/bin`
 that will be used for compilation by the plugin.
 
-### Building the Plugin
+#### Building the Plugin
 Run the following command from the root directory to generate the editor gdextension plugin:
 ```
 scons target=template_debug custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json
 scons target=template_release custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json
-scons target=template_debug platform=android custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json
-scons target=template_release platform=android custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json
 ```
 
-#### Linux / MacOS
+##### Linux / MacOS
 Run the following command from the root directory to build the vendors `AAR` Android binaries:
 ```
 ./gradlew build
 ```
 
-#### Windows
+##### Windows
 Run the following command from the root directory to build the vendors `AAR` Android binaries:
 ```
 gradlew.bat build

--- a/build.gradle
+++ b/build.gradle
@@ -27,4 +27,102 @@ version = getReleaseVersion()
 
 task clean(type: Delete) {
     delete rootProject.buildDir
+
+    dependsOn 'cleanAddon'
+
+    dependsOn ':godotopenxrkhronos:clean'
+    dependsOn ':godotopenxrlynx:clean'
+    dependsOn ':godotopenxrmeta:clean'
+    dependsOn ':godotopenxrpico:clean'
+}
+
+/**
+ * Clean the artifacts for the 'godotopenxrvendors' addon
+ */
+task cleanAddon(type: Delete) {
+    // Delete the bin directory for the addon
+    delete("demo/addons/godotopenxrvendors/.bin")
+}
+
+/**
+ * Build the 'godotopenxrvendors' plugin
+ */
+task buildPlugin {
+    // Generate the editor gdextension binaries
+    dependsOn ':buildSconsArtifacts'
+
+    dependsOn ":godotopenxrkhronos:build"
+    dependsOn ":godotopenxrlynx:build"
+    dependsOn ":godotopenxrmeta:build"
+    dependsOn ":godotopenxrpico:build"
+}
+
+/**
+ * Build the scons artifacts for the project
+ */
+task buildSconsArtifacts {
+    // Find scons' executable path
+    File sconsExecutableFile = null
+    def sconsName = "scons"
+    def sconsExts = (org.gradle.internal.os.OperatingSystem.current().isWindows()
+            ? [".bat", ".cmd", ".ps1", ".exe"]
+            : [""])
+    logger.debug("Looking for $sconsName executable path")
+    for (ext in sconsExts) {
+        String sconsNameExt = sconsName + ext
+        logger.debug("Checking $sconsNameExt")
+        sconsExecutableFile = org.gradle.internal.os.OperatingSystem.current().findInPath(sconsNameExt)
+        if (sconsExecutableFile != null) {
+            // We're done!
+            break
+        }
+        // Check all the options in path
+        List<File> allOptions = org.gradle.internal.os.OperatingSystem.current().findAllInPath(sconsNameExt)
+        if (!allOptions.isEmpty()) {
+            // Pick the first option and we're done!
+            sconsExecutableFile = allOptions.get(0)
+            break
+        }
+    }
+    if (sconsExecutableFile == null) {
+        throw new GradleException("Unable to find executable path for the '$sconsName' command.")
+    } else {
+        logger.debug("Found executable path for $sconsName: ${sconsExecutableFile.absolutePath}")
+    }
+
+    // Build the Godot-CPP bindings
+    tasks.create(name: "buildGodotCPPArm64Debug", type: Exec) {
+        executable sconsExecutableFile.absolutePath
+        args "--directory=thirdparty/godot-cpp", "platform=android", "target=template_debug", "arch=arm64", "custom_api_file=../godot_cpp_gdextension_api/extension_api.json"
+    }
+    tasks.create(name: "buildGodotCPPArm64Release", type: Exec) {
+        executable sconsExecutableFile.absolutePath
+        args "--directory=thirdparty/godot-cpp", "platform=android", "target=template_release", "arch=arm64", "custom_api_file=../godot_cpp_gdextension_api/extension_api.json"
+    }
+    tasks.create(name: "buildGodotCPPX86_64Debug", type: Exec) {
+        executable sconsExecutableFile.absolutePath
+        args "--directory=thirdparty/godot-cpp", "platform=android", "target=template_debug", "arch=x86_64", "custom_api_file=../godot_cpp_gdextension_api/extension_api.json"
+    }
+    tasks.create(name: "buildGodotCPPX86_64Release", type: Exec) {
+        executable sconsExecutableFile.absolutePath
+        args "--directory=thirdparty/godot-cpp", "platform=android", "target=template_release", "arch=x86_64", "custom_api_file=../godot_cpp_gdextension_api/extension_api.json"
+    }
+
+    dependsOn 'buildGodotCPPArm64Debug'
+    dependsOn 'buildGodotCPPArm64Release'
+    dependsOn 'buildGodotCPPX86_64Debug'
+    dependsOn 'buildGodotCPPX86_64Release'
+
+    // Creating gradle task to generate the editor gdextension binaries
+    tasks.create(name: "buildGodotOpenXRVendorsDebugGDExtension", type: Exec) {
+        executable sconsExecutableFile.absolutePath
+        args "--directory=.", "target=template_debug", "custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json"
+    }
+    tasks.create(name: "buildGodotOpenXRVendorsReleaseGDExtension", type: Exec) {
+        executable sconsExecutableFile.absolutePath
+        args "--directory=.", "target=template_release", "custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json"
+    }
+
+    dependsOn 'buildGodotOpenXRVendorsDebugGDExtension'
+    dependsOn 'buildGodotOpenXRVendorsReleaseGDExtension'
 }

--- a/godotopenxrkhronos/build.gradle
+++ b/godotopenxrkhronos/build.gradle
@@ -67,6 +67,15 @@ dependencies {
     compileOnly libraries.godotAndroidLib
 }
 
+task cleanAssets(type: Delete) {
+    // Delete the 'addons' directory in the 'assets' folder
+    delete("src/main/assets/addons")
+}
+
+task cleanCxx(type: Delete) {
+    delete(".cxx")
+}
+
 task copyDebugAARToAddons(type: Copy) {
     from 'build/outputs/aar'
     include 'godotopenxrkhronos-debug.aar'
@@ -91,3 +100,5 @@ preBuild.dependsOn(copyGdExtensionConfigToAssets)
 assemble.dependsOn(copyGdExtensionConfigToAssets)
 assemble.finalizedBy(copyDebugAARToAddons)
 assemble.finalizedBy(copyReleaseAARToAddons)
+clean.dependsOn(cleanAssets)
+clean.dependsOn(cleanCxx)

--- a/godotopenxrlynx/build.gradle
+++ b/godotopenxrlynx/build.gradle
@@ -67,6 +67,15 @@ dependencies {
     compileOnly libraries.godotAndroidLib
 }
 
+task cleanAssets(type: Delete) {
+    // Delete the 'addons' directory in the 'assets' folder
+    delete("src/main/assets/addons")
+}
+
+task cleanCxx(type: Delete) {
+    delete(".cxx")
+}
+
 task copyDebugAARToAddons(type: Copy) {
     from 'build/outputs/aar'
     include 'godotopenxrlynx-debug.aar'
@@ -91,3 +100,5 @@ preBuild.dependsOn(copyGdExtensionConfigToAssets)
 assemble.dependsOn(copyGdExtensionConfigToAssets)
 assemble.finalizedBy(copyDebugAARToAddons)
 assemble.finalizedBy(copyReleaseAARToAddons)
+clean.dependsOn(cleanAssets)
+clean.dependsOn(cleanCxx)

--- a/godotopenxrmeta/build.gradle
+++ b/godotopenxrmeta/build.gradle
@@ -67,6 +67,15 @@ dependencies {
     compileOnly libraries.godotAndroidLib
 }
 
+task cleanAssets(type: Delete) {
+    // Delete the 'addons' directory in the 'assets' folder
+    delete("src/main/assets/addons")
+}
+
+task cleanCxx(type: Delete) {
+    delete(".cxx")
+}
+
 task copyDebugAARToAddons(type: Copy) {
     from 'build/outputs/aar'
     include 'godotopenxrmeta-debug.aar'
@@ -91,3 +100,5 @@ preBuild.dependsOn(copyGdExtensionConfigToAssets)
 assemble.dependsOn(copyGdExtensionConfigToAssets)
 assemble.finalizedBy(copyDebugAARToAddons)
 assemble.finalizedBy(copyReleaseAARToAddons)
+clean.dependsOn(cleanAssets)
+clean.dependsOn(cleanCxx)

--- a/godotopenxrpico/build.gradle
+++ b/godotopenxrpico/build.gradle
@@ -67,6 +67,15 @@ dependencies {
     compileOnly libraries.godotAndroidLib
 }
 
+task cleanAssets(type: Delete) {
+    // Delete the 'addons' directory in the 'assets' folder
+    delete("src/main/assets/addons")
+}
+
+task cleanCxx(type: Delete) {
+    delete(".cxx")
+}
+
 task copyDebugAARToAddons(type: Copy) {
     from 'build/outputs/aar'
     include 'godotopenxrpico-debug.aar'
@@ -91,3 +100,5 @@ preBuild.dependsOn(copyGdExtensionConfigToAssets)
 assemble.dependsOn(copyGdExtensionConfigToAssets)
 assemble.finalizedBy(copyDebugAARToAddons)
 assemble.finalizedBy(copyReleaseAARToAddons)
+clean.dependsOn(cleanAssets)
+clean.dependsOn(cleanCxx)


### PR DESCRIPTION
- Update the `gradlew clean` command to have it remove the generated `.cxx` build directories
- Add a `gradlew buildPlugin` command that runs all the individual build commands