### PR TITLE
Update OpenXRFbHandTrackingMesh node and extension wrapper

### DIFF
--- a/common/src/main/cpp/extensions/openxr_fb_hand_tracking_capsules_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_fb_hand_tracking_capsules_extension_wrapper.cpp
@@ -93,7 +93,7 @@ uint64_t OpenXRFbHandTrackingCapsulesExtensionWrapper::_set_hand_joint_locations
 }
 
 Transform3D OpenXRFbHandTrackingCapsulesExtensionWrapper::get_hand_capsule_transform(int p_hand_index, int p_capsule_index) const {
-	ERR_FAIL_INDEX_V_MSG(p_hand_index, Hand::HAND_MAX, Transform3D(), vformat("Invalid hand index %d", p_hand_index));
+	ERR_FAIL_INDEX_V_MSG(p_hand_index, HAND_MAX, Transform3D(), vformat("Invalid hand index %d", p_hand_index));
 	ERR_FAIL_INDEX_V_MSG(p_capsule_index, XR_FB_HAND_TRACKING_CAPSULE_COUNT, Transform3D(), vformat("Invalid capsule index %d", p_capsule_index));
 
 	if (!fb_hand_tracking_capsules_ext) {
@@ -123,7 +123,7 @@ Transform3D OpenXRFbHandTrackingCapsulesExtensionWrapper::get_hand_capsule_trans
 }
 
 float OpenXRFbHandTrackingCapsulesExtensionWrapper::get_hand_capsule_height(int p_hand_index, int p_capsule_index) const {
-	ERR_FAIL_INDEX_V_MSG(p_hand_index, Hand::HAND_MAX, 0.0, vformat("Invalid hand index %d", p_hand_index));
+	ERR_FAIL_INDEX_V_MSG(p_hand_index, HAND_MAX, 0.0, vformat("Invalid hand index %d", p_hand_index));
 	ERR_FAIL_INDEX_V_MSG(p_capsule_index, XR_FB_HAND_TRACKING_CAPSULE_COUNT, 0.0, vformat("Invalid capsule index %d", p_capsule_index));
 
 	if (!fb_hand_tracking_capsules_ext) {
@@ -141,7 +141,7 @@ float OpenXRFbHandTrackingCapsulesExtensionWrapper::get_hand_capsule_height(int 
 }
 
 float OpenXRFbHandTrackingCapsulesExtensionWrapper::get_hand_capsule_radius(int p_hand_index, int p_capsule_index) const {
-	ERR_FAIL_INDEX_V_MSG(p_hand_index, Hand::HAND_MAX, 0.0, vformat("Invalid hand index %d", p_hand_index));
+	ERR_FAIL_INDEX_V_MSG(p_hand_index, HAND_MAX, 0.0, vformat("Invalid hand index %d", p_hand_index));
 	ERR_FAIL_INDEX_V_MSG(p_capsule_index, XR_FB_HAND_TRACKING_CAPSULE_COUNT, 0.0, vformat("Invalid capsule index %d", p_capsule_index));
 
 	if (!fb_hand_tracking_capsules_ext) {
@@ -153,7 +153,7 @@ float OpenXRFbHandTrackingCapsulesExtensionWrapper::get_hand_capsule_radius(int 
 }
 
 XRHandTracker::HandJoint OpenXRFbHandTrackingCapsulesExtensionWrapper::get_hand_capsule_joint(int p_hand_index, int p_capsule_index) const {
-	ERR_FAIL_INDEX_V_MSG(p_hand_index, Hand::HAND_MAX, HandJoint(0), vformat("Invalid hand index %d", p_hand_index));
+	ERR_FAIL_INDEX_V_MSG(p_hand_index, HAND_MAX, HandJoint(0), vformat("Invalid hand index %d", p_hand_index));
 	ERR_FAIL_INDEX_V_MSG(p_capsule_index, XR_FB_HAND_TRACKING_CAPSULE_COUNT, HandJoint(0), vformat("Invalid capsule index %d", p_capsule_index));
 
 	if (!fb_hand_tracking_capsules_ext) {

--- a/common/src/main/cpp/include/classes/openxr_fb_hand_tracking_mesh.h
+++ b/common/src/main/cpp/include/classes/openxr_fb_hand_tracking_mesh.h
@@ -33,19 +33,20 @@
 #include <godot_cpp/classes/material.hpp>
 #include <godot_cpp/classes/mesh_instance3d.hpp>
 #include <godot_cpp/classes/skeleton3d.hpp>
-#include <godot_cpp/classes/xr_hand_tracker.hpp>
 
 namespace godot {
-class OpenXRFbHandTrackingMesh : public Node3D {
-	GDCLASS(OpenXRFbHandTrackingMesh, Node3D)
+class OpenXRFbHandTrackingMesh : public Skeleton3D {
+	GDCLASS(OpenXRFbHandTrackingMesh, Skeleton3D)
 public:
-	using Hand = XRHandTracker::Hand;
+	enum Hand {
+		HAND_LEFT,
+		HAND_RIGHT,
+		HAND_MAX
+	};
 
 private:
 	Hand hand = Hand::HAND_LEFT;
 	Ref<Material> material;
-
-	Skeleton3D *skeleton = nullptr;
 
 	MeshInstance3D *mesh_instance = nullptr;
 
@@ -56,9 +57,9 @@ protected:
 
 	static void _bind_methods();
 
-public:
-	Skeleton3D *get_skeleton() const;
+	void construct_skeleton();
 
+public:
 	MeshInstance3D *get_mesh_instance() const;
 
 	void set_hand(Hand p_hand);
@@ -74,5 +75,7 @@ public:
 	float get_scale_override() const;
 };
 } //namespace godot
+
+VARIANT_ENUM_CAST(OpenXRFbHandTrackingMesh::Hand);
 
 #endif

--- a/common/src/main/cpp/include/extensions/openxr_fb_hand_tracking_capsules_extension_wrapper.h
+++ b/common/src/main/cpp/include/extensions/openxr_fb_hand_tracking_capsules_extension_wrapper.h
@@ -42,7 +42,6 @@ class OpenXRFbHandTrackingCapsulesExtensionWrapper : public OpenXRExtensionWrapp
 	GDCLASS(OpenXRFbHandTrackingCapsulesExtensionWrapper, OpenXRExtensionWrapperExtension);
 
 public:
-	using Hand = XRHandTracker::Hand;
 	using HandJoint = XRHandTracker::HandJoint;
 
 	godot::Dictionary _get_requested_extensions() override;
@@ -78,7 +77,8 @@ private:
 
 	bool fb_hand_tracking_capsules_ext = false;
 
-	XrHandTrackingCapsulesStateFB capsules_state[Hand::HAND_MAX];
+	static const int HAND_MAX = 2;
+	XrHandTrackingCapsulesStateFB capsules_state[HAND_MAX];
 };
 
 #endif // OPENXR_FB_HAND_TRACKING_CAPSULES_EXTENSION_WRAPPER_H

--- a/common/src/main/cpp/include/extensions/openxr_fb_hand_tracking_mesh_extension_wrapper.h
+++ b/common/src/main/cpp/include/extensions/openxr_fb_hand_tracking_mesh_extension_wrapper.h
@@ -30,11 +30,12 @@
 #ifndef OPENXR_FB_HAND_TRACKING_MESH_EXTENSION_WRAPPER_H
 #define OPENXR_FB_HAND_TRACKING_MESH_EXTENSION_WRAPPER_H
 
+#include "classes/openxr_fb_hand_tracking_mesh.h"
+
 #include <openxr/openxr.h>
 #include <godot_cpp/classes/array_mesh.hpp>
 #include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
 #include <godot_cpp/classes/skeleton3d.hpp>
-#include <godot_cpp/classes/xr_hand_tracker.hpp>
 #include <godot_cpp/templates/local_vector.hpp>
 #include <map>
 
@@ -53,7 +54,7 @@ public:
 		LocalVector<XrHandJointEXT> joint_parents;
 	};
 
-	using Hand = XRHandTracker::Hand;
+	using Hand = OpenXRFbHandTrackingMesh::Hand;
 
 	godot::Dictionary _get_requested_extensions() override;
 
@@ -78,7 +79,8 @@ public:
 	void enable_fetch_hand_mesh_data();
 	bool fetch_hand_mesh_data(Hand p_hand);
 	Ref<ArrayMesh> get_mesh(Hand p_hand);
-	void construct_skeleton(Hand p_hand, Skeleton3D *r_skeleton);
+	void construct_skeleton(Skeleton3D *r_skeleton);
+	void reset_skeleton_pose(Hand p_hand, Skeleton3D *r_skeleton);
 
 	OpenXRFbHandTrackingMeshExtensionWrapper();
 	~OpenXRFbHandTrackingMeshExtensionWrapper();

--- a/demo/main.tscn
+++ b/demo/main.tscn
@@ -1,14 +1,13 @@
-[gd_scene load_steps=24 format=4 uid="uid://cqsodpswgup8w"]
+[gd_scene load_steps=23 format=3 uid="uid://cqsodpswgup8w"]
 
 [ext_resource type="Script" path="res://main.gd" id="1_fsva1"]
 [ext_resource type="PackedScene" uid="uid://c0uv4eu2yjm3b" path="res://viewport_2d_in_3d.tscn" id="2_7whgo"]
 [ext_resource type="Image" uid="uid://dcd586e34414y" path="res://assets/color-lut.png" id="2_lpxwd"]
 [ext_resource type="PackedScene" uid="uid://d4b4rllli6tqp" path="res://tablet_content.tscn" id="3_45w5g"]
 [ext_resource type="PackedScene" uid="uid://bcjp8kcgde4cs" path="res://scene_anchor.tscn" id="4_3u3ah"]
-[ext_resource type="Image" uid="uid://dqxb16d1fqtrw" path="res://assets/color-lut-inverted-32.png" id="4_pv7hh"]
 [ext_resource type="PackedScene" uid="uid://cay8oh2ll7yxi" path="res://assets/test_kun/Test-Kun.fbx" id="4_b317s"]
+[ext_resource type="Image" uid="uid://dqxb16d1fqtrw" path="res://assets/color-lut-inverted-32.png" id="4_pv7hh"]
 [ext_resource type="PackedScene" uid="uid://bwfyi8pgigune" path="res://xr_fb_hand_tracking_aim_demo.tscn" id="5_6bxyh"]
-[ext_resource type="PackedScene" uid="uid://bwo5nq0clfe3c" path="res://scene_global_mesh.tscn" id="5_7ikgf"]
 
 [sub_resource type="Gradient" id="Gradient_yvg3n"]
 offsets = PackedFloat32Array(0, 0.484615, 1)
@@ -74,6 +73,10 @@ environment = SubResource("Environment_m0xew")
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
 transform = Transform3D(0.677077, -0.692092, 0.25015, 0.264251, 0.545897, 0.79509, -0.686831, -0.472235, 0.552501, 0, 0, 0)
+
+[node name="Floor_AvatarOffset_Avatar_Test-Kun_Armature_GeneralSkeleton#XRBodyModifier3D" type="XRBodyModifier3D" parent="."]
+transform = Transform3D(-1, 0, -8.74228e-08, 0, 1, 0, 8.74228e-08, 0, -1, 0, 0, 0)
+bone_update = 1
 
 [node name="XROrigin3D" type="XROrigin3D" parent="."]
 
@@ -144,21 +147,52 @@ tracker = &"/user/eyes_ext"
 transform = Transform3D(1, 0, 0, 0, -0.0133513, 0.999911, 0, -0.999911, -0.0133513, 0, 0, -1.18886)
 mesh = SubResource("SphereMesh_5gcab")
 
-[node name="LeftXRHandModifier3D" type="XRHandModifier3D" parent="XROrigin3D"]
-
-[node name="LeftHandModel" type="OpenXRFbHandTrackingMesh" parent="XROrigin3D/LeftXRHandModifier3D"]
-
-[node name="RightXRHandModifier3D" type="XRHandModifier3D" parent="XROrigin3D"]
-hand_tracker = &"/user/right"
-
-[node name="RightHandModel" type="OpenXRFbHandTrackingMesh" parent="XROrigin3D/RightXRHandModifier3D"]
-hand = 1
-
 [node name="OpenXRFbSceneManager" type="OpenXRFbSceneManager" parent="XROrigin3D"]
 default_scene = ExtResource("4_3u3ah")
 auto_create = false
 visible = false
-scenes/global_mesh = ExtResource("5_7ikgf")
+
+[node name="LeftHandTracker" type="XRNode3D" parent="XROrigin3D"]
+tracker = &"/user/hand_tracker/left"
+
+[node name="LeftHandModel" type="OpenXRFbHandTrackingMesh" parent="XROrigin3D/LeftHandTracker"]
+
+[node name="LeftXRHandModifier3D" type="XRHandModifier3D" parent="XROrigin3D/LeftHandTracker/LeftHandModel"]
+
+[node name="RightHandTracker" type="XRNode3D" parent="XROrigin3D"]
+tracker = &"/user/hand_tracker/right"
+
+[node name="RightHandModel" type="OpenXRFbHandTrackingMesh" parent="XROrigin3D/RightHandTracker"]
+hand = 1
+bones/0/name = "RightPalm"
+bones/1/name = "RightHand"
+bones/2/name = "RightThumbMetacarpal"
+bones/3/name = "RightThumbProximal"
+bones/4/name = "RightThumbDistal"
+bones/5/name = "RightThumbTip"
+bones/6/name = "RightIndexMetacarpal"
+bones/7/name = "RightIndexProximal"
+bones/8/name = "RightIndexIntermediate"
+bones/9/name = "RightIndexDistal"
+bones/10/name = "RightIndexTip"
+bones/11/name = "RightMiddleMetacarpal"
+bones/12/name = "RightMiddleProximal"
+bones/13/name = "RightMiddleIntermediate"
+bones/14/name = "RightMiddleDistal"
+bones/15/name = "RightMiddleTip"
+bones/16/name = "RightRingMetacarpal"
+bones/17/name = "RightRingProximal"
+bones/18/name = "RightRingIntermediate"
+bones/19/name = "RightRingDistal"
+bones/20/name = "RightRingTip"
+bones/21/name = "RightLittleMetacarpal"
+bones/22/name = "RightLittleProximal"
+bones/23/name = "RightLittleIntermediate"
+bones/24/name = "RightLittleDistal"
+bones/25/name = "RightLittleTip"
+
+[node name="RightXRHandModifier3D" type="XRHandModifier3D" parent="XROrigin3D/RightHandTracker/RightHandModel"]
+hand_tracker = &"/user/hand_tracker/right"
 
 [node name="Floor" type="MeshInstance3D" parent="."]
 mesh = SubResource("PlaneMesh_mjcgt")
@@ -171,10 +205,6 @@ tracker = &"/user/body_tracker"
 
 [node name="Test-Kun" parent="Floor/AvatarOffset/Avatar" instance=ExtResource("4_b317s")]
 transform = Transform3D(-1, 0, 8.74228e-08, 0, 1, 0, -8.74228e-08, 0, -1, 0, 0, 0)
-
-[node name="XRBodyModifier3D" type="XRBodyModifier3D" parent="Floor/AvatarOffset/Avatar/Test-Kun/Armature/GeneralSkeleton" index="2"]
-transform = Transform3D(-1, 0, -8.74228e-08, 0, 1, 0, 8.74228e-08, 0, -1, 0, 0, 0)
-bone_update = 1
 
 [node name="XRFaceModifier3D" type="XRFaceModifier3D" parent="Floor/AvatarOffset/Avatar"]
 target = NodePath("../Test-Kun/Armature/GeneralSkeleton/Body")

--- a/thirdparty/godot_cpp_gdextension_api/README.md
+++ b/thirdparty/godot_cpp_gdextension_api/README.md
@@ -4,7 +4,7 @@ This directory contains the API JSON for
 [**Godot Engine**](https://github.com/godotengine/godot)'s *GDExtensions* API.
 
 ## Current API version
-- [commit 7529c0bec597d70bc61975a82063bb5112ac8879](https://github.com/godotengine/godot/commit/7529c0bec597d70bc61975a82063bb5112ac8879)
+- [commit 6118592c6d88350d01f74faff6fd49754f84a7d0](https://github.com/godotengine/godot/commit/6118592c6d88350d01f74faff6fd49754f84a7d0)
 
 ## Updating API
 


### PR DESCRIPTION
Updating `OpenXRFbHandTrackingMesh` to work with the new `XRTracker` PR: https://github.com/godotengine/godot/pull/90645

The `OpenXRFbHandTrackingMesh` now inherits from `Skeleton3D`. For it to work with `XRHandModifier3D`, it now constructs the skeleton on `NOTIFICATION_POSTINITIALIZE`, and then does the rest of the setup after the `openxr_fb_hand_tracking_mesh_data_fetched` signal.