### PR TITLE
Implement XR_META_automatic_layer_filter extension

### DIFF
--- a/common/src/main/cpp/include/extensions/openxr_fb_composition_layer_settings_extension_wrapper.h
+++ b/common/src/main/cpp/include/extensions/openxr_fb_composition_layer_settings_extension_wrapper.h
@@ -77,6 +77,7 @@ private:
 	HashMap<String, bool *> request_extensions;
 
 	bool fb_composition_layer_settings = false;
+	bool meta_automatic_layer_filter = false;
 
 	HashMap<const XrCompositionLayerBaseHeader *, XrCompositionLayerSettingsFB> layer_structs;
 };


### PR DESCRIPTION
This PR is a follow up to https://github.com/GodotVR/godot_openxr_vendors/pull/136. The previous settings have now been moved into a "manual" subcategory, while this PR adds new properties related to the "auto" subcategory. Set `enable_auto_filter` to `true`, and within `options` select the candidate filters you would like it to be able to select from.

If `enable_auto_filter` is `true` and at least one option is selected, automatic filtering will override the manual options.

![composition_layer_auto_filtering](https://github.com/GodotVR/godot_openxr_vendors/assets/95497005/351f8985-0bfa-4883-b864-febac8d23729)
