### PR TITLE
Add support for sharing and bulk saving (and sharing) of spatial anchors

### DIFF
--- a/common/src/main/cpp/classes/openxr_fb_spatial_entity_batch.cpp
+++ b/common/src/main/cpp/classes/openxr_fb_spatial_entity_batch.cpp
@@ -1,0 +1,132 @@
+/**************************************************************************/
+/*  openxr_fb_spatial_entity_batch.cpp                                    */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "classes/openxr_fb_spatial_entity_batch.h"
+
+#include <godot_cpp/templates/local_vector.hpp>
+
+#include "extensions/openxr_fb_spatial_entity_storage_batch_extension_wrapper.h"
+#include "extensions/openxr_fb_spatial_entity_sharing_extension_wrapper.h"
+
+#include "classes/openxr_fb_spatial_entity_user.h"
+
+using namespace godot;
+
+void OpenXRFbSpatialEntityBatch::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_entities"), &OpenXRFbSpatialEntityBatch::get_entities);
+
+	ClassDB::bind_method(D_METHOD("save_to_storage", "location"), &OpenXRFbSpatialEntityBatch::save_to_storage);
+	ClassDB::bind_method(D_METHOD("share_with_users", "users"), &OpenXRFbSpatialEntityBatch::share_with_users);
+
+	ClassDB::bind_static_method("OpenXRFbSpatialEntityBatch", D_METHOD("create_batch", "entities"), &OpenXRFbSpatialEntityBatch::create_batch);
+
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "entities", PROPERTY_HINT_ARRAY_TYPE, "OpenXRFbSpatialEntity"), "", "get_entities");
+
+	ADD_SIGNAL(MethodInfo("openxr_fb_spatial_entity_batch_saved", PropertyInfo(Variant::Type::BOOL, "succeeded"), PropertyInfo(Variant::Type::INT, "location")));
+	ADD_SIGNAL(MethodInfo("openxr_fb_spatial_entity_batch_shared", PropertyInfo(Variant::Type::BOOL, "succeeded")));
+}
+
+String OpenXRFbSpatialEntityBatch::_to_string() const {
+	PackedStringArray uuids;
+	uuids.resize(entities.size());
+	for (int i = 0; i < entities.size(); i++) {
+		Ref<OpenXRFbSpatialEntity> entity = entities[i];
+		uuids[i] = entity.is_valid() ? entity->get_uuid() : "null";
+	}
+	return String("[OpenXRFbSpatialEntityBatch ") + String(", ").join(uuids) + String("]");
+}
+
+TypedArray<OpenXRFbSpatialEntity> OpenXRFbSpatialEntityBatch::get_entities() const {
+	return entities;
+}
+
+void OpenXRFbSpatialEntityBatch::save_to_storage(OpenXRFbSpatialEntity::StorageLocation p_location) {
+	XrSpaceListSaveInfoFB save_info = {
+		XR_TYPE_SPACE_LIST_SAVE_INFO_FB, // type
+		nullptr, // next
+		(uint32_t)spaces.size(), // spaceCount
+		const_cast<XrSpace *>(spaces.ptr()), // spaces
+		OpenXRFbSpatialEntity::to_openxr_storage_location(p_location), // location
+	};
+
+	Ref<OpenXRFbSpatialEntityBatch> *userdata = memnew(Ref<OpenXRFbSpatialEntityBatch>(this));
+	OpenXRFbSpatialEntityStorageBatchExtensionWrapper::get_singleton()->save_spaces(&save_info, OpenXRFbSpatialEntityBatch::_on_save_to_storage, userdata);
+}
+
+void OpenXRFbSpatialEntityBatch::_on_save_to_storage(XrResult p_result, XrSpaceStorageLocationFB p_location, void *p_userdata) {
+	Ref<OpenXRFbSpatialEntityBatch> *userdata = (Ref<OpenXRFbSpatialEntityBatch> *)p_userdata;
+	(*userdata)->emit_signal("openxr_fb_spatial_entity_batch_saved", XR_SUCCEEDED(p_result), OpenXRFbSpatialEntity::from_openxr_storage_location(p_location));
+	memdelete(userdata);
+}
+
+void OpenXRFbSpatialEntityBatch::share_with_users(const TypedArray<OpenXRFbSpatialEntityUser> &p_users) {
+	LocalVector<XrSpaceUserFB> users;
+	users.resize(p_users.size());
+	for (int i = 0; i < p_users.size(); i++) {
+		Ref<OpenXRFbSpatialEntityUser> user = p_users[i];
+		users[i] = user->get_user_handle();
+	}
+
+	XrSpaceShareInfoFB info = {
+		XR_TYPE_SPACE_SHARE_INFO_FB, // type
+		nullptr, // next
+		(uint32_t)spaces.size(), // spaceCount
+		const_cast<XrSpace *>(spaces.ptr()), // spaces
+		(uint32_t)users.size(), // userCount
+		users.ptr(), // users
+	};
+
+	Ref<OpenXRFbSpatialEntityBatch> *userdata = memnew(Ref<OpenXRFbSpatialEntityBatch>(this));
+	OpenXRFbSpatialEntitySharingExtensionWrapper::get_singleton()->share_spaces(&info, OpenXRFbSpatialEntityBatch::_on_share_with_users, userdata);
+}
+
+void OpenXRFbSpatialEntityBatch::_on_share_with_users(XrResult p_result, void *p_userdata) {
+	Ref<OpenXRFbSpatialEntityBatch> *userdata = (Ref<OpenXRFbSpatialEntityBatch> *)p_userdata;
+	(*userdata)->emit_signal("openxr_fb_spatial_entity_batch_shared", XR_SUCCEEDED(p_result));
+	memdelete(userdata);
+}
+
+
+Ref<OpenXRFbSpatialEntityBatch> OpenXRFbSpatialEntityBatch::create_batch(const TypedArray<OpenXRFbSpatialEntity> &p_entities) {
+	return Ref<OpenXRFbSpatialEntityBatch>(memnew(OpenXRFbSpatialEntityBatch(p_entities)));
+}
+
+OpenXRFbSpatialEntityBatch::OpenXRFbSpatialEntityBatch(const TypedArray<OpenXRFbSpatialEntity> &p_entities) {
+	entities = p_entities;
+
+	for (int i = 0; i < entities.size(); i++) {
+		Ref<OpenXRFbSpatialEntity> entity = entities[i];
+		if (entity.is_valid()) {
+			XrSpace space = entity->get_space();
+			if (space != XR_NULL_HANDLE) {
+				spaces.push_back(space);
+			}
+		}
+	}
+}

