### PR TITLE
Retire use of the XRHandTracker::Hand

### DIFF
--- a/common/src/main/cpp/classes/openxr_fb_hand_tracking_mesh.cpp
+++ b/common/src/main/cpp/classes/openxr_fb_hand_tracking_mesh.cpp
@@ -71,7 +71,7 @@ void OpenXRFbHandTrackingMesh::set_hand(Hand p_hand) {
 	hand = p_hand;
 }
 
-XRHandTracker::Hand OpenXRFbHandTrackingMesh::get_hand() const {
+OpenXRFbHandTrackingMesh::Hand OpenXRFbHandTrackingMesh::get_hand() const {
 	return hand;
 }
 

--- a/common/src/main/cpp/include/classes/openxr_fb_hand_tracking_mesh.h
+++ b/common/src/main/cpp/include/classes/openxr_fb_hand_tracking_mesh.h
@@ -39,7 +39,11 @@ namespace godot {
 class OpenXRFbHandTrackingMesh : public Node3D {
 	GDCLASS(OpenXRFbHandTrackingMesh, Node3D)
 public:
-	using Hand = XRHandTracker::Hand;
+	enum Hand {
+		HAND_LEFT,
+		HAND_RIGHT,
+		HAND_MAX,
+	};
 
 private:
 	Hand hand = Hand::HAND_LEFT;
@@ -74,5 +78,7 @@ public:
 	float get_scale_override() const;
 };
 } //namespace godot
+
+VARIANT_ENUM_CAST(godot::OpenXRFbHandTrackingMesh::Hand);
 
 #endif

--- a/common/src/main/cpp/include/extensions/openxr_fb_hand_tracking_capsules_extension_wrapper.h
+++ b/common/src/main/cpp/include/extensions/openxr_fb_hand_tracking_capsules_extension_wrapper.h
@@ -42,7 +42,6 @@ class OpenXRFbHandTrackingCapsulesExtensionWrapper : public OpenXRExtensionWrapp
 	GDCLASS(OpenXRFbHandTrackingCapsulesExtensionWrapper, OpenXRExtensionWrapperExtension);
 
 public:
-	using Hand = XRHandTracker::Hand;
 	using HandJoint = XRHandTracker::HandJoint;
 
 	godot::Dictionary _get_requested_extensions() override;
@@ -70,6 +69,12 @@ protected:
 	static void _bind_methods();
 
 private:
+	enum Hand {
+		HAND_LEFT,
+		HAND_RIGHT,
+		HAND_MAX,
+	};
+
 	std::map<godot::String, bool *> request_extensions;
 
 	void cleanup();

--- a/common/src/main/cpp/include/extensions/openxr_fb_hand_tracking_mesh_extension_wrapper.h
+++ b/common/src/main/cpp/include/extensions/openxr_fb_hand_tracking_mesh_extension_wrapper.h
@@ -38,6 +38,7 @@
 #include <godot_cpp/templates/local_vector.hpp>
 #include <map>
 
+#include "classes/openxr_fb_hand_tracking_mesh.h"
 #include "util.h"
 
 using namespace godot;
@@ -53,7 +54,7 @@ public:
 		LocalVector<XrHandJointEXT> joint_parents;
 	};
 
-	using Hand = XRHandTracker::Hand;
+	using Hand = OpenXRFbHandTrackingMesh::Hand;
 
 	godot::Dictionary _get_requested_extensions() override;
 

--- a/thirdparty/godot_cpp_gdextension_api/README.md
+++ b/thirdparty/godot_cpp_gdextension_api/README.md
@@ -4,7 +4,7 @@ This directory contains the API JSON for
 [**Godot Engine**](https://github.com/godotengine/godot)'s *GDExtensions* API.
 
 ## Current API version
-- [commit 7529c0bec597d70bc61975a82063bb5112ac8879](https://github.com/godotengine/godot/commit/7529c0bec597d70bc61975a82063bb5112ac8879)
+- [commit 6118592c6d88350d01f74faff6fd49754f84a7d0](https://github.com/godotengine/godot/commit/6118592c6d88350d01f74faff6fd49754f84a7d0)
 
 ## Updating API
 


### PR DESCRIPTION
When `XRHandTracker` was initially developed it had a `Hand` enum _[Left=0, Right=1]_ identify the tracked hand.

When XR Trackers were reorganized into an inheritance-tree, `XRHandTracker` was modified to extend from `XRPositionalTracker` which already has a `hand` property. This resulted in duplicate information, and for C#/.Net a collision between the enum and property symbol names.

~~PR https://github.com/godotengine/godot/pull/91130 has been introduced to remove `XRHandTracker::Hand` from Godot, and this PR removes its use in godot_openxr_vendors.~~

UPDATE: The Godot PR has been merged removing `XRHandTracker::Hand`. This PR now includes the updated extension_api.json including that merge.