### PR TITLE
Generate normals and tangets for Meta's global scene mesh

### DIFF
--- a/common/src/main/cpp/classes/openxr_fb_spatial_entity.cpp
+++ b/common/src/main/cpp/classes/openxr_fb_spatial_entity.cpp
@@ -36,6 +36,7 @@
 #include <godot_cpp/classes/concave_polygon_shape3d.hpp>
 #include <godot_cpp/classes/mesh_instance3d.hpp>
 #include <godot_cpp/classes/plane_mesh.hpp>
+#include <godot_cpp/classes/surface_tool.hpp>
 #include <godot_cpp/templates/local_vector.hpp>
 
 #include "extensions/openxr_fb_spatial_entity_extension_wrapper.h"
@@ -265,9 +266,16 @@ MeshInstance3D *OpenXRFbSpatialEntity::create_mesh_instance() const {
 	MeshInstance3D *mesh_instance = nullptr;
 
 	if (is_component_enabled(COMPONENT_TYPE_TRIANGLE_MESH)) {
+		Ref<SurfaceTool> surface_tool;
+		surface_tool.instantiate();
+
+		surface_tool->create_from_arrays(get_triangle_mesh(), Mesh::PRIMITIVE_TRIANGLES);
+		surface_tool->generate_normals();
+		surface_tool->generate_tangents();
+
 		Ref<ArrayMesh> array_mesh;
 		array_mesh.instantiate();
-		array_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, get_triangle_mesh());
+		array_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, surface_tool->commit_to_arrays());
 
 		mesh_instance = memnew(MeshInstance3D);
 		mesh_instance->set_mesh(array_mesh);


### PR DESCRIPTION
@Nitwel brought up on Discord that `OpenXRFbSpatialEntity.create_mesh_instance()` for the global scene mesh won't have normals or tangents and hence can't be correctly lit.

Since developers can access the raw data we get from the API via `OpenXRFbSpatialEntity.get_triangle_mesh()`, I think doing this extra bit of processing in `create_mesh_instance()` makes sense.

(I had thought this would maybe allow us to remove the "deindexing" that we're doing in `scene_global_mesh.gd`, because `SurfaceTool` has to deindex the mesh in order to generate the normals, however, it will automatically re-index it afterwards. I had considered purposefully deindexing it, but that increases the size of the mesh data by a lot, and I don't know if most folks will end up needing that anyway. So, I just stuck with what we previously had in `scene_global_mesh.gd` for now.)