### PR TITLE
Implement XR_FB_composition_layer_settings extension wrapper

### DIFF
--- a/common/src/main/cpp/extensions/openxr_fb_composition_layer_settings_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_fb_composition_layer_settings_extension_wrapper.cpp
@@ -1,0 +1,164 @@
+/**************************************************************************/
+/*  openxr_fb_composition_layer_settings_extension_wrapper.cpp            */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "extensions/openxr_fb_composition_layer_settings_extension_wrapper.h"
+
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+using namespace godot;
+
+static const char *SUPERSAMPLING_MODE_PROPERTY_NAME = "XR_FB_composition_layer_settings/supersampling_mode";
+static const char *SHARPENING_MODE_PROPERTY_NAME = "XR_FB_composition_layer_settings/sharpening_mode";
+
+OpenXRFbCompositionLayerSettingsExtensionWrapper *OpenXRFbCompositionLayerSettingsExtensionWrapper::singleton = nullptr;
+
+OpenXRFbCompositionLayerSettingsExtensionWrapper *OpenXRFbCompositionLayerSettingsExtensionWrapper::get_singleton() {
+	if (singleton == nullptr) {
+		singleton = memnew(OpenXRFbCompositionLayerSettingsExtensionWrapper());
+	}
+	return singleton;
+}
+
+OpenXRFbCompositionLayerSettingsExtensionWrapper::OpenXRFbCompositionLayerSettingsExtensionWrapper() :
+		OpenXRExtensionWrapperExtension() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "An OpenXRFbCompositionLayerSettingsExtensionWrapper singleton already exists.");
+
+	request_extensions[XR_FB_COMPOSITION_LAYER_SETTINGS_EXTENSION_NAME] = &fb_composition_layer_settings;
+	singleton = this;
+}
+
+OpenXRFbCompositionLayerSettingsExtensionWrapper::~OpenXRFbCompositionLayerSettingsExtensionWrapper() {
+	cleanup();
+}
+
+void OpenXRFbCompositionLayerSettingsExtensionWrapper::_bind_methods() {
+	BIND_ENUM_CONSTANT(SUPERSAMPLING_MODE_DISABLED);
+	BIND_ENUM_CONSTANT(SUPERSAMPLING_MODE_NORMAL);
+	BIND_ENUM_CONSTANT(SUPERSAMPLING_MODE_QUALITY);
+
+	BIND_ENUM_CONSTANT(SHARPENING_MODE_DISABLED);
+	BIND_ENUM_CONSTANT(SHARPENING_MODE_NORMAL);
+	BIND_ENUM_CONSTANT(SHARPENING_MODE_QUALITY);
+}
+
+void OpenXRFbCompositionLayerSettingsExtensionWrapper::cleanup() {
+	fb_composition_layer_settings = false;
+}
+
+Dictionary OpenXRFbCompositionLayerSettingsExtensionWrapper::_get_requested_extensions() {
+	Dictionary result;
+	for (auto ext : request_extensions) {
+		uint64_t value = reinterpret_cast<uint64_t>(ext.value);
+		result[ext.key] = (Variant)value;
+	}
+	return result;
+}
+
+uint64_t OpenXRFbCompositionLayerSettingsExtensionWrapper::_set_viewport_composition_layer_and_get_next_pointer(const void *p_layer, const Dictionary &p_property_values, void *p_next_pointer) {
+	if (!fb_composition_layer_settings) {
+		return reinterpret_cast<uint64_t>(p_next_pointer);
+	}
+
+	const XrCompositionLayerBaseHeader *layer = reinterpret_cast<const XrCompositionLayerBaseHeader *>(p_layer);
+
+	if (!layer_structs.has(layer)) {
+		layer_structs[layer] = {
+			XR_TYPE_COMPOSITION_LAYER_SETTINGS_FB, // type
+			p_next_pointer, // next
+			0, // layerFlags
+		};
+	}
+
+	XrCompositionLayerSettingsFB *settings = layer_structs.getptr(layer);
+
+	settings->layerFlags = 0;
+
+	switch ((SupersamplingMode)(int)p_property_values.get(SUPERSAMPLING_MODE_PROPERTY_NAME, SUPERSAMPLING_MODE_DISABLED)) {
+		case SUPERSAMPLING_MODE_NORMAL: {
+			settings->layerFlags |= XR_COMPOSITION_LAYER_SETTINGS_NORMAL_SUPER_SAMPLING_BIT_FB;
+		} break;
+		case SUPERSAMPLING_MODE_QUALITY: {
+			settings->layerFlags |= XR_COMPOSITION_LAYER_SETTINGS_QUALITY_SUPER_SAMPLING_BIT_FB;
+		} break;
+	}
+
+	switch ((SharpeningMode)(int)p_property_values.get(SHARPENING_MODE_PROPERTY_NAME, SHARPENING_MODE_DISABLED)) {
+		case SHARPENING_MODE_NORMAL: {
+			settings->layerFlags |= XR_COMPOSITION_LAYER_SETTINGS_NORMAL_SHARPENING_BIT_FB;
+		} break;
+		case SHARPENING_MODE_QUALITY: {
+			settings->layerFlags |= XR_COMPOSITION_LAYER_SETTINGS_QUALITY_SHARPENING_BIT_FB;
+		} break;
+	}
+
+	if (settings->layerFlags == 0) {
+		return reinterpret_cast<uint64_t>(p_next_pointer);
+	}
+
+	return reinterpret_cast<uint64_t>(settings);
+}
+
+void OpenXRFbCompositionLayerSettingsExtensionWrapper::_on_viewport_composition_layer_destroyed(const void *p_layer) {
+	if (fb_composition_layer_settings) {
+		const XrCompositionLayerBaseHeader *layer = reinterpret_cast<const XrCompositionLayerBaseHeader *>(p_layer);
+		layer_structs.erase(layer);
+	}
+}
+
+TypedArray<Dictionary> OpenXRFbCompositionLayerSettingsExtensionWrapper::_get_viewport_composition_layer_extension_properties() {
+	TypedArray<Dictionary> properties;
+
+	{
+		Dictionary supersampling_mode;
+		supersampling_mode["name"] = SUPERSAMPLING_MODE_PROPERTY_NAME;
+		supersampling_mode["type"] = Variant::INT;
+		supersampling_mode["hint"] = PROPERTY_HINT_ENUM;
+		supersampling_mode["hint_string"] = "Disabled,Normal,Quality";
+		properties.push_back(supersampling_mode);
+	}
+
+	{
+		Dictionary sharpening_mode;
+		sharpening_mode["name"] = SHARPENING_MODE_PROPERTY_NAME;
+		sharpening_mode["type"] = Variant::INT;
+		sharpening_mode["hint"] = PROPERTY_HINT_ENUM;
+		sharpening_mode["hint_string"] = "Disabled,Normal,Quality";
+		properties.push_back(sharpening_mode);
+	}
+
+	return properties;
+}
+
+Dictionary OpenXRFbCompositionLayerSettingsExtensionWrapper::_get_viewport_composition_layer_extension_property_defaults() {
+	Dictionary defaults;
+	defaults[SUPERSAMPLING_MODE_PROPERTY_NAME] = (int)SUPERSAMPLING_MODE_DISABLED;
+	defaults[SHARPENING_MODE_PROPERTY_NAME] = (int)SHARPENING_MODE_DISABLED;
+	return defaults;
+}

--- a/common/src/main/cpp/include/extensions/openxr_fb_composition_layer_settings_extension_wrapper.h
+++ b/common/src/main/cpp/include/extensions/openxr_fb_composition_layer_settings_extension_wrapper.h
@@ -1,0 +1,87 @@
+/**************************************************************************/
+/*  openxr_fb_composition_layer_settings_extension_wrapper.h              */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef OPENXR_FB_COMPOSITION_LAYER_SETTINGS_EXTENSION_WRAPPER_H
+#define OPENXR_FB_COMPOSITION_LAYER_SETTINGS_EXTENSION_WRAPPER_H
+
+#include <openxr/openxr.h>
+
+#include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
+#include <godot_cpp/templates/hash_map.hpp>
+
+using namespace godot;
+
+// Wrapper for XR_FB_composition_layer_settings extension.
+class OpenXRFbCompositionLayerSettingsExtensionWrapper : public OpenXRExtensionWrapperExtension {
+	GDCLASS(OpenXRFbCompositionLayerSettingsExtensionWrapper, OpenXRExtensionWrapperExtension);
+
+public:
+	godot::Dictionary _get_requested_extensions() override;
+
+	static OpenXRFbCompositionLayerSettingsExtensionWrapper *get_singleton();
+
+	enum SupersamplingMode {
+		SUPERSAMPLING_MODE_DISABLED,
+		SUPERSAMPLING_MODE_NORMAL,
+		SUPERSAMPLING_MODE_QUALITY,
+	};
+
+	enum SharpeningMode {
+		SHARPENING_MODE_DISABLED,
+		SHARPENING_MODE_NORMAL,
+		SHARPENING_MODE_QUALITY,
+	};
+
+	virtual uint64_t _set_viewport_composition_layer_and_get_next_pointer(const void *p_layer, const Dictionary &p_property_values, void *p_next_pointer) override;
+	virtual void _on_viewport_composition_layer_destroyed(const void *p_layer) override;
+	virtual TypedArray<Dictionary> _get_viewport_composition_layer_extension_properties() override;
+	virtual Dictionary _get_viewport_composition_layer_extension_property_defaults() override;
+
+	OpenXRFbCompositionLayerSettingsExtensionWrapper();
+	~OpenXRFbCompositionLayerSettingsExtensionWrapper();
+
+protected:
+	static void _bind_methods();
+
+private:
+	void cleanup();
+
+	static OpenXRFbCompositionLayerSettingsExtensionWrapper *singleton;
+
+	HashMap<String, bool *> request_extensions;
+
+	bool fb_composition_layer_settings = false;
+
+	HashMap<const XrCompositionLayerBaseHeader *, XrCompositionLayerSettingsFB> layer_structs;
+};
+
+VARIANT_ENUM_CAST(OpenXRFbCompositionLayerSettingsExtensionWrapper::SupersamplingMode);
+VARIANT_ENUM_CAST(OpenXRFbCompositionLayerSettingsExtensionWrapper::SharpeningMode);
+
+#endif // OPENXR_FB_COMPOSITION_LAYER_SETTINGS_EXTENSION_WRAPPER_H

--- a/common/src/main/cpp/register_types.cpp
+++ b/common/src/main/cpp/register_types.cpp
@@ -46,6 +46,7 @@
 #include "extensions/openxr_fb_body_tracking_extension_wrapper.h"
 #include "extensions/openxr_fb_composition_layer_alpha_blend_extension_wrapper.h"
 #include "extensions/openxr_fb_composition_layer_secure_content_extension_wrapper.h"
+#include "extensions/openxr_fb_composition_layer_settings_extension_wrapper.h"
 #include "extensions/openxr_fb_face_tracking_extension_wrapper.h"
 #include "extensions/openxr_fb_hand_tracking_aim_extension_wrapper.h"
 #include "extensions/openxr_fb_hand_tracking_capsules_extension_wrapper.h"
@@ -122,6 +123,9 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			ClassDB::register_class<OpenXRFbCompositionLayerAlphaBlendExtensionWrapper>();
 			OpenXRFbCompositionLayerAlphaBlendExtensionWrapper::get_singleton()->register_extension_wrapper();
 
+			ClassDB::register_class<OpenXRFbCompositionLayerSettingsExtensionWrapper>();
+			OpenXRFbCompositionLayerSettingsExtensionWrapper::get_singleton()->register_extension_wrapper();
+
 			ClassDB::register_class<OpenXRHtcFacialTrackingExtensionWrapper>();
 			OpenXRHtcFacialTrackingExtensionWrapper::get_singleton()->register_extension_wrapper();
 
@@ -141,6 +145,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			Engine::get_singleton()->register_singleton("OpenXRFbSceneExtensionWrapper", OpenXRFbSceneExtensionWrapper::get_singleton());
 			Engine::get_singleton()->register_singleton("OpenXRFbHandTrackingAimExtensionWrapper", OpenXRFbHandTrackingAimExtensionWrapper::get_singleton());
 			Engine::get_singleton()->register_singleton("OpenXRFbHandTrackingCapsulesExtensionWrapper", OpenXRFbHandTrackingCapsulesExtensionWrapper::get_singleton());
+			Engine::get_singleton()->register_singleton("OpenXRFbCompositionLayerSettingsExtensionWrapper", OpenXRFbCompositionLayerSettingsExtensionWrapper::get_singleton());
 			Engine::get_singleton()->register_singleton("OpenXRHtcFacialTrackingExtensionWrapper", OpenXRHtcFacialTrackingExtensionWrapper::get_singleton());
 
 			ClassDB::register_class<OpenXRFbRenderModel>();


### PR DESCRIPTION
Adds composition layer filtering properties to `OpenXRCompositionLayer` nodes, allowing users to adjust supersampling and sharpening settings. These settings can improve the image quality of composition layers. More info [here](https://developer.oculus.com/documentation/native/android/mobile-openxr-composition-layer-filtering/). Planning to add auto filtering soon as well, which requires the XR_META_automatic_layer_filter extension.

![composition_layer_settings](https://github.com/GodotVR/godot_openxr_vendors/assets/95497005/216308e8-6a61-429d-b7dd-73a07e9ab71b)

