### PR TITLE
Hand Silhouette Outline shader/material for Meta Hand-tracking Model

### DIFF
--- a/demo/assets/hand_outline.gdshader
+++ b/demo/assets/hand_outline.gdshader
@@ -1,0 +1,20 @@
+shader_type spatial;
+
+render_mode cull_front, unshaded;
+uniform vec3 outline_color : source_color = vec3(0.26, 0.34, 0.40);
+uniform float outline_width : hint_range(0.0, 2.5, 0.01) = 1.6;
+uniform float max_opacity : hint_range(0.0, 1.0, 0.01) = 0.95;
+uniform float fade_offset : hint_range(0.0, 0.1, 0.001) = 0.055;
+uniform float fade_sharpness : hint_range(0.0, 35.0, 0.01) = 32.00;
+
+varying vec3 vertex_pos;
+
+void vertex() {
+	VERTEX += NORMAL * (0.001 * outline_width);
+	vertex_pos = VERTEX;
+}
+
+void fragment() {
+	ALBEDO = outline_color;
+	ALPHA = (clamp((vertex_pos.y + fade_offset) * fade_sharpness, 0.00, 0.95));
+}

--- a/demo/assets/hand_silhouette.gdshader
+++ b/demo/assets/hand_silhouette.gdshader
@@ -1,0 +1,18 @@
+shader_type spatial;
+
+render_mode unshaded, cull_disabled;
+uniform vec3 silhouette_color : source_color = vec3(0.071, 0.068, 0.104);
+uniform float max_opacity : hint_range(0.0, 1.0, 0.01) = 0.95;
+uniform float fade_offset : hint_range(0.0, 0.1, 0.001) = 0.055;
+uniform float fade_sharpness : hint_range(0.0, 35.0, 0.01) = 28.00;
+
+varying vec3 vertex_pos;
+
+void vertex() {
+	vertex_pos = VERTEX;
+}
+
+void fragment() {
+	ALBEDO = silhouette_color;
+	ALPHA = (clamp((vertex_pos.y + fade_offset) * fade_sharpness, 0.00, max_opacity));
+}

--- a/demo/assets/hand_silhouette_outline_mat.tres
+++ b/demo/assets/hand_silhouette_outline_mat.tres
@@ -1,0 +1,22 @@
+[gd_resource type="ShaderMaterial" load_steps=4 format=4 uid="uid://bdwh0vc86hsdb"]
+
+[ext_resource type="Shader" path="res://assets/hand_outline.gdshader" id="1_wpjxj"]
+[ext_resource type="Shader" path="res://assets/hand_silhouette.gdshader" id="2_dvpns"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_42j4f"]
+render_priority = 0
+shader = ExtResource("1_wpjxj")
+shader_parameter/outline_color = Color(0.26, 0.34, 0.4, 1)
+shader_parameter/outline_width = 1.6
+shader_parameter/max_opacity = 0.95
+shader_parameter/fade_offset = 0.055
+shader_parameter/fade_sharpness = 32.0
+
+[resource]
+render_priority = 1
+next_pass = SubResource("ShaderMaterial_42j4f")
+shader = ExtResource("2_dvpns")
+shader_parameter/silhouette_color = Color(0.071, 0.068, 0.104, 1)
+shader_parameter/max_opacity = 0.95
+shader_parameter/fade_offset = 0.055
+shader_parameter/fade_sharpness = 28.0

--- a/demo/main.tscn
+++ b/demo/main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=23 format=3 uid="uid://cqsodpswgup8w"]
+[gd_scene load_steps=24 format=3 uid="uid://cqsodpswgup8w"]
 
 [ext_resource type="Script" path="res://main.gd" id="1_fsva1"]
 [ext_resource type="PackedScene" uid="uid://c0uv4eu2yjm3b" path="res://viewport_2d_in_3d.tscn" id="2_7whgo"]
@@ -8,6 +8,7 @@
 [ext_resource type="PackedScene" uid="uid://cay8oh2ll7yxi" path="res://assets/test_kun/Test-Kun.fbx" id="4_b317s"]
 [ext_resource type="Image" uid="uid://dqxb16d1fqtrw" path="res://assets/color-lut-inverted-32.png" id="4_pv7hh"]
 [ext_resource type="PackedScene" uid="uid://bwfyi8pgigune" path="res://xr_fb_hand_tracking_aim_demo.tscn" id="5_6bxyh"]
+[ext_resource type="Material" uid="uid://bdwh0vc86hsdb" path="res://assets/hand_silhouette_outline_mat.tres" id="7_tpkib"]
 
 [sub_resource type="Gradient" id="Gradient_yvg3n"]
 offsets = PackedFloat32Array(0, 0.484615, 1)
@@ -152,6 +153,7 @@ visible = false
 tracker = &"/user/hand_tracker/left"
 
 [node name="LeftHandModel" type="OpenXRFbHandTrackingMesh" parent="XROrigin3D/LeftHandTracker"]
+material = ExtResource("7_tpkib")
 
 [node name="LeftXRHandModifier3D" type="XRHandModifier3D" parent="XROrigin3D/LeftHandTracker/LeftHandModel"]
 
@@ -186,6 +188,7 @@ bones/22/name = "RightLittleProximal"
 bones/23/name = "RightLittleIntermediate"
 bones/24/name = "RightLittleDistal"
 bones/25/name = "RightLittleTip"
+material = ExtResource("7_tpkib")
 
 [node name="RightXRHandModifier3D" type="XRHandModifier3D" parent="XROrigin3D/RightHandTracker/RightHandModel"]
 hand_tracker = &"/user/hand_tracker/right"


### PR DESCRIPTION
I created a simple Hand Silhouette Outline shader and material for the Meta Hand-tracking Model (Can be used with adjusted values for other hand models as well, but I only used and tested it on the meta hand model.)

It was inspired by the hand shader found in the meta menu.

![handtrackingshader-ezgif com-optimize](https://github.com/GodotVR/godot_openxr_vendors/assets/9072324/1ecc5cc4-765b-4ea3-bbda-d05ea23f1a31)

The shader works in 2 passes, with the first one taking priority and a second one with lower priority being responsible for the outline. Shader properties are available to customize the fade, colors, opacity and outline width.

![image](https://github.com/GodotVR/godot_openxr_vendors/assets/9072324/13eab9c1-9c08-492e-8ca5-dcc6586caed1)