--- a/common/src/main/cpp/classes/openxr_fb_spatial_entity_user.cpp
+++ b/common/src/main/cpp/classes/openxr_fb_spatial_entity_user.cpp
@@ -1,0 +1,63 @@
+/**************************************************************************/
+/*  openxr_fb_spatial_entity_user.cpp                                     */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "classes/openxr_fb_spatial_entity_user.h"
+
+#include "extensions/openxr_fb_spatial_entity_user_extension_wrapper.h"
+
+using namespace godot;
+
+void OpenXRFbSpatialEntityUser::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_user_id"), &OpenXRFbSpatialEntityUser::get_user_id);
+
+	ClassDB::bind_static_method("OpenXRFbSpatialEntityUser", D_METHOD("create_user", "user_id"), &OpenXRFbSpatialEntityUser::create_user);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "user_id", PROPERTY_HINT_NONE, ""), "", "get_user_id");
+}
+
+String OpenXRFbSpatialEntityUser::_to_string() const {
+	return String("[OpenXRFbSpatialEntityUser ") + itos(user_id) + String("]");
+}
+
+uint64_t OpenXRFbSpatialEntityUser::get_user_id() const {
+	return user_id;
+}
+
+Ref<OpenXRFbSpatialEntityUser> OpenXRFbSpatialEntityUser::create_user(uint64_t p_user_id) {
+	return Ref<OpenXRFbSpatialEntityUser>(memnew(OpenXRFbSpatialEntityUser(p_user_id)));
+}
+
+OpenXRFbSpatialEntityUser::OpenXRFbSpatialEntityUser(uint64_t p_user_id) {
+	user_id = p_user_id;
+
+	OpenXRFbSpatialEntityUserExtensionWrapper *spatial_entity_user_extension = OpenXRFbSpatialEntityUserExtensionWrapper::get_singleton();
+	if (spatial_entity_user_extension) {
+		user = spatial_entity_user_extension->create_user(p_user_id);
+	}
+}

