### PR TITLE
Add settings for HTC

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 - Add XR_FB_hand_tracking_capsules extension wrapper
 - Add OpenXRFbPassthroughGeometry node
 - Add OpenXRMetaPassthroughColorLut
+- Add feature flags to Khronos loader for HTC
 
 ## 2.0.3
 - Migrate the export scripts from gdscript to C++ via gdextension

--- a/common/src/main/cpp/include/export/khronos_export_plugin.h
+++ b/common/src/main/cpp/include/export/khronos_export_plugin.h
@@ -35,16 +35,31 @@
 
 using namespace godot;
 
+static const int MANIFEST_FALSE_VALUE = 0;
+static const int MANIFEST_TRUE_VALUE = 1;
+
 class KhronosEditorExportPlugin : public OpenXREditorExportPlugin {
 	GDCLASS(KhronosEditorExportPlugin, OpenXREditorExportPlugin)
 
 public:
 	KhronosEditorExportPlugin();
 
+	TypedArray<Dictionary> _get_export_options(const Ref<EditorExportPlatform> &platform) const override;
+
+	PackedStringArray _get_export_features(const Ref<EditorExportPlatform> &platform, bool debug) const override;
+
+	String _get_export_option_warning(const Ref<EditorExportPlatform> &platform, const String &option) const override;
+
 	String _get_android_manifest_activity_element_contents(const Ref<EditorExportPlatform> &platform, bool debug) const override;
+	String _get_android_manifest_element_contents(const Ref<EditorExportPlatform> &platform, bool debug) const override;
 
 protected:
 	static void _bind_methods();
+
+	Dictionary _hand_tracking_option;
+	Dictionary _tracker_option;
+	Dictionary _eye_tracking_option;
+	Dictionary _lip_expression_option;
 };
 
 class KhronosEditorPlugin : public EditorPlugin {

--- a/godotopenxrkhronos/src/main/java/org/godotengine/openxr/vendors/khronos/GodotOpenXRKhronos.kt
+++ b/godotopenxrkhronos/src/main/java/org/godotengine/openxr/vendors/khronos/GodotOpenXRKhronos.kt
@@ -68,4 +68,12 @@ class GodotOpenXRKhronos(godot: Godot?) : GodotPlugin(godot) {
     override fun getPluginName(): String {
         return "GodotOpenXRKhronos"
     }
+
+    override fun supportsFeature(featureTag: String): Boolean {
+        if ("PERMISSION_XR_EXT_eye_gaze_interaction" == featureTag) {
+            /* HTC doesn't require permission, if other headsets that use the Khronos loader do, we need to figure out how to tell them apart... */
+            return true
+        }
+        return false
+    }
 }


### PR DESCRIPTION
This adds a number of setting for HTC to the export profiles:

![image](https://github.com/GodotVR/godot_openxr_vendors/assets/1945449/c3ce0dc6-daf5-4f6a-94d5-1866b8da834e)

I've added a subsection for HTC here under a header for Khronos as we'll be adding settings for other platforms in a similar fashion as more and more headsets support the Khronos loader.

Also in the case of HTC these settings are simply `No/Yes`, not `None,Optional,Required`. Unlike with Meta, HTC doesn't gate functionality on these feature flags, these feature flags are purely used by the store to inform the user what features the game makes use of.