### PR TITLE
Fix crash caused by missing `return`

### DIFF
--- a/common/src/main/cpp/extensions/openxr_fb_passthrough_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_fb_passthrough_extension_wrapper.cpp
@@ -844,6 +844,8 @@ bool OpenXRFbPassthroughExtensionWrapper::initialize_fb_triangle_mesh_extension(
 
 bool OpenXRFbPassthroughExtensionWrapper::initialize_meta_passthrough_preferences_extension(const XrInstance p_instance) {
 	GDEXTENSION_INIT_XR_FUNC_V(xrGetPassthroughPreferencesMETA);
+
+	return true;
 }
 
 bool OpenXRFbPassthroughExtensionWrapper::initialize_meta_passthrough_color_lut_extension(const XrInstance p_instance) {


### PR DESCRIPTION
I'm assuming this `return` statement was lost in one of the recent rebases :-)

Without this `return`, I'm getting an odd crash on current `master`:

```
04-26 15:08:11.360  6681  6681 F DEBUG   : signal 5 (SIGTRAP), code 1 (TRAP_BRKPT), fault addr 0x70c2a1e6ec
04-26 15:08:11.360  6681  6681 F DEBUG   :     x0  0000000000000000  x1  b4000070b0dc4910  x2  0000000000000000  x3  00000070aecfc8bc
04-26 15:08:11.360  6681  6681 F DEBUG   :     x4  00000070bc1a064c  x5  666572656e636573  x6  7365636e65726566  x7  7f7f7f7f7f7f7f7f
04-26 15:08:11.360  6681  6681 F DEBUG   :     x8  00000070a619cb74  x9  0000000000000002  x10 0000000000000001  x11 ff80000000000000
04-26 15:08:11.360  6681  6681 F DEBUG   :     x12 000000713a23c7c8  x13 0000000000000001  x14 0000000000000009  x15 0000000000000010
04-26 15:08:11.360  6681  6681 F DEBUG   :     x16 00000070bb1f32a0  x17 00000071c657d19c  x18 00000070aebc6000  x19 b4000070c6d4d310
04-26 15:08:11.360  6681  6681 F DEBUG   :     x20 0100000000000001  x21 0000000000000000  x22 00000070aecfdcc0  x23 b4000070b0cec488
04-26 15:08:11.360  6681  6681 F DEBUG   :     x24 00000070aecfdcc0  x25 0000003fff6f0810  x26 00000070aecfccf0  x27 0000000000001148
04-26 15:08:11.360  6681  6681 F DEBUG   :     x28 00000070aecfd290  x29 00000070aecfc980
04-26 15:08:11.360  6681  6681 F DEBUG   :     lr  00000070c2a1e650  sp  00000070aecfc920  pc  00000070c2a1e6ec  pst 0000000060001000
04-26 15:08:11.360  6681  6681 F DEBUG   : backtrace:
04-26 15:08:11.360  6681  6681 F DEBUG   :       #00 pc 00000000001e96ec  /data/app/~~C97zT0NP8l5wElpFWhovLA==/org.godotengine.openxr.vendors.demo-9FGgp-0ZwDegQ9YuW5li_g==/base.apk!libgodotopenxrvendors.so (OpenXRFbPassthroughExtensionWrapper::initialize_meta_passthrough_preferences_extension(XrInstance_T*)+312) (BuildId: 540b37e6acddcbaeecc01afceace7bb9cd7f6794)
04-26 15:08:11.360  6681  6681 F DEBUG   :       #01 pc 00000000001e803c  /data/app/~~C97zT0NP8l5wElpFWhovLA==/org.godotengine.openxr.vendors.demo-9FGgp-0ZwDegQ9YuW5li_g==/base.apk!libgodotopenxrvendors.so (OpenXRFbPassthroughExtensionWrapper::_on_instance_created(unsigned long)+336) (BuildId: 540b37e6acddcbaeecc01afceace7bb9cd7f6794)
```

It's odd, because `TRAP_BRKPT` suggests that it's stopping on a breakpoint, but I certainly didn't set any breakpoint. And, normally, a C++ function missing a return would trudge onward with junk memory, rather than crash. So, my best guess is that some magic validation is catching this, and then triggering this crash to let us know?

Anyway, adding the `return` statement fixes it :-)