### PR TITLE
Update to the GDExtension API containing XRTracker

### DIFF
--- a/common/src/main/cpp/classes/openxr_fb_hand_tracking_mesh.cpp
+++ b/common/src/main/cpp/classes/openxr_fb_hand_tracking_mesh.cpp
@@ -54,7 +54,8 @@ void OpenXRFbHandTrackingMesh::setup_hand_mesh(Hand p_hand) {
 
 	XRHandModifier3D *parent = Object::cast_to<XRHandModifier3D>(get_parent());
 	if (parent) {
-		parent->set_target(parent->get_path_to(skeleton));
+		// TODO: Fix node relationship
+		//parent->set_target(parent->get_path_to(skeleton));
 	}
 }
 

--- a/common/src/main/cpp/extensions/openxr_fb_face_tracking_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_fb_face_tracking_extension_wrapper.cpp
@@ -113,14 +113,14 @@ void OpenXRFbFaceTrackingExtensionWrapper::_on_session_created(uint64_t instance
 	}
 
 	// Create the face-tracker handle
-    XrFaceTrackingDataSource2FB dataSources[2] = {
-        XR_FACE_TRACKING_DATA_SOURCE2_VISUAL_FB,
-        XR_FACE_TRACKING_DATA_SOURCE2_AUDIO_FB
-    };
+	XrFaceTrackingDataSource2FB dataSources[2] = {
+		XR_FACE_TRACKING_DATA_SOURCE2_VISUAL_FB,
+		XR_FACE_TRACKING_DATA_SOURCE2_AUDIO_FB
+	};
 	XrFaceTrackerCreateInfo2FB createInfo2 = { XR_TYPE_FACE_TRACKER_CREATE_INFO2_FB };
 	createInfo2.faceExpressionSet = XR_FACE_EXPRESSION_SET2_DEFAULT_FB;
-    createInfo2.requestedDataSourceCount = 2;
-    createInfo2.requestedDataSources = dataSources;
+	createInfo2.requestedDataSourceCount = 2;
+	createInfo2.requestedDataSources = dataSources;
 	XrResult result = xrCreateFaceTracker2FB(SESSION, &createInfo2, &face_tracker2);
 	if (XR_FAILED(result)) {
 		UtilityFunctions::print("Failed to create face-tracker handle: ", result);
@@ -130,6 +130,7 @@ void OpenXRFbFaceTrackingExtensionWrapper::_on_session_created(uint64_t instance
 	// Construct the XRFaceTracker if necessary
 	if (xr_face_tracker.is_null()) {
 		xr_face_tracker.instantiate();
+		xr_face_tracker->set_tracker_name("/user/face_tracker");
 	}
 }
 
@@ -150,7 +151,7 @@ void OpenXRFbFaceTrackingExtensionWrapper::_on_session_destroyed() {
 	if (xr_face_tracker_registered) {
 		XRServer *xr_server = XRServer::get_singleton();
 		if (xr_server) {
-			xr_server->remove_face_tracker("/user/head");
+			xr_server->remove_tracker(xr_face_tracker);
 		}
 	}
 	xr_face_tracker_registered = false;
@@ -347,7 +348,7 @@ void OpenXRFbFaceTrackingExtensionWrapper::_on_process() {
 	if (!xr_face_tracker_registered) {
 		XRServer *xr_server = XRServer::get_singleton();
 		if (xr_server) {
-			xr_server->add_face_tracker("/user/head", xr_face_tracker);
+			xr_server->add_tracker(xr_face_tracker);
 			xr_face_tracker_registered = true;
 		}
 	}

--- a/thirdparty/godot_cpp_gdextension_api/README.md
+++ b/thirdparty/godot_cpp_gdextension_api/README.md
@@ -4,8 +4,7 @@ This directory contains the API JSON for
 [**Godot Engine**](https://github.com/godotengine/godot)'s *GDExtensions* API.
 
 ## Current API version
-- **Godot Engine v4.3.dev5.official**
-- [commit 89f70e98d209563abb4dbc1f8cd5d76c81eb7940](https://github.com/godotengine/godot/commit/89f70e98d209563abb4dbc1f8cd5d76c81eb7940)
+- [commit 7529c0bec597d70bc61975a82063bb5112ac8879](https://github.com/godotengine/godot/commit/7529c0bec597d70bc61975a82063bb5112ac8879)
 
 ## Updating API
 


### PR DESCRIPTION
This PR updates the GDExtension API to the version containing the new XRTracker reorganization. This PR just gets nodes compiling, and subsequent work will be needed to restore functionality - such as the node-restructure needed for hand meshes.