### PR TITLE
Add support for HTC passthrough

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 - Add OpenXRFbPassthroughGeometry node
 - Add OpenXRMetaPassthroughColorLut
 - Add feature flags to Khronos loader for HTC
+- Add XR_HTC_passthrough extension wrapper
 
 ## 2.0.3
 - Migrate the export scripts from gdscript to C++ via gdextension

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,3 +14,4 @@ This plugin has been developed by or received contributions from:
 - [Malcolm A Nixon](https://github.com/Malcolmnixon)
 - [David Snopek](https://github.com/dsnopek)
 - [Logan Lang](https://github.com/devloglogan)
+- [Hartmut Seichter](https://github.com/seichter)

--- a/common/src/main/cpp/extensions/openxr_fb_passthrough_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_fb_passthrough_extension_wrapper.cpp
@@ -201,6 +201,10 @@ void OpenXRFbPassthroughExtensionWrapper::_on_session_created(uint64_t p_session
 }
 
 void OpenXRFbPassthroughExtensionWrapper::_on_state_ready() {
+	if (!fb_passthrough_ext) {
+		return;
+	}
+
 	XRInterface::EnvironmentBlendMode blend_mode = get_blend_mode();
 	if (blend_mode == XRInterface::XR_ENV_BLEND_MODE_ALPHA_BLEND) {
 		start_passthrough_layer(LAYER_PURPOSE_RECONSTRUCTION);
@@ -208,6 +212,10 @@ void OpenXRFbPassthroughExtensionWrapper::_on_state_ready() {
 }
 
 void OpenXRFbPassthroughExtensionWrapper::_on_process() {
+	if (!fb_passthrough_ext) {
+		return;
+	}
+
 	XRInterface::EnvironmentBlendMode blend_mode = get_blend_mode();
 
 	// Reconstruction layer will always take priority
@@ -221,6 +229,10 @@ void OpenXRFbPassthroughExtensionWrapper::_on_process() {
 }
 
 bool OpenXRFbPassthroughExtensionWrapper::_on_event_polled(const void *p_event) {
+	if (!fb_passthrough_ext) {
+		return false;
+	}
+
 	if (static_cast<const XrEventDataBuffer *>(p_event)->type == XR_TYPE_EVENT_DATA_PASSTHROUGH_STATE_CHANGED_FB) {
 		XrEventDataPassthroughStateChangedFB *passthrough_event = (XrEventDataPassthroughStateChangedFB *)p_event;
 		switch (passthrough_event->flags) {

--- a/common/src/main/cpp/extensions/openxr_htc_passthrough_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_htc_passthrough_extension_wrapper.cpp
@@ -1,0 +1,160 @@
+/**************************************************************************/
+/*  openxr_htc_passthrough_extension_wrapper.cpp                          */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "extensions/openxr_htc_passthrough_extension_wrapper.h"
+
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
+
+using namespace godot;
+
+OpenXRHtcPassthroughExtensionWrapper *OpenXRHtcPassthroughExtensionWrapper::singleton = nullptr;
+
+OpenXRHtcPassthroughExtensionWrapper *OpenXRHtcPassthroughExtensionWrapper::get_singleton() {
+	if (singleton == nullptr) {
+		singleton = memnew(OpenXRHtcPassthroughExtensionWrapper());
+	}
+	return singleton;
+}
+
+OpenXRHtcPassthroughExtensionWrapper::OpenXRHtcPassthroughExtensionWrapper() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "An OpenXRHtcPassthroughExtensionWrapper singleton already exists.");
+
+	request_extensions[XR_HTC_PASSTHROUGH_EXTENSION_NAME] = &htc_passthrough_ext;
+
+	singleton = this;
+}
+
+OpenXRHtcPassthroughExtensionWrapper::~OpenXRHtcPassthroughExtensionWrapper() {
+	cleanup();
+	singleton = nullptr;
+}
+
+void OpenXRHtcPassthroughExtensionWrapper::cleanup() {
+	htc_passthrough_ext = false;
+}
+
+void OpenXRHtcPassthroughExtensionWrapper::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_passthrough_supported"), &OpenXRHtcPassthroughExtensionWrapper::is_passthrough_supported);
+	ClassDB::bind_method(D_METHOD("is_passthrough_started"), &OpenXRHtcPassthroughExtensionWrapper::is_passthrough_started);
+}
+
+godot::Dictionary OpenXRHtcPassthroughExtensionWrapper::_get_requested_extensions() {
+	godot::Dictionary result;
+
+	for (auto ext : request_extensions) {
+		godot::String key = ext.first;
+		uint64_t value = reinterpret_cast<uint64_t>(ext.second);
+		result[key] = (godot::Variant)value;
+	}
+
+	return result;
+}
+
+void OpenXRHtcPassthroughExtensionWrapper::_on_instance_created(uint64_t p_instance) {
+	XrInstance instance = (XrInstance)p_instance;
+	if (htc_passthrough_ext) {
+		bool result = initialize_htc_passthrough_extension(instance);
+		if (!result) {
+			UtilityFunctions::printerr("Failed to initialize htc_passthrough extension");
+			htc_passthrough_ext = false;
+		}
+	}
+}
+
+void OpenXRHtcPassthroughExtensionWrapper::_on_instance_destroyed() {
+	cleanup();
+}
+
+void OpenXRHtcPassthroughExtensionWrapper::_on_session_created(uint64_t p_session) {
+	if (htc_passthrough_ext) {
+		// If it's already supported, then we don't want to emulate it.
+		if (get_openxr_api()->is_environment_blend_mode_alpha_supported() != OpenXRAPIExtension::OPENXR_ALPHA_BLEND_MODE_SUPPORT_NONE) {
+			return;
+		}
+
+		// Note: With HTC Passthrough, we create our handle and just switch passthrough
+		// by providing, or not providing, a passthrough composition layer.
+		XrSession session = (XrSession)p_session;
+
+		const XrPassthroughCreateInfoHTC create_info = {
+			XR_TYPE_PASSTHROUGH_CREATE_INFO_HTC, // XrStructureType
+			nullptr, // next
+			XR_PASSTHROUGH_FORM_PLANAR_HTC // XrPassthroughFormHTC
+		};
+
+		XrResult result = xrCreatePassthroughHTC(session, &create_info, &passthrough_handle);
+		if (XR_FAILED(result)) {
+			UtilityFunctions::printerr("Failed to create passthrough");
+			passthrough_handle = XR_NULL_HANDLE;
+			return;
+		}
+
+		get_openxr_api()->register_composition_layer_provider(this);
+		get_openxr_api()->set_emulate_environment_blend_mode_alpha_blend(true);
+	}
+}
+
+void OpenXRHtcPassthroughExtensionWrapper::_on_session_destroyed() {
+	if (htc_passthrough_ext && passthrough_handle != XR_NULL_HANDLE) {
+		XrResult result = xrDestroyPassthroughHTC(passthrough_handle);
+		if (XR_FAILED(result)) {
+			UtilityFunctions::printerr("Unable to destroy passthrough feature");
+		}
+		passthrough_handle = XR_NULL_HANDLE;
+
+		get_openxr_api()->unregister_composition_layer_provider(this);
+		get_openxr_api()->set_emulate_environment_blend_mode_alpha_blend(false);
+	}
+}
+
+bool OpenXRHtcPassthroughExtensionWrapper::initialize_htc_passthrough_extension(const XrInstance p_instance) {
+	GDEXTENSION_INIT_XR_FUNC_V(xrCreatePassthroughHTC);
+	GDEXTENSION_INIT_XR_FUNC_V(xrDestroyPassthroughHTC);
+
+	return true;
+}
+
+int OpenXRHtcPassthroughExtensionWrapper::_get_composition_layer_count() {
+	return is_passthrough_started() ? 1 : 0;
+}
+
+uint64_t OpenXRHtcPassthroughExtensionWrapper::_get_composition_layer(int p_index) {
+	if (p_index == 0) {
+		composition_passthrough_layer.passthrough = passthrough_handle;
+		return reinterpret_cast<uint64_t>(&composition_passthrough_layer);
+	} else {
+		return 0;
+	}
+}
+
+int OpenXRHtcPassthroughExtensionWrapper::_get_composition_layer_order(int p_index) {
+	// Ensure the passthrough layer will be behind the projection layer.
+	return -100;
+}
+

--- a/common/src/main/cpp/include/extensions/openxr_htc_passthrough_extension_wrapper.h
+++ b/common/src/main/cpp/include/extensions/openxr_htc_passthrough_extension_wrapper.h
@@ -1,0 +1,122 @@
+/**************************************************************************/
+/*  openxr_htc_passthrough_extension_wrapper.h                            */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef OPENXR_HTC_PASSTHROUGH_EXTENSION_WRAPPER_H
+#define OPENXR_HTC_PASSTHROUGH_EXTENSION_WRAPPER_H
+
+#include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
+#include <godot_cpp/classes/xr_interface.hpp>
+#include <godot_cpp/classes/xr_server.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+#include <openxr/openxr.h>
+
+#include "util.h"
+
+#include <map>
+
+using namespace godot;
+
+// Wrapper for the HTC XR passthrough extension.
+class OpenXRHtcPassthroughExtensionWrapper : public OpenXRExtensionWrapperExtension {
+	GDCLASS(OpenXRHtcPassthroughExtensionWrapper, OpenXRExtensionWrapperExtension);
+
+public:
+	static OpenXRHtcPassthroughExtensionWrapper *get_singleton();
+
+	OpenXRHtcPassthroughExtensionWrapper();
+	~OpenXRHtcPassthroughExtensionWrapper();
+
+	godot::Dictionary _get_requested_extensions() override;
+
+	void _on_instance_created(uint64_t p_instance) override;
+	void _on_instance_destroyed() override;
+	void _on_session_created(uint64_t p_session) override;
+	void _on_session_destroyed() override;
+
+	bool is_passthrough_supported() {
+		return htc_passthrough_ext;
+	}
+
+	bool is_passthrough_started() {
+		return htc_passthrough_ext && (passthrough_handle != XR_NULL_HANDLE) && (get_blend_mode() == XRInterface::XR_ENV_BLEND_MODE_ALPHA_BLEND);
+	}
+
+	int _get_composition_layer_count() override;
+	uint64_t _get_composition_layer(int p_index) override;
+	int _get_composition_layer_order(int p_index) override;
+
+protected:
+	static void _bind_methods();
+
+private:
+	// Create a passthrough feature
+	EXT_PROTO_XRRESULT_FUNC3(xrCreatePassthroughHTC,
+			(XrSession), session,
+			(const XrPassthroughCreateInfoHTC *), create_info,
+			(XrPassthroughHTC *), feature_out)
+
+	// Destroy a previously created passthrough feature
+	EXT_PROTO_XRRESULT_FUNC1(xrDestroyPassthroughHTC, (XrPassthroughHTC), feature)
+
+	static OpenXRHtcPassthroughExtensionWrapper *singleton;
+
+	std::map<godot::String, bool *> request_extensions;
+
+	bool htc_passthrough_ext = false;
+
+	XrPassthroughHTC passthrough_handle = XR_NULL_HANDLE;
+
+	XrCompositionLayerPassthroughHTC composition_passthrough_layer = {
+		XR_TYPE_COMPOSITION_LAYER_PASSTHROUGH_HTC, // XrStructureType
+		nullptr, // next
+		XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT, //  XrCompositionLayerFlags
+		XR_NULL_HANDLE, // XrSpace
+		XR_NULL_HANDLE, // XrPassthroughHTC
+		{
+				// XrPassthroughColorHTC
+				XR_TYPE_PASSTHROUGH_COLOR_HTC, // XrStructureType
+				nullptr, // next
+				1.0f // alpha (preset to opaque)
+		}
+	};
+
+	bool initialize_htc_passthrough_extension(const XrInstance p_instance);
+	void cleanup();
+
+	XRInterface::EnvironmentBlendMode get_blend_mode() {
+		Ref<XRInterface> xr_interface = XRServer::get_singleton()->find_interface("OpenXR");
+		if (xr_interface.is_valid()) {
+			return xr_interface->get_environment_blend_mode();
+		}
+		return XRInterface::XR_ENV_BLEND_MODE_OPAQUE;
+	}
+};
+
+#endif // OPENXR_HTC_PASSTHROUGH_EXTENSION_WRAPPER_H

--- a/common/src/main/cpp/register_types.cpp
+++ b/common/src/main/cpp/register_types.cpp
@@ -63,6 +63,7 @@
 #include "extensions/openxr_fb_spatial_entity_storage_batch_extension_wrapper.h"
 #include "extensions/openxr_fb_spatial_entity_user_extension_wrapper.h"
 #include "extensions/openxr_htc_facial_tracking_extension_wrapper.h"
+#include "extensions/openxr_htc_passthrough_extension_wrapper.h"
 #include "extensions/openxr_meta_spatial_entity_mesh_extension_wrapper.h"
 
 #include "classes/openxr_fb_hand_tracking_mesh.h"
@@ -144,6 +145,9 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			ClassDB::register_class<OpenXRHtcFacialTrackingExtensionWrapper>();
 			OpenXRHtcFacialTrackingExtensionWrapper::get_singleton()->register_extension_wrapper();
 
+			ClassDB::register_class<OpenXRHtcPassthroughExtensionWrapper>();
+			OpenXRHtcPassthroughExtensionWrapper::get_singleton()->register_extension_wrapper();
+
 		} break;
 
 		case MODULE_INITIALIZATION_LEVEL_SERVERS:
@@ -162,6 +166,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			Engine::get_singleton()->register_singleton("OpenXRFbHandTrackingCapsulesExtensionWrapper", OpenXRFbHandTrackingCapsulesExtensionWrapper::get_singleton());
 			Engine::get_singleton()->register_singleton("OpenXRFbCompositionLayerSettingsExtensionWrapper", OpenXRFbCompositionLayerSettingsExtensionWrapper::get_singleton());
 			Engine::get_singleton()->register_singleton("OpenXRHtcFacialTrackingExtensionWrapper", OpenXRHtcFacialTrackingExtensionWrapper::get_singleton());
+			Engine::get_singleton()->register_singleton("OpenXRHtcPassthroughExtensionWrapper", OpenXRHtcPassthroughExtensionWrapper::get_singleton());
 
 			ClassDB::register_class<OpenXRFbRenderModel>();
 			ClassDB::register_class<OpenXRFbHandTrackingMesh>();


### PR DESCRIPTION
This PR adds support for HTCs version of passthrough in a way that is transparent to the user.
Here we also react to our blend mode.

I did have to add some extra checks to the Meta implementation because while the HTC implementation became active, Metas implementation wasn't checking whether it was actually active and just started error spamming as a result :P

Note that there is an interesting difference here as well, while Meta explicitly requires us to start and stop passthrough, HTC doesn't. We do need to create a passthrough handle once the session is setup, but from then on passthrough is purely switched on whether the passthrough composition layer is added.

I am making the assumption here, and I think that's a fairly safe assumption, that no device is going to support both Metas and HTCs passthrough extensions. If this does become an issue we may need to do something like `set_emulate_environment_blend_mode_alpha_blend` returning an error when another extension has already claimed it.

Tested this on my HTC Elite XR and seems to work fine. 

Note, thanks to @seichter (PR https://github.com/godotengine/godot/pull/86407) for doing much of the ground work. Made it really easy to implement this in the vendor plugin. 