### PR TITLE
Cleanup: Update hand material resource format

### DIFF
--- a/demo/assets/hand_silhouette_outline_mat.tres
+++ b/demo/assets/hand_silhouette_outline_mat.tres
@@ -1,4 +1,4 @@
-[gd_resource type="ShaderMaterial" load_steps=4 format=4 uid="uid://bdwh0vc86hsdb"]
+[gd_resource type="ShaderMaterial" load_steps=4 format=3 uid="uid://bdwh0vc86hsdb"]
 
 [ext_resource type="Shader" path="res://assets/hand_outline.gdshader" id="1_wpjxj"]
 [ext_resource type="Shader" path="res://assets/hand_silhouette.gdshader" id="2_dvpns"]


### PR DESCRIPTION
When opening up the demo project on godot master, the hand material resource will always be updated to `format=3`.