--- a/common/src/main/cpp/extensions/openxr_fb_spatial_entity_sharing_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_fb_spatial_entity_sharing_extension_wrapper.cpp
@@ -1,0 +1,130 @@
+/**************************************************************************/
+/*  openxr_fb_spatial_entity_sharing_extension_wrapper.cpp                */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "extensions/openxr_fb_spatial_entity_sharing_extension_wrapper.h"
+
+#include <godot_cpp/classes/object.hpp>
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
+#include <godot_cpp/templates/vector.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+using namespace godot;
+
+OpenXRFbSpatialEntitySharingExtensionWrapper *OpenXRFbSpatialEntitySharingExtensionWrapper::singleton = nullptr;
+
+OpenXRFbSpatialEntitySharingExtensionWrapper *OpenXRFbSpatialEntitySharingExtensionWrapper::get_singleton() {
+	if (singleton == nullptr) {
+		singleton = memnew(OpenXRFbSpatialEntitySharingExtensionWrapper());
+	}
+	return singleton;
+}
+
+OpenXRFbSpatialEntitySharingExtensionWrapper::OpenXRFbSpatialEntitySharingExtensionWrapper() :
+		OpenXRExtensionWrapperExtension() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "An OpenXRFbSpatialEntitySharingExtensionWrapper singleton already exists.");
+
+	request_extensions[XR_FB_SPATIAL_ENTITY_SHARING_EXTENSION_NAME] = &fb_spatial_entity_sharing_ext;
+	singleton = this;
+}
+
+OpenXRFbSpatialEntitySharingExtensionWrapper::~OpenXRFbSpatialEntitySharingExtensionWrapper() {
+	cleanup();
+}
+
+void OpenXRFbSpatialEntitySharingExtensionWrapper::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_spatial_entity_sharing_supported"), &OpenXRFbSpatialEntitySharingExtensionWrapper::is_spatial_entity_sharing_supported);
+}
+
+void OpenXRFbSpatialEntitySharingExtensionWrapper::cleanup() {
+	fb_spatial_entity_sharing_ext = false;
+}
+
+Dictionary OpenXRFbSpatialEntitySharingExtensionWrapper::_get_requested_extensions() {
+	Dictionary result;
+	for (auto ext : request_extensions) {
+		uint64_t value = reinterpret_cast<uint64_t>(ext.value);
+		result[ext.key] = (Variant)value;
+	}
+	return result;
+}
+
+void OpenXRFbSpatialEntitySharingExtensionWrapper::_on_instance_created(uint64_t instance) {
+	if (fb_spatial_entity_sharing_ext) {
+		bool result = initialize_fb_spatial_entity_sharing_extension((XrInstance)instance);
+		if (!result) {
+			UtilityFunctions::printerr("Failed to initialize fb_spatial_entity_sharing extension");
+			fb_spatial_entity_sharing_ext = false;
+		}
+	}
+}
+
+void OpenXRFbSpatialEntitySharingExtensionWrapper::_on_instance_destroyed() {
+	cleanup();
+}
+
+bool OpenXRFbSpatialEntitySharingExtensionWrapper::initialize_fb_spatial_entity_sharing_extension(const XrInstance &p_instance) {
+	GDEXTENSION_INIT_XR_FUNC_V(xrShareSpacesFB);
+
+	return true;
+}
+
+bool OpenXRFbSpatialEntitySharingExtensionWrapper::_on_event_polled(const void *event) {
+	if (static_cast<const XrEventDataBuffer *>(event)->type == XR_TYPE_EVENT_DATA_SPACE_SHARE_COMPLETE_FB) {
+		on_space_share_complete((const XrEventDataSpaceShareCompleteFB *)event);
+		return true;
+	}
+
+	return false;
+}
+
+bool OpenXRFbSpatialEntitySharingExtensionWrapper::share_spaces(const XrSpaceShareInfoFB *p_info, ShareSpacesCompleteCallback p_callback, void *p_userdata) {
+	XrAsyncRequestIdFB request_id;
+
+	const XrResult result = xrShareSpacesFB(SESSION, p_info, &request_id);
+	if (!XR_SUCCEEDED(result)) {
+		WARN_PRINT("xrShareSpacesFB failed!");
+		WARN_PRINT(get_openxr_api()->get_error_string(result));
+		p_callback(result, p_userdata);
+		return false;
+	}
+
+	requests[request_id] = RequestInfo(p_callback, p_userdata);
+	return true;
+}
+
+void OpenXRFbSpatialEntitySharingExtensionWrapper::on_space_share_complete(const XrEventDataSpaceShareCompleteFB *event) {
+	if (!requests.has(event->requestId)) {
+		WARN_PRINT("Received unexpected XR_TYPE_EVENT_DATA_SPACE_SHARE_COMPLETE_FB");
+		return;
+	}
+
+	RequestInfo *request = requests.getptr(event->requestId);
+	request->callback(event->result, request->userdata);
+	requests.erase(event->requestId);
+}

--- a/common/src/main/cpp/extensions/openxr_fb_spatial_entity_storage_batch_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_fb_spatial_entity_storage_batch_extension_wrapper.cpp
@@ -1,0 +1,130 @@
+/**************************************************************************/
+/*  openxr_fb_spatial_entity_storage_batch_extension_wrapper.cpp          */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "extensions/openxr_fb_spatial_entity_storage_batch_extension_wrapper.h"
+
+#include <godot_cpp/classes/object.hpp>
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
+#include <godot_cpp/templates/vector.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+using namespace godot;
+
+OpenXRFbSpatialEntityStorageBatchExtensionWrapper *OpenXRFbSpatialEntityStorageBatchExtensionWrapper::singleton = nullptr;
+
+OpenXRFbSpatialEntityStorageBatchExtensionWrapper *OpenXRFbSpatialEntityStorageBatchExtensionWrapper::get_singleton() {
+	if (singleton == nullptr) {
+		singleton = memnew(OpenXRFbSpatialEntityStorageBatchExtensionWrapper());
+	}
+	return singleton;
+}
+
+OpenXRFbSpatialEntityStorageBatchExtensionWrapper::OpenXRFbSpatialEntityStorageBatchExtensionWrapper() :
+		OpenXRExtensionWrapperExtension() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "An OpenXRFbSpatialEntityStorageBatchExtensionWrapper singleton already exists.");
+
+	request_extensions[XR_FB_SPATIAL_ENTITY_STORAGE_BATCH_EXTENSION_NAME] = &fb_spatial_entity_storage_batch_ext;
+	singleton = this;
+}
+
+OpenXRFbSpatialEntityStorageBatchExtensionWrapper::~OpenXRFbSpatialEntityStorageBatchExtensionWrapper() {
+	cleanup();
+}
+
+void OpenXRFbSpatialEntityStorageBatchExtensionWrapper::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_spatial_entity_storage_batch_supported"), &OpenXRFbSpatialEntityStorageBatchExtensionWrapper::is_spatial_entity_storage_batch_supported);
+}
+
+void OpenXRFbSpatialEntityStorageBatchExtensionWrapper::cleanup() {
+	fb_spatial_entity_storage_batch_ext = false;
+}
+
+Dictionary OpenXRFbSpatialEntityStorageBatchExtensionWrapper::_get_requested_extensions() {
+	Dictionary result;
+	for (auto ext : request_extensions) {
+		uint64_t value = reinterpret_cast<uint64_t>(ext.value);
+		result[ext.key] = (Variant)value;
+	}
+	return result;
+}
+
+void OpenXRFbSpatialEntityStorageBatchExtensionWrapper::_on_instance_created(uint64_t instance) {
+	if (fb_spatial_entity_storage_batch_ext) {
+		bool result = initialize_fb_spatial_entity_storage_batch_extension((XrInstance)instance);
+		if (!result) {
+			UtilityFunctions::printerr("Failed to initialize fb_spatial_entity_storage_batch extension");
+			fb_spatial_entity_storage_batch_ext = false;
+		}
+	}
+}
+
+void OpenXRFbSpatialEntityStorageBatchExtensionWrapper::_on_instance_destroyed() {
+	cleanup();
+}
+
+bool OpenXRFbSpatialEntityStorageBatchExtensionWrapper::initialize_fb_spatial_entity_storage_batch_extension(const XrInstance &p_instance) {
+	GDEXTENSION_INIT_XR_FUNC_V(xrSaveSpaceListFB);
+
+	return true;
+}
+
+bool OpenXRFbSpatialEntityStorageBatchExtensionWrapper::_on_event_polled(const void *event) {
+	if (static_cast<const XrEventDataBuffer *>(event)->type == XR_TYPE_EVENT_DATA_SPACE_LIST_SAVE_COMPLETE_FB) {
+		on_space_list_save_complete((const XrEventDataSpaceListSaveCompleteFB *)event);
+		return true;
+	}
+
+	return false;
+}
+
+bool OpenXRFbSpatialEntityStorageBatchExtensionWrapper::save_spaces(const XrSpaceListSaveInfoFB *p_info, SaveSpacesCompleteCallback p_callback, void *p_userdata) {
+	XrAsyncRequestIdFB request_id;
+
+	const XrResult result = xrSaveSpaceListFB(SESSION, p_info, &request_id);
+	if (!XR_SUCCEEDED(result)) {
+		WARN_PRINT("xrSaveSpaceList failed!");
+		WARN_PRINT(get_openxr_api()->get_error_string(result));
+		p_callback(result, p_info->location, p_userdata);
+		return false;
+	}
+
+	requests[request_id] = RequestInfo(p_callback, p_userdata, p_info->location);
+	return true;
+}
+
+void OpenXRFbSpatialEntityStorageBatchExtensionWrapper::on_space_list_save_complete(const XrEventDataSpaceListSaveCompleteFB *event) {
+	if (!requests.has(event->requestId)) {
+		WARN_PRINT("Received unexpected XR_TYPE_EVENT_DATA_SPACE_LIST_SAVE_COMPLETE_FB");
+		return;
+	}
+
+	RequestInfo *request = requests.getptr(event->requestId);
+	request->callback(event->result, request->location, request->userdata);
+	requests.erase(event->requestId);
+}

--- a/common/src/main/cpp/extensions/openxr_fb_spatial_entity_user_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_fb_spatial_entity_user_extension_wrapper.cpp
@@ -1,0 +1,134 @@
+/**************************************************************************/
+/*  openxr_fb_spatial_entity_user_extension_wrapper.cpp                   */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "extensions/openxr_fb_spatial_entity_user_extension_wrapper.h"
+
+#include <godot_cpp/classes/object.hpp>
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
+#include <godot_cpp/templates/vector.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+using namespace godot;
+
+OpenXRFbSpatialEntityUserExtensionWrapper *OpenXRFbSpatialEntityUserExtensionWrapper::singleton = nullptr;
+
+OpenXRFbSpatialEntityUserExtensionWrapper *OpenXRFbSpatialEntityUserExtensionWrapper::get_singleton() {
+	if (singleton == nullptr) {
+		singleton = memnew(OpenXRFbSpatialEntityUserExtensionWrapper());
+	}
+	return singleton;
+}
+
+OpenXRFbSpatialEntityUserExtensionWrapper::OpenXRFbSpatialEntityUserExtensionWrapper() :
+		OpenXRExtensionWrapperExtension() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "An OpenXRFbSpatialEntityUserExtensionWrapper singleton already exists.");
+
+	request_extensions[XR_FB_SPATIAL_ENTITY_USER_EXTENSION_NAME] = &fb_spatial_entity_user_ext;
+	singleton = this;
+}
+
+OpenXRFbSpatialEntityUserExtensionWrapper::~OpenXRFbSpatialEntityUserExtensionWrapper() {
+	cleanup();
+}
+
+void OpenXRFbSpatialEntityUserExtensionWrapper::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_spatial_entity_user_supported"), &OpenXRFbSpatialEntityUserExtensionWrapper::is_spatial_entity_user_supported);
+}
+
+void OpenXRFbSpatialEntityUserExtensionWrapper::cleanup() {
+	fb_spatial_entity_user_ext = false;
+}
+
+Dictionary OpenXRFbSpatialEntityUserExtensionWrapper::_get_requested_extensions() {
+	Dictionary result;
+	for (auto ext : request_extensions) {
+		uint64_t value = reinterpret_cast<uint64_t>(ext.value);
+		result[ext.key] = (Variant)value;
+	}
+	return result;
+}
+
+void OpenXRFbSpatialEntityUserExtensionWrapper::_on_instance_created(uint64_t instance) {
+	if (fb_spatial_entity_user_ext) {
+		bool result = initialize_fb_spatial_entity_user_extension((XrInstance)instance);
+		if (!result) {
+			UtilityFunctions::printerr("Failed to initialize fb_spatial_entity_user extension");
+			fb_spatial_entity_user_ext = false;
+		}
+	}
+}
+
+void OpenXRFbSpatialEntityUserExtensionWrapper::_on_instance_destroyed() {
+	cleanup();
+}
+
+bool OpenXRFbSpatialEntityUserExtensionWrapper::initialize_fb_spatial_entity_user_extension(const XrInstance &p_instance) {
+	GDEXTENSION_INIT_XR_FUNC_V(xrCreateSpaceUserFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrGetSpaceUserIdFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrDestroySpaceUserFB);
+
+	return true;
+}
+
+XrSpaceUserFB OpenXRFbSpatialEntityUserExtensionWrapper::create_user(uint64_t p_user_id) {
+	XrSpaceUserCreateInfoFB info = {
+		XR_TYPE_SPACE_USER_CREATE_INFO_FB, // type
+		nullptr, // next
+		p_user_id, // userId
+	};
+
+	XrSpaceUserFB user = XR_NULL_HANDLE;
+
+	XrResult result = xrCreateSpaceUserFB(SESSION, &info, &user);
+	if (XR_FAILED(result)) {
+		UtilityFunctions::printerr(vformat("xrCreateSpaceUserFB failed: %s", get_openxr_api()->get_error_string(result)));
+		return XR_NULL_HANDLE;
+	}
+
+	return user;
+}
+
+uint64_t OpenXRFbSpatialEntityUserExtensionWrapper::get_user_id(XrSpaceUserFB p_user) {
+	XrSpaceUserIdFB user_id = 0;
+
+	XrResult result = xrGetSpaceUserIdFB(p_user, &user_id);
+	if (XR_FAILED(result)) {
+		UtilityFunctions::printerr(vformat("xrGetSpaceUserIdFB failed: %s", get_openxr_api()->get_error_string(result)));
+		return 0;
+	}
+
+	return user_id;
+}
+
+void OpenXRFbSpatialEntityUserExtensionWrapper::destroy_user(XrSpaceUserFB p_user) {
+	XrResult result = xrDestroySpaceUserFB(p_user);
+	if (XR_FAILED(result)) {
+		UtilityFunctions::printerr(vformat("xrDestroySpaceUserFB failed: %s", get_openxr_api()->get_error_string(result)));
+	}
+}

--- a/common/src/main/cpp/include/classes/openxr_fb_spatial_entity.h
+++ b/common/src/main/cpp/include/classes/openxr_fb_spatial_entity.h
@@ -38,6 +38,7 @@
 namespace godot {
 class Node3D;
 class MeshInstance3D;
+class OpenXRFbSpatialEntityUser;
 
 class OpenXRFbSpatialEntity : public RefCounted {
 	GDCLASS(OpenXRFbSpatialEntity, RefCounted);
@@ -74,6 +75,7 @@ protected:
 	static void _on_set_component_enabled_completed(XrResult p_result, XrSpaceComponentTypeFB p_component, bool p_enabled, void *p_userdata);
 	static void _on_save_to_storage(XrResult p_result, XrSpaceStorageLocationFB p_location, void *p_userdata);
 	static void _on_erase_from_storage(XrResult p_result, XrSpaceStorageLocationFB p_location, void *p_userdata);
+	static void _on_share_with_users(XrResult p_result, void *p_userdata);
 
 	String _to_string() const;
 
@@ -107,6 +109,7 @@ public:
 
 	void save_to_storage(StorageLocation p_location = STORAGE_LOCAL);
 	void erase_from_storage(StorageLocation p_location = STORAGE_LOCAL);
+	void share_with_users(const TypedArray<OpenXRFbSpatialEntityUser> &p_users);
 	void destroy();
 
 	static XrSpaceStorageLocationFB to_openxr_storage_location(StorageLocation p_location);

--- a/common/src/main/cpp/include/classes/openxr_fb_spatial_entity_batch.h
+++ b/common/src/main/cpp/include/classes/openxr_fb_spatial_entity_batch.h
@@ -1,0 +1,67 @@
+/**************************************************************************/
+/*  openxr_fb_spatial_entity_batch.h                                      */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef OPENXR_FB_SPATIAL_ENTITY_BATCH_H
+#define OPENXR_FB_SPATIAL_ENTITY_BATCH_H
+
+#include <openxr/openxr.h>
+
+#include "openxr_fb_spatial_entity.h"
+
+namespace godot {
+class OpenXRFbSpatialEntityUser;
+
+class OpenXRFbSpatialEntityBatch : public RefCounted {
+	GDCLASS(OpenXRFbSpatialEntityBatch, RefCounted);
+
+	Vector<XrSpace> spaces;
+	TypedArray<OpenXRFbSpatialEntity> entities;
+
+protected:
+	static void _bind_methods();
+
+	static void _on_save_to_storage(XrResult p_result, XrSpaceStorageLocationFB p_location, void *p_userdata);
+	static void _on_share_with_users(XrResult p_result, void *p_userdata);
+
+	String _to_string() const;
+
+public:
+	TypedArray<OpenXRFbSpatialEntity> get_entities() const;
+
+	void save_to_storage(OpenXRFbSpatialEntity::StorageLocation p_location);
+	void share_with_users(const TypedArray<OpenXRFbSpatialEntityUser> &p_users);
+
+	static Ref<OpenXRFbSpatialEntityBatch> create_batch(const TypedArray<OpenXRFbSpatialEntity> &p_entities);
+
+	OpenXRFbSpatialEntityBatch() = default;
+	OpenXRFbSpatialEntityBatch(const TypedArray<OpenXRFbSpatialEntity> &p_entities);
+};
+} // namespace godot
+
+#endif

--- a/common/src/main/cpp/include/classes/openxr_fb_spatial_entity_user.h
+++ b/common/src/main/cpp/include/classes/openxr_fb_spatial_entity_user.h
@@ -1,0 +1,61 @@
+/**************************************************************************/
+/*  openxr_fb_spatial_entity_user.h                                       */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef OPENXR_FB_SPATIAL_ENTITY_USER_H
+#define OPENXR_FB_SPATIAL_ENTITY_USER_H
+
+#include <openxr/openxr.h>
+
+#include <godot_cpp/classes/ref_counted.hpp>
+
+namespace godot {
+class OpenXRFbSpatialEntityUser : public RefCounted {
+	GDCLASS(OpenXRFbSpatialEntityUser, RefCounted);
+
+	uint64_t user_id = 0;
+	XrSpaceUserFB user = XR_NULL_HANDLE;
+
+protected:
+	static void _bind_methods();
+
+	String _to_string() const;
+
+public:
+	_FORCE_INLINE_ XrSpaceUserFB get_user_handle() { return user; }
+
+	uint64_t get_user_id() const;
+
+	static Ref<OpenXRFbSpatialEntityUser> create_user(uint64_t p_user_id);
+
+	OpenXRFbSpatialEntityUser() = default;
+	OpenXRFbSpatialEntityUser(uint64_t p_user_id);
+};
+} // namespace godot
+
+#endif

--- a/common/src/main/cpp/include/extensions/openxr_fb_spatial_entity_sharing_extension_wrapper.h
+++ b/common/src/main/cpp/include/extensions/openxr_fb_spatial_entity_sharing_extension_wrapper.h
@@ -1,0 +1,98 @@
+/**************************************************************************/
+/*  openxr_fb_spatial_entity_sharing_extension_wrapper.h                  */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <openxr/openxr.h>
+#include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
+#include <godot_cpp/templates/hash_map.hpp>
+
+#include "util.h"
+
+using namespace godot;
+
+// Wrapper for XR_FB_spatial_entity_sharing extension.
+class OpenXRFbSpatialEntitySharingExtensionWrapper : public OpenXRExtensionWrapperExtension {
+	GDCLASS(OpenXRFbSpatialEntitySharingExtensionWrapper, OpenXRExtensionWrapperExtension);
+
+public:
+	Dictionary _get_requested_extensions() override;
+
+	void _on_instance_created(uint64_t instance) override;
+	void _on_instance_destroyed() override;
+
+	bool is_spatial_entity_sharing_supported() {
+		return fb_spatial_entity_sharing_ext;
+	}
+
+	typedef void (*ShareSpacesCompleteCallback)(XrResult p_result, void *p_userdata);
+
+	bool share_spaces(const XrSpaceShareInfoFB *p_info, ShareSpacesCompleteCallback p_callback, void *p_userdata);
+
+	virtual bool _on_event_polled(const void *event) override;
+
+	static OpenXRFbSpatialEntitySharingExtensionWrapper *get_singleton();
+
+	OpenXRFbSpatialEntitySharingExtensionWrapper();
+	~OpenXRFbSpatialEntitySharingExtensionWrapper();
+
+protected:
+	static void _bind_methods();
+
+private:
+	EXT_PROTO_XRRESULT_FUNC3(xrShareSpacesFB,
+			(XrSession), session,
+			(const XrSpaceShareInfoFB *), info,
+			(XrAsyncRequestIdFB *), requestId);
+
+	bool initialize_fb_spatial_entity_sharing_extension(const XrInstance &instance);
+	void on_space_share_complete(const XrEventDataSpaceShareCompleteFB *event);
+
+	HashMap<String, bool *> request_extensions;
+
+	struct RequestInfo {
+		ShareSpacesCompleteCallback callback = nullptr;
+		void *userdata = nullptr;
+
+		RequestInfo() { }
+
+		RequestInfo(ShareSpacesCompleteCallback p_callback, void *p_userdata) {
+			callback = p_callback;
+			userdata = p_userdata;
+		}
+	};
+
+	HashMap<XrAsyncRequestIdFB, RequestInfo> requests;
+
+	void cleanup();
+
+	static OpenXRFbSpatialEntitySharingExtensionWrapper *singleton;
+
+	bool fb_spatial_entity_sharing_ext = false;
+};

--- a/common/src/main/cpp/include/extensions/openxr_fb_spatial_entity_storage_batch_extension_wrapper.h
+++ b/common/src/main/cpp/include/extensions/openxr_fb_spatial_entity_storage_batch_extension_wrapper.h
@@ -1,0 +1,100 @@
+/**************************************************************************/
+/*  openxr_fb_spatial_entity_storage_batch_extension_wrapper.h            */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <openxr/openxr.h>
+#include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
+#include <godot_cpp/templates/hash_map.hpp>
+
+#include "util.h"
+
+using namespace godot;
+
+// Wrapper for XR_FB_spatial_entity_storage_batch extension.
+class OpenXRFbSpatialEntityStorageBatchExtensionWrapper : public OpenXRExtensionWrapperExtension {
+	GDCLASS(OpenXRFbSpatialEntityStorageBatchExtensionWrapper, OpenXRExtensionWrapperExtension);
+
+public:
+	Dictionary _get_requested_extensions() override;
+
+	void _on_instance_created(uint64_t instance) override;
+	void _on_instance_destroyed() override;
+
+	bool is_spatial_entity_storage_batch_supported() {
+		return fb_spatial_entity_storage_batch_ext;
+	}
+
+	typedef void (*SaveSpacesCompleteCallback)(XrResult p_result, XrSpaceStorageLocationFB p_location, void *p_userdata);
+
+	bool save_spaces(const XrSpaceListSaveInfoFB *p_info, SaveSpacesCompleteCallback p_callback, void *p_userdata);
+
+	virtual bool _on_event_polled(const void *event) override;
+
+	static OpenXRFbSpatialEntityStorageBatchExtensionWrapper *get_singleton();
+
+	OpenXRFbSpatialEntityStorageBatchExtensionWrapper();
+	~OpenXRFbSpatialEntityStorageBatchExtensionWrapper();
+
+protected:
+	static void _bind_methods();
+
+private:
+	EXT_PROTO_XRRESULT_FUNC3(xrSaveSpaceListFB,
+			(XrSession), session,
+			(const XrSpaceListSaveInfoFB *), info,
+			(XrAsyncRequestIdFB *), requestId);
+
+	bool initialize_fb_spatial_entity_storage_batch_extension(const XrInstance &instance);
+	void on_space_list_save_complete(const XrEventDataSpaceListSaveCompleteFB *event);
+
+	HashMap<String, bool *> request_extensions;
+
+	struct RequestInfo {
+		SaveSpacesCompleteCallback callback = nullptr;
+		void *userdata = nullptr;
+		XrSpaceStorageLocationFB location = XR_SPACE_STORAGE_LOCATION_INVALID_FB;
+
+		RequestInfo() { }
+
+		RequestInfo(SaveSpacesCompleteCallback p_callback, void *p_userdata, XrSpaceStorageLocationFB p_location) {
+			callback = p_callback;
+			userdata = p_userdata;
+			location = p_location;
+		}
+	};
+
+	HashMap<XrAsyncRequestIdFB, RequestInfo> requests;
+
+	void cleanup();
+
+	static OpenXRFbSpatialEntityStorageBatchExtensionWrapper *singleton;
+
+	bool fb_spatial_entity_storage_batch_ext = false;
+};

--- a/common/src/main/cpp/include/extensions/openxr_fb_spatial_entity_user_extension_wrapper.h
+++ b/common/src/main/cpp/include/extensions/openxr_fb_spatial_entity_user_extension_wrapper.h
@@ -1,0 +1,88 @@
+/**************************************************************************/
+/*  openxr_fb_spatial_entity_user_extension_wrapper.h                     */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <openxr/openxr.h>
+#include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
+#include <godot_cpp/templates/hash_map.hpp>
+
+#include "util.h"
+
+using namespace godot;
+
+// Wrapper for XR_FB_spatial_entity_user extension.
+class OpenXRFbSpatialEntityUserExtensionWrapper : public OpenXRExtensionWrapperExtension {
+	GDCLASS(OpenXRFbSpatialEntityUserExtensionWrapper, OpenXRExtensionWrapperExtension);
+
+public:
+	Dictionary _get_requested_extensions() override;
+
+	void _on_instance_created(uint64_t instance) override;
+	void _on_instance_destroyed() override;
+
+	bool is_spatial_entity_user_supported() {
+		return fb_spatial_entity_user_ext;
+	}
+
+	XrSpaceUserFB create_user(uint64_t p_user_id);
+	uint64_t get_user_id(XrSpaceUserFB p_user);
+	void destroy_user(XrSpaceUserFB p_user);
+
+	static OpenXRFbSpatialEntityUserExtensionWrapper *get_singleton();
+
+	OpenXRFbSpatialEntityUserExtensionWrapper();
+	~OpenXRFbSpatialEntityUserExtensionWrapper();
+
+protected:
+	static void _bind_methods();
+
+private:
+	EXT_PROTO_XRRESULT_FUNC3(xrCreateSpaceUserFB,
+			(XrSession), session,
+			(const XrSpaceUserCreateInfoFB *), info,
+			(XrSpaceUserFB *), user);
+
+	EXT_PROTO_XRRESULT_FUNC2(xrGetSpaceUserIdFB,
+			(XrSpaceUserFB), user,
+			(XrSpaceUserIdFB *), userId);
+
+	EXT_PROTO_XRRESULT_FUNC1(xrDestroySpaceUserFB,
+			(XrSpaceUserFB), user);
+
+	bool initialize_fb_spatial_entity_user_extension(const XrInstance &instance);
+
+	HashMap<String, bool *> request_extensions;
+
+	void cleanup();
+
+	static OpenXRFbSpatialEntityUserExtensionWrapper *singleton;
+
+	bool fb_spatial_entity_user_ext = false;
+};

--- a/common/src/main/cpp/register_types.cpp
+++ b/common/src/main/cpp/register_types.cpp
@@ -58,7 +58,10 @@
 #include "extensions/openxr_fb_spatial_entity_container_extension_wrapper.h"
 #include "extensions/openxr_fb_spatial_entity_extension_wrapper.h"
 #include "extensions/openxr_fb_spatial_entity_query_extension_wrapper.h"
+#include "extensions/openxr_fb_spatial_entity_sharing_extension_wrapper.h"
 #include "extensions/openxr_fb_spatial_entity_storage_extension_wrapper.h"
+#include "extensions/openxr_fb_spatial_entity_storage_batch_extension_wrapper.h"
+#include "extensions/openxr_fb_spatial_entity_user_extension_wrapper.h"
 #include "extensions/openxr_htc_facial_tracking_extension_wrapper.h"
 #include "extensions/openxr_meta_spatial_entity_mesh_extension_wrapper.h"
 
@@ -68,7 +71,9 @@
 #include "classes/openxr_fb_scene_manager.h"
 #include "classes/openxr_fb_spatial_anchor_manager.h"
 #include "classes/openxr_fb_spatial_entity.h"
+#include "classes/openxr_fb_spatial_entity_batch.h"
 #include "classes/openxr_fb_spatial_entity_query.h"
+#include "classes/openxr_fb_spatial_entity_user.h"
 #include "classes/openxr_meta_passthrough_color_lut.h"
 
 using namespace godot;
@@ -88,14 +93,23 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			ClassDB::register_class<OpenXRFbSpatialEntityExtensionWrapper>();
 			OpenXRFbSpatialEntityExtensionWrapper::get_singleton()->register_extension_wrapper();
 
+			ClassDB::register_class<OpenXRFbSpatialEntitySharingExtensionWrapper>();
+			OpenXRFbSpatialEntitySharingExtensionWrapper::get_singleton()->register_extension_wrapper();
+
 			ClassDB::register_class<OpenXRFbSpatialEntityStorageExtensionWrapper>();
 			OpenXRFbSpatialEntityStorageExtensionWrapper::get_singleton()->register_extension_wrapper();
+
+			ClassDB::register_class<OpenXRFbSpatialEntityStorageBatchExtensionWrapper>();
+			OpenXRFbSpatialEntityStorageBatchExtensionWrapper::get_singleton()->register_extension_wrapper();
 
 			ClassDB::register_class<OpenXRFbSpatialEntityQueryExtensionWrapper>();
 			OpenXRFbSpatialEntityQueryExtensionWrapper::get_singleton()->register_extension_wrapper();
 
 			ClassDB::register_class<OpenXRFbSpatialEntityContainerExtensionWrapper>();
 			OpenXRFbSpatialEntityContainerExtensionWrapper::get_singleton()->register_extension_wrapper();
+
+			ClassDB::register_class<OpenXRFbSpatialEntityUserExtensionWrapper>();
+			OpenXRFbSpatialEntityUserExtensionWrapper::get_singleton()->register_extension_wrapper();
 
 			ClassDB::register_class<OpenXRMetaSpatialEntityMeshExtensionWrapper>();
 			OpenXRMetaSpatialEntityMeshExtensionWrapper::get_singleton()->register_extension_wrapper();
@@ -154,7 +168,9 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			ClassDB::register_class<OpenXRFbSceneManager>();
 			ClassDB::register_class<OpenXRFbSpatialAnchorManager>();
 			ClassDB::register_class<OpenXRFbSpatialEntity>();
+			ClassDB::register_class<OpenXRFbSpatialEntityBatch>();
 			ClassDB::register_class<OpenXRFbSpatialEntityQuery>();
+			ClassDB::register_class<OpenXRFbSpatialEntityUser>();
 			ClassDB::register_class<OpenXRFbPassthroughGeometry>();
 			ClassDB::register_class<OpenXRMetaPassthroughColorLut>();
 

--- a/demo/spatial_anchor.gd
+++ b/demo/spatial_anchor.gd
@@ -14,6 +14,9 @@ func setup_scene(spatial_entity: OpenXRFbSpatialEntity) -> void:
 	material.albedo_color = color
 	mesh_instance.set_surface_override_material(0, material)
 
+	spatial_entity.openxr_fb_spatial_entity_saved.connect(self._on_saved_to_cloud.bind(spatial_entity))
+	spatial_entity.save_to_storage(OpenXRFbSpatialEntity.STORAGE_CLOUD)
+
 func set_selected(p_selected: bool) -> void:
 	selected = p_selected
 
@@ -23,3 +26,25 @@ func set_selected(p_selected: bool) -> void:
 	else:
 		material.albedo_color = color
 	mesh_instance.set_surface_override_material(0, material)
+
+func _on_saved_to_cloud(p_success: bool, p_location: OpenXRFbSpatialEntity.StorageLocation, p_spatial_entity: OpenXRFbSpatialEntity) -> void:
+	print("Saved ", p_spatial_entity.uuid, " to cloud: ", p_success)
+
+	if p_success:
+		p_spatial_entity.openxr_fb_spatial_entity_set_component_enabled_completed.connect(self._on_enable_sharable.bind(p_spatial_entity))
+		p_spatial_entity.set_component_enabled(OpenXRFbSpatialEntity.COMPONENT_TYPE_SHARABLE, true)
+
+func _on_enable_sharable(p_success: bool, p_component: OpenXRFbSpatialEntity.StorageLocation, p_enabled: bool, p_spatial_entity: OpenXRFbSpatialEntity) -> void:
+	print("Enable ", p_spatial_entity.uuid, " as sharable: ", p_success)
+
+	if p_success:
+		# Note: For this to really work, we'd need a real user ID from the platform SDK.
+		#       This is outside the scope of what we can do in the demo here.
+		var spatial_entity_user = OpenXRFbSpatialEntityUser.create_user(1234)
+
+		p_spatial_entity.openxr_fb_spatial_entity_shared.connect(self._on_shared.bind(p_spatial_entity))
+		# Note: Uncomment to test sharing.
+		#p_spatial_entity.share_with_users([ spatial_entity_user ])
+
+func _on_shared(p_success: bool, p_spatial_entity: OpenXRFbSpatialEntity) -> void:
+	print("Share ", p_spatial_entity.uuid, " is success: ", p_success)


### PR DESCRIPTION
Builds on top of PR https://github.com/GodotVR/godot_openxr_vendors/pull/121 (marking this one as draft until that one is merged)

This PR adds support for sharing and bulk saving (and sharing) of developer-created spatial anchors.

I was able to fully test bulk saving, but only partially test sharing. To really test sharing would need a dedicated sample project, because it would require using Meta's Platform SDK as well as implement some kind of multiplayer networking. That's out of scope for the simple demo here.