### PR TITLE
Update color map resource to gradient type

### DIFF
--- a/common/src/main/cpp/extensions/openxr_fb_passthrough_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_fb_passthrough_extension_wrapper.cpp
@@ -30,7 +30,6 @@
 
 #include "extensions/openxr_fb_passthrough_extension_wrapper.h"
 
-#include <godot_cpp/classes/gradient.hpp>
 #include <godot_cpp/classes/image.hpp>
 #include <godot_cpp/classes/main_loop.hpp>
 #include <godot_cpp/classes/open_xrapi_extension.hpp>
@@ -577,13 +576,13 @@ void OpenXRFbPassthroughExtensionWrapper::set_passthrough_filter(PassthroughFilt
 	}
 }
 
-void OpenXRFbPassthroughExtensionWrapper::set_color_map(const Ref<GradientTexture1D> &p_gradient) {
+void OpenXRFbPassthroughExtensionWrapper::set_color_map(const Ref<Gradient> &p_gradient) {
 	if (p_gradient.is_null()) {
 		return;
 	}
 
 	for (int i = 0; i < XR_PASSTHROUGH_COLOR_MAP_MONO_SIZE_FB; i++) {
-		Color sample_color = p_gradient->get_gradient()->sample((double)i / (double)XR_PASSTHROUGH_COLOR_MAP_MONO_SIZE_FB);
+		Color sample_color = p_gradient->sample((double)i / (double)XR_PASSTHROUGH_COLOR_MAP_MONO_SIZE_FB);
 		color_map.textureColorMap[i] = { sample_color.r, sample_color.g, sample_color.b, sample_color.a };
 	}
 

--- a/common/src/main/cpp/include/extensions/openxr_fb_passthrough_extension_wrapper.h
+++ b/common/src/main/cpp/include/extensions/openxr_fb_passthrough_extension_wrapper.h
@@ -35,7 +35,7 @@
 #include "classes/openxr_meta_passthrough_color_lut.h"
 
 #include <godot_cpp/classes/curve.hpp>
-#include <godot_cpp/classes/gradient_texture1_d.hpp>
+#include <godot_cpp/classes/gradient.hpp>
 #include <godot_cpp/classes/mesh.hpp>
 #include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
 #include <godot_cpp/classes/xr_interface.hpp>
@@ -123,7 +123,7 @@ public:
 
 	void set_passthrough_filter(PassthroughFilter p_filter);
 	PassthroughFilter get_current_passthrough_filter() { return current_passthrough_filter; }
-	void set_color_map(const Ref<GradientTexture1D> &p_gradient);
+	void set_color_map(const Ref<Gradient> &p_gradient);
 	void set_mono_map(const Ref<Curve> &p_curve);
 	void set_brightness_contrast_saturation(float p_brightness, float p_contrast, float p_saturation);
 

--- a/demo/main.gd
+++ b/demo/main.gd
@@ -1,6 +1,6 @@
 extends Node3D
 
-@export var passthrough_gradient: GradientTexture1D
+@export var passthrough_gradient: Gradient
 @export var passthrough_curve: Curve
 @export var bcs: Vector3
 @export var color_lut: Image

--- a/demo/main.tscn
+++ b/demo/main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=28 format=3 uid="uid://cqsodpswgup8w"]
+[gd_scene load_steps=27 format=3 uid="uid://cqsodpswgup8w"]
 
 [ext_resource type="Script" path="res://main.gd" id="1_fsva1"]
 [ext_resource type="PackedScene" uid="uid://c0uv4eu2yjm3b" path="res://viewport_2d_in_3d.tscn" id="2_7whgo"]
@@ -12,12 +12,9 @@
 [ext_resource type="PackedScene" uid="uid://dsfd7xrm6o50p" path="res://spatial_anchor.tscn" id="5_g7mio"]
 [ext_resource type="Material" uid="uid://bdwh0vc86hsdb" path="res://assets/hand_silhouette_outline_mat.tres" id="7_tpkib"]
 
-[sub_resource type="Gradient" id="Gradient_yvg3n"]
-offsets = PackedFloat32Array(0, 0.484615, 1)
-colors = PackedColorArray(0.989632, 1, 0, 1, 0, 0.117083, 1, 1, 1, 0, 0.89539, 1)
-
-[sub_resource type="GradientTexture1D" id="GradientTexture1D_syqxs"]
-gradient = SubResource("Gradient_yvg3n")
+[sub_resource type="Gradient" id="Gradient_hxe3h"]
+offsets = PackedFloat32Array(0, 0.5, 1)
+colors = PackedColorArray(1, 1, 0, 1, 0, 0, 1, 1, 1, 0, 1, 1)
 
 [sub_resource type="Curve" id="Curve_ykaux"]
 _data = [Vector2(0, 0), 0.0, 0.0, 0, 0, Vector2(0.240642, 1), 0.0, 0.0, 0, 0, Vector2(0.502674, 0), 0.0, 0.0, 0, 0, Vector2(0.759358, 1), 0.0, 0.0, 0, 0, Vector2(1, 0), 0.0, 0.0, 0, 0]
@@ -72,7 +69,7 @@ size = Vector2(10, 10)
 
 [node name="Main" type="Node3D"]
 script = ExtResource("1_fsva1")
-passthrough_gradient = SubResource("GradientTexture1D_syqxs")
+passthrough_gradient = SubResource("Gradient_hxe3h")
 passthrough_curve = SubResource("Curve_ykaux")
 bcs = Vector3(-10, 50, 0)
 color_lut = ExtResource("2_lpxwd")
@@ -185,7 +182,6 @@ tracker = &"/user/hand_tracker/right"
 [node name="RightHandModel" type="OpenXRFbHandTrackingMesh" parent="XROrigin3D/RightHandTracker"]
 hand = 1
 material = ExtResource("7_tpkib")
-use_scale_override = false
 bones/0/name = "RightPalm"
 bones/1/name = "RightHand"
 bones/2/name = "RightThumbMetacarpal"


### PR DESCRIPTION
Changes the color map passthrough filter resource from `GradientTexture1D` to `Gradient`. I was just calling `get_gradient()` from the `GradientTexture1D`, so this change is more efficient and cuts out that extra step.

I've also removed the meaningless line of `use_scale_override = false` from `main.tscn` which should have been removed in a previous hand tacking mesh cleanup PR.