### PR TITLE
Implement hole punch functionality for `OpenXRFbPassthroughGeometry` node

### DIFF
--- a/common/src/main/cpp/include/classes/openxr_fb_passthrough_geometry.h
+++ b/common/src/main/cpp/include/classes/openxr_fb_passthrough_geometry.h
@@ -44,9 +44,13 @@ private:
 	void create_passthrough_geometry();
 	void destroy_passthrough_geometry();
 
-	XrGeometryInstanceFB geometry_instance = XR_NULL_HANDLE;
+	void instatiate_opaque_mesh();
+	void delete_opaque_mesh();
+
 	Ref<Mesh> mesh;
-	MeshInstance3D *preview_mesh = nullptr;
+	bool enable_hole_punch = true;
+	XrGeometryInstanceFB geometry_instance = XR_NULL_HANDLE;
+	MeshInstance3D *opaque_mesh = nullptr;
 
 protected:
 	void _notification(int p_what);
@@ -56,6 +60,9 @@ protected:
 public:
 	void set_mesh(const Ref<Mesh> &p_mesh);
 	Ref<Mesh> get_mesh() const;
+
+	void set_enable_hole_punch(bool p_enable);
+	bool get_enable_hole_punch() const;
 };
 } //namespace godot
 

--- a/demo/main.gd
+++ b/demo/main.gd
@@ -270,11 +270,11 @@ func update_passthrough_mode() -> void:
 			xr_interface.environment_blend_mode = XRInterface.XR_ENV_BLEND_MODE_ALPHA_BLEND
 			passthrough_mode_info.text = STRING_BASE + "Full"
 		OpenXRFbPassthroughExtensionWrapper.LAYER_PURPOSE_RECONSTRUCTION:
+			enable_passthrough_environment(false)
 			xr_interface.environment_blend_mode = XRInterface.XR_ENV_BLEND_MODE_OPAQUE
 			open_xr_fb_passthrough_geometry.show()
 			passthrough_mode_info.text = STRING_BASE + "Geometry"
 		OpenXRFbPassthroughExtensionWrapper.LAYER_PURPOSE_PROJECTED:
-			enable_passthrough_environment(false)
 			open_xr_fb_passthrough_geometry.hide()
 			passthrough_mode_info.text = STRING_BASE + "None"
 


### PR DESCRIPTION
In a similar fashion to https://github.com/godotengine/godot/pull/91485, implements "hole punching" for fb passthrough geometry. This mode makes it so objects behind the passthrough geometry will not be seen, like [the clip in this comment](https://github.com/godotengine/godot/pull/91096#issuecomment-2074150150). The passthrough geometry in this repo's demo now has this enabled.

I believe this mode would be the more common use case for passthrough geometry, so I've set `enable_hole_punch` to `true` by default.