### PR TITLE
Add API documentation for Meta's Scene Understanding and Spatial Anchor APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ local.properties
 
 # Misc
 .DS_Store
+/common/src/gen/

--- a/SConstruct
+++ b/SConstruct
@@ -19,6 +19,10 @@ sources += Glob("#common/src/main/cpp/export/*.cpp")
 sources += Glob("#common/src/main/cpp/extensions/*.cpp")
 sources += Glob("#common/src/main/cpp/classes/*.cpp")
 
+if env["target"] in ["editor", "template_debug"]:
+  doc_data = env.GodotCPPDocData("#common/src/gen/doc_data.gen.cpp", source=Glob("doc_classes/*.xml"))
+  sources.append(doc_data)
+
 binary_path = '#demo/addons/godotopenxrvendors/.bin'
 project_name = 'godotopenxrvendors'
 

--- a/common/src/main/cpp/classes/openxr_fb_spatial_entity_query.cpp
+++ b/common/src/main/cpp/classes/openxr_fb_spatial_entity_query.cpp
@@ -178,7 +178,7 @@ bool OpenXRFbSpatialEntityQuery::_execute_query_by_uuid() {
 		XR_TYPE_SPACE_QUERY_INFO_FB, // type
 		nullptr, // next
 		XR_SPACE_QUERY_ACTION_LOAD_FB, // queryAction
-		max_results, // maxResultsCount
+		uuid_array.size(), // maxResultsCount
 		(XrDuration)(timeout * 1000000), // timeout
 		(XrSpaceFilterInfoBaseHeaderFB *)&filter, // filter
 		nullptr, // excludeFilter

--- a/doc_classes/OpenXRFbCompositionLayerAlphaBlendExtensionWrapper.xml
+++ b/doc_classes/OpenXRFbCompositionLayerAlphaBlendExtensionWrapper.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OpenXRFbCompositionLayerAlphaBlendExtensionWrapper" inherits="OpenXRExtensionWrapperExtension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<constants>
+		<constant name="BLEND_FACTOR_ZERO" value="0" enum="BlendFactor">
+		</constant>
+		<constant name="BLEND_FACTOR_ONE" value="1" enum="BlendFactor">
+		</constant>
+		<constant name="BLEND_FACTOR_SRC_ALPHA" value="2" enum="BlendFactor">
+		</constant>
+		<constant name="BLEND_FACTOR_ONE_MINUS_SRC_ALPHA" value="3" enum="BlendFactor">
+		</constant>
+		<constant name="BLEND_FACTOR_DST_ALPHA" value="4" enum="BlendFactor">
+		</constant>
+		<constant name="BLEND_FACTOR_ONE_MINUS_DST_ALPHA" value="5" enum="BlendFactor">
+		</constant>
+	</constants>
+</class>

--- a/doc_classes/OpenXRFbCompositionLayerSettingsExtensionWrapper.xml
+++ b/doc_classes/OpenXRFbCompositionLayerSettingsExtensionWrapper.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OpenXRFbCompositionLayerSettingsExtensionWrapper" inherits="OpenXRExtensionWrapperExtension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<constants>
+		<constant name="SUPERSAMPLING_MODE_DISABLED" value="0" enum="SupersamplingMode">
+		</constant>
+		<constant name="SUPERSAMPLING_MODE_NORMAL" value="1" enum="SupersamplingMode">
+		</constant>
+		<constant name="SUPERSAMPLING_MODE_QUALITY" value="2" enum="SupersamplingMode">
+		</constant>
+		<constant name="SHARPENING_MODE_DISABLED" value="0" enum="SharpeningMode">
+		</constant>
+		<constant name="SHARPENING_MODE_NORMAL" value="1" enum="SharpeningMode">
+		</constant>
+		<constant name="SHARPENING_MODE_QUALITY" value="2" enum="SharpeningMode">
+		</constant>
+	</constants>
+</class>

--- a/doc_classes/OpenXRFbHandTrackingCapsulesExtensionWrapper.xml
+++ b/doc_classes/OpenXRFbHandTrackingCapsulesExtensionWrapper.xml
@@ -7,33 +7,33 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="get_hand_capsule_count">
+		<method name="get_hand_capsule_count" qualifiers="const">
 			<return type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="get_hand_capsule_height">
+		<method name="get_hand_capsule_height" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="hand_index" type="int" />
 			<param index="1" name="capsule_index" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="get_hand_capsule_joint">
+		<method name="get_hand_capsule_joint" qualifiers="const">
 			<return type="int" enum="XRHandTracker.HandJoint" />
 			<param index="0" name="hand_index" type="int" />
 			<param index="1" name="capsule_index" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="get_hand_capsule_radius">
+		<method name="get_hand_capsule_radius" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="hand_index" type="int" />
 			<param index="1" name="capsule_index" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="get_hand_capsule_transform">
+		<method name="get_hand_capsule_transform" qualifiers="const">
 			<return type="Transform3D" />
 			<param index="0" name="hand_index" type="int" />
 			<param index="1" name="capsule_index" type="int" />

--- a/doc_classes/OpenXRFbHandTrackingMesh.xml
+++ b/doc_classes/OpenXRFbHandTrackingMesh.xml
@@ -7,7 +7,7 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="get_mesh_instance">
+		<method name="get_mesh_instance" qualifiers="const">
 			<return type="MeshInstance3D" />
 			<description>
 			</description>
@@ -18,9 +18,9 @@
 		</member>
 		<member name="material" type="Material" setter="set_material" getter="get_material">
 		</member>
-		<member name="scale_override" type="float" setter="set_scale_override" getter="get_scale_override" default="2.51113e-42">
+		<member name="scale_override" type="float" setter="set_scale_override" getter="get_scale_override">
 		</member>
-		<member name="use_scale_override" type="bool" setter="set_use_scale_override" getter="get_use_scale_override" default="true">
+		<member name="use_scale_override" type="bool" setter="set_use_scale_override" getter="get_use_scale_override">
 		</member>
 	</members>
 	<constants>

--- a/doc_classes/OpenXRFbPassthroughExtensionWrapper.xml
+++ b/doc_classes/OpenXRFbPassthroughExtensionWrapper.xml
@@ -85,7 +85,7 @@
 		</method>
 		<method name="set_color_map">
 			<return type="void" />
-			<param index="0" name="gradient" type="GradientTexture1D" />
+			<param index="0" name="gradient" type="Gradient" />
 			<description>
 			</description>
 		</method>

--- a/doc_classes/OpenXRFbPassthroughGeometry.xml
+++ b/doc_classes/OpenXRFbPassthroughGeometry.xml
@@ -7,6 +7,8 @@
 	<tutorials>
 	</tutorials>
 	<members>
+		<member name="enable_hole_punch" type="bool" setter="set_enable_hole_punch" getter="get_enable_hole_punch" default="true">
+		</member>
 		<member name="mesh" type="Mesh" setter="set_mesh" getter="get_mesh">
 		</member>
 	</members>

--- a/doc_classes/OpenXRFbRenderModelExtensionWrapper.xml
+++ b/doc_classes/OpenXRFbRenderModelExtensionWrapper.xml
@@ -7,7 +7,7 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="is_enabled">
+		<method name="is_enabled" qualifiers="const">
 			<return type="bool" />
 			<description>
 			</description>

--- a/doc_classes/OpenXRFbSceneCaptureExtensionWrapper.xml
+++ b/doc_classes/OpenXRFbSceneCaptureExtensionWrapper.xml
@@ -1,31 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="OpenXRFbSceneCaptureExtensionWrapper" inherits="OpenXRExtensionWrapperExtension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
+		Wraps the [code]XR_FB_scene_capture[/code] extension.
 	</brief_description>
 	<description>
+		Wraps the [code]XR_FB_scene_capture[/code] extension.
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="is_scene_capture_enabled">
+		<method name="is_scene_capture_enabled" deprecated="Use [method OpenXRFbSceneManager.is_scene_capture_enabled] instead.">
 			<return type="bool" />
 			<description>
+				Checks if this extension is enabled.
 			</description>
 		</method>
-		<method name="is_scene_capture_supported">
+		<method name="is_scene_capture_supported" deprecated="Use [method OpenXRFbSceneManager.is_scene_capture_enabled] instead.">
 			<return type="bool" />
 			<description>
+				Checks if scene capture is supported.
 			</description>
 		</method>
-		<method name="request_scene_capture">
+		<method name="request_scene_capture" deprecated="Use [method OpenXRFbSceneManager.request_scene_capture] instead.">
 			<return type="bool" />
 			<description>
+				Requests the user go through the scene capture process.
+				The [signal scene_capture_completed] signal will be emitted when the process has completed.
 			</description>
 		</method>
 	</methods>
 	<signals>
 		<signal name="scene_capture_completed">
 			<description>
+				Emitted when the scene capture process is completed.
 			</description>
 		</signal>
 	</signals>

--- a/doc_classes/OpenXRFbSceneExtensionWrapper.xml
+++ b/doc_classes/OpenXRFbSceneExtensionWrapper.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="OpenXRFbSceneExtensionWrapper" inherits="OpenXRExtensionWrapperExtension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
+		Wraps the [code]XR_FB_scene[/code] extension.
 	</brief_description>
 	<description>
+		Wraps the [code]XR_FB_scene[/code] extension.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,6 +12,7 @@
 		<method name="is_scene_supported">
 			<return type="bool" />
 			<description>
+				Checks if this extension is supported.
 			</description>
 		</method>
 	</methods>

--- a/doc_classes/OpenXRFbSceneManager.xml
+++ b/doc_classes/OpenXRFbSceneManager.xml
@@ -1,74 +1,101 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="OpenXRFbSceneManager" inherits="Node" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
+		Provides an easy-to-use way to interact with Meta's Scene Understanding.
 	</brief_description>
 	<description>
+		Provides an easy-to-use way to interact with Meta's Scene Understanding.
+		This node allows you to register scenes to be instantiated for each scene anchor that is discovered, and provide a method that will be called on them after creation with a [OpenXRFbSpatialEntity] that can be used to setup the scene using data from the scene anchor.
+		Each instantiated scene will be added as a child of an [XRAnchor3D] node that will be positioned using tracking data from the headset.
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="are_scene_anchors_created">
+		<method name="are_scene_anchors_created" qualifiers="const">
 			<return type="bool" />
 			<description>
+				Checks if the scene anchors have been created already or not.
 			</description>
 		</method>
 		<method name="create_scene_anchors">
 			<return type="int" enum="Error" />
 			<description>
+				Attempts to create the scene anchors discovered in the physical space around the user.
+				This is an asynchronous operation - the [signal openxr_fb_scene_data_missing] signal will be emitted if no scene data can be found, and the [signal openxr_fb_scene_anchor_created] signal will be emitted for each scene anchor successfully created.
+				This will only work during an active OpenXR session. If you've set [member auto_create] to [code]true[/code], then this method will be called automatically when an OpenXR session has begun.
 			</description>
 		</method>
-		<method name="get_anchor_node">
+		<method name="get_anchor_node" qualifiers="const">
 			<return type="XRAnchor3D" />
 			<param index="0" name="uuid" type="StringName" />
 			<description>
+				Gets the [XRAnchor3D] node which was created for the spatial entity with the given UUID.
+				Note: All anchors will be created asynchronously, either by calling [method create_scene_anchors] or when the OpenXR session begins if [member auto_create] is set to [code]true[/code].
 			</description>
 		</method>
-		<method name="get_anchor_uuids">
+		<method name="get_anchor_uuids" qualifiers="const">
 			<return type="Array" />
 			<description>
+				Gets the UUIDs of all scene anchors that have been created.
+				Note: All anchors will be created asynchronously, either by calling [method create_scene_anchors] or when the OpenXR session begins if [member auto_create] is set to [code]true[/code].
 			</description>
 		</method>
-		<method name="get_spatial_entity">
+		<method name="get_spatial_entity" qualifiers="const">
 			<return type="OpenXRFbSpatialEntity" />
 			<param index="0" name="uuid" type="StringName" />
 			<description>
+				Gets the spatial entity identified by the given UUID.
+				Note: Only works for spatial entities that were loaded as a result of calling [method create_scene_anchors] or when the OpenXR session begins if [member auto_create] is set to [code]true[/code].
 			</description>
 		</method>
 		<method name="hide">
 			<return type="void" />
 			<description>
+				Hides all scene anchors created by this manager.
 			</description>
 		</method>
-		<method name="is_scene_capture_enabled">
+		<method name="is_scene_capture_enabled" qualifiers="const">
 			<return type="bool" />
 			<description>
+				Checks if scene capture is enabled.
 			</description>
 		</method>
 		<method name="remove_scene_anchors">
 			<return type="void" />
 			<description>
+				Removes all scene anchors.
+				This will be done automatically when the OpenXR session ends, or when this node is removed from the scene tree.
 			</description>
 		</method>
-		<method name="request_scene_capture">
+		<method name="request_scene_capture" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="request" type="String" default="&quot;&quot;" />
 			<description>
+				Requests the user go through the scene capture process.
+				This will only work if scene capture is enabled, which can be checked by calling [method is_scene_capture_enabled].
+				The [signal openxr_fb_scene_capture_completed] signal will be emitted when the process has completed.
 			</description>
 		</method>
 		<method name="show">
 			<return type="void" />
 			<description>
+				Shows all scene anchors created by this manager, if they had been previously hidden.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="auto_create" type="bool" setter="set_auto_create" getter="get_auto_create" default="true">
+			If enabled, this node will run [method create_scene_anchors] when an OpenXR session starts.
 		</member>
 		<member name="default_scene" type="PackedScene" setter="set_default_scene" getter="get_default_scene">
+			The default scene to be instatiated for any scene anchor, if there isn't a scene registered for the given type of scene anchor.
 		</member>
 		<member name="scene_setup_method" type="StringName" setter="set_scene_setup_method" getter="get_scene_setup_method" default="&amp;&quot;setup_scene&quot;">
+			The method that will be called on scenes after they have been instantiated for a scene anchor.
+			The method will be called with a single [OpenXRFbSpatialEntity] argument, representing the scene anchor.
 		</member>
 		<member name="visible" type="bool" setter="set_visible" getter="get_visible" default="true">
+			Controls the visibility of the scene anchors managed by this node.
 		</member>
 	</members>
 	<signals>
@@ -76,15 +103,20 @@
 			<param index="0" name="scene_node" type="Object" />
 			<param index="1" name="spatial_entity" type="Object" />
 			<description>
+				Emitted when a new scene anchor is created.
+				It will receive the scene that was instantiated, and the `OpenXRFbSpatialEntity` object representing the scene anchor.
 			</description>
 		</signal>
 		<signal name="openxr_fb_scene_capture_completed">
 			<param index="0" name="success" type="bool" />
 			<description>
+				Emitted when the scene capture process is completed.
 			</description>
 		</signal>
 		<signal name="openxr_fb_scene_data_missing">
 			<description>
+				Emitted after [method create_scene_anchors] is called (or the OpenXR session has begun if [member auto_create] is [code]true[/code]), if no scene data can be found.
+				Depending on your application, this may be a good time to initiate the scene capture process via [method request_scene_capture].
 			</description>
 		</signal>
 	</signals>

--- a/doc_classes/OpenXRFbSpatialAnchorManager.xml
+++ b/doc_classes/OpenXRFbSpatialAnchorManager.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OpenXRFbSpatialAnchorManager" inherits="Node" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Provides an easy-to-use way to interact with Meta's Spatial Anchors.
+	</brief_description>
+	<description>
+		Provides an easy-to-use way to interact with Meta's Spatial Anchors.
+		Spatial anchors allow the developer to place virtual objects in a real world location that is persisted over time and adjusted by the headsets tracking.
+		This node allows creating, loading, or removing spatial anchors; and instantiating a scene to represent the virtual objects located at those anchors. Each instantiated scene will be added as a child of an [XRAnchor3D] node that will be positioned using tracking data from the headset.
+		Even though the spatial anchors are saved to the headset's local storage, only the UUID and position are saved. Any application-specific data about what those spatial anchors actually represent (for example, what virtual object is placed there) must be saved by the developer in some other way (for example, as a file saved in [code]user://[/code]). For this reason, spatial anchors aren't automatically loaded (like [OpenXRFbSceneManager] does for scene anchors), and the developer must call [method load_anchors] to reload persisted anchors.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="create_anchor">
+			<return type="void" />
+			<param index="0" name="transform" type="Transform3D" />
+			<param index="1" name="custom_data" type="Dictionary" default="{}" />
+			<description>
+				Creates a new spatial anchor at the given position (in global space).
+				The [param custom_data] argument is application-specific data about what the spatial entity represents (for example, what virtual object should be placed there). This data will be stashed on [member OpenXRFbSpatialEntity.custom_data].
+				This is an asynchronous operation - the [signal openxr_fb_spatial_anchor_tracked] signal will be emitted if creation was successful, or the [signal openxr_fb_spatial_anchor_create_failed] signal will be emitted if unsuccessful.
+			</description>
+		</method>
+		<method name="get_anchor_node" qualifiers="const">
+			<return type="XRAnchor3D" />
+			<param index="0" name="uuid" type="StringName" />
+			<description>
+				Gets the [XRAnchor3D] node which was created for the spatial entity with the given UUID.
+				Note: All anchors will be created asynchronously via [method create_anchor], [method load_anchor], [method load_anchors], or [method track_anchor].
+			</description>
+		</method>
+		<method name="get_anchor_uuids" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Gets the UUIDs of all spatial anchors that have been created.
+				Note: All anchors will be created asynchronously via [method create_anchor], [method load_anchor], [method load_anchors], or [method track_anchor].
+			</description>
+		</method>
+		<method name="get_spatial_entity" qualifiers="const">
+			<return type="OpenXRFbSpatialEntity" />
+			<param index="0" name="uuid" type="StringName" />
+			<description>
+				Gets the spatial entity identified by the given UUID.
+				Note: All anchors will be created asynchronously via [method create_anchor], [method load_anchor], [method load_anchors], or [method track_anchor].
+			</description>
+		</method>
+		<method name="hide">
+			<return type="void" />
+			<description>
+				Hides all spatial anchors created by this manager.
+			</description>
+		</method>
+		<method name="load_anchor">
+			<return type="void" />
+			<param index="0" name="uuid" type="StringName" />
+			<param index="1" name="custom_data" type="Dictionary" default="{}" />
+			<param index="2" name="location" type="int" enum="OpenXRFbSpatialEntity.StorageLocation" default="0" />
+			<description>
+				Loads a spatial anchor with the given UUID from the given storage.
+				The [param custom_data] argument is application-specific data about what the spatial entity represents (for example, what virtual object should be placed there). This data will be stashed on [member OpenXRFbSpatialEntity.custom_data].
+				This is an asynchronous operation - the [signal openxr_fb_spatial_anchor_tracked] signal will be emitted if the load was successful, or the [signal openxr_fb_spatial_anchor_load_failed] signal will be emitted if unsuccessful.
+			</description>
+		</method>
+		<method name="load_anchors">
+			<return type="void" />
+			<param index="0" name="uuids" type="StringName[]" />
+			<param index="1" name="all_custom_data" type="Dictionary" default="{}" />
+			<param index="2" name="location" type="int" enum="OpenXRFbSpatialEntity.StorageLocation" default="0" />
+			<param index="3" name="erase_unknown_anchors" type="bool" default="false" />
+			<description>
+				Loads a list of spatial anchors with the given UUIDs from the given storage.
+				The [param all_custom_data] argument is a [Dictionary] containing application-specific data about what the spatial entity represents (for example, what virtual object should be placed there), keyed by the UUID of the spatial anchor its associated with. This data will be stashed on [member OpenXRFbSpatialEntity.custom_data].
+				If [param erase_unknown_anchors] is [code]true[/code], then all spatial anchors tracked by the headset that aren't in the given list of UUIDs will be erased. This can be used to clean up the list of spatial anchors, if some weren't erased from storage.
+				This is an asynchronous operation - the [signal openxr_fb_spatial_anchor_tracked] signal will be emitted (for each anchor) if the load was successful, or the [signal openxr_fb_spatial_anchor_load_failed] signal will be emitted (for each anchor) if unsuccessful.
+			</description>
+		</method>
+		<method name="show">
+			<return type="void" />
+			<description>
+				Shows all spatial anchors created by this manager, if they had been previously hidden.
+			</description>
+		</method>
+		<method name="track_anchor">
+			<return type="void" />
+			<param index="0" name="spatial_entity" type="OpenXRFbSpatialEntity" />
+			<description>
+				Tracks an existing [OpenXRFbSpatialEntity].
+				This is an asynchronous operation - the [signal openxr_fb_spatial_anchor_tracked] signal will be emitted if the tracking was successful, or the [signal openxr_fb_spatial_anchor_track_failed] signal will be emitted if unsuccessful.
+			</description>
+		</method>
+		<method name="untrack_anchor">
+			<return type="void" />
+			<param index="0" name="spatial_entity_or_uuid" type="Variant" />
+			<description>
+				Untracks the given spatial anchor (either by UUID or [OpenXRFbSpatialEntity] object).
+				This will remove the [XRAnchor3D] node and will erase the anchor from local headset storage automatically. If it's been stored in the cloud, it can be erased by calling [method OpenXRFbSpatialEntity.erase_from_storage].
+				This is an asynchronous operation - the [signal openxr_fb_spatial_anchor_untracked] signal will be emitted regardless of whether the operation was fully successful or not.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="scene" type="PackedScene" setter="set_scene" getter="get_scene">
+			The scene to be instantiated automatically for each spatial anchor.
+			This is optional - using the [signal openxr_fb_spatial_anchor_tracked] signal and creating any necessary nodes from there is a valid alternative approach.
+		</member>
+		<member name="scene_setup_method" type="StringName" setter="set_scene_setup_method" getter="get_scene_setup_method" default="&amp;&quot;setup_scene&quot;">
+			The method that will be called on scenes after they have been instantiated for a spatial anchor.
+			The method will be called with a single [OpenXRFbSpatialEntity] argument, representing the spatial anchor.
+		</member>
+		<member name="visible" type="bool" setter="set_visible" getter="get_visible" default="true">
+			Controls the visibility of the spatial anchors managed by this node.
+		</member>
+	</members>
+	<signals>
+		<signal name="openxr_fb_spatial_anchor_create_failed">
+			<param index="0" name="transform" type="Transform3D" />
+			<param index="1" name="custom_data" type="Dictionary" />
+			<description>
+				Emitted after [method create_anchor] is called, if the operation was unsuccessful.
+			</description>
+		</signal>
+		<signal name="openxr_fb_spatial_anchor_load_failed">
+			<param index="0" name="uuid" type="StringName" />
+			<param index="1" name="custom_data" type="Dictionary" />
+			<param index="2" name="location" type="int" />
+			<description>
+				Emitted after [method load_anchor] or [method load_anchors] is called, if the operation was unsuccessful.
+			</description>
+		</signal>
+		<signal name="openxr_fb_spatial_anchor_track_failed">
+			<param index="0" name="spatial_entity" type="Object" />
+			<description>
+				Emitted after [method track_anchor] is called, if the operation was unsuccessful.
+			</description>
+		</signal>
+		<signal name="openxr_fb_spatial_anchor_tracked">
+			<param index="0" name="anchor_node" type="Object" />
+			<param index="1" name="spatial_entity" type="Object" />
+			<param index="2" name="is_new" type="bool" />
+			<description>
+				Emitted any time a new spatial anchor is successfully tracked, as a result of calling [method create_anchor], [method load_anchor], [method load_anchors] or [method track_anchor].
+			</description>
+		</signal>
+		<signal name="openxr_fb_spatial_anchor_untracked">
+			<param index="0" name="anchor_node" type="Object" />
+			<param index="1" name="spatial_entity" type="Object" />
+			<description>
+				Emitted any time a spatial anchor is untracked as a result of calling [method untrack_anchor].
+				This signal will be emitted regardless of whether the operation was fully successful or not.
+			</description>
+		</signal>
+	</signals>
+</class>

--- a/doc_classes/OpenXRFbSpatialEntity.xml
+++ b/doc_classes/OpenXRFbSpatialEntity.xml
@@ -1,77 +1,149 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="OpenXRFbSpatialEntity" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
+		Represents a spatial entity in Meta's Scene Understanding and Spatial Anchor APIs.
 	</brief_description>
 	<description>
+		Represents a spatial entity in Meta's Scene Understanding and Spatial Anchor APIs.
+		A spatial entity can be a spatial anchor created by the application or an element of the real-world environment (sometimes called a "scene anchor"), such as walls, floor, ceiling, furniture, or even a mesh created using the headset's depth sensor, as a result of the user going through the scene capture process.
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="create_collision_shape">
+		<method name="create_collision_shape" qualifiers="const">
 			<return type="Node3D" />
 			<description>
+				Creates a [CollisionShape3D] node with the shape and position of the spatial entity, if it has that data. Otherwise, it will return [code]null[/code].
+				The spatial entity must have one of the components [constant COMPONENT_TYPE_TRIANGLE_MESH], [constant COMPONENT_TYPE_BOUNDED_3D], or [constant COMPONENT_TYPE_BOUNDED_2D] enabled, which can be checked by calling [method is_component_enabled].
+				The underlying data can be accessed via [method get_triangle_mesh], [method get_bounding_box_3d], or [method get_bounding_box_2d].
 			</description>
 		</method>
-		<method name="create_mesh_instance">
+		<method name="create_mesh_instance" qualifiers="const">
 			<return type="MeshInstance3D" />
 			<description>
+				Creates a [MeshInstance3D] node with the shape and position of the spatial entity, if it has that data. Otherwise, it will return [code]null[/code].
+				The spatial entity must have one of the compenents [constant COMPONENT_TYPE_TRIANGLE_MESH], [constant COMPONENT_TYPE_BOUNDED_3D], or [constant COMPONENT_TYPE_BOUNDED_2D] enabled, which can be checked by calling [method is_component_enabled].
+				The underlying data can be accessed via [method get_triangle_mesh], [method get_bounding_box_3d], or [method get_bounding_box_2d].
 			</description>
 		</method>
-		<method name="get_boundary_2d">
+		<method name="create_spatial_anchor" qualifiers="static">
+			<return type="OpenXRFbSpatialEntity" />
+			<param index="0" name="transform" type="Transform3D" />
+			<description>
+				Creates a new spatial anchor at the given position (relative to the current [XROrigin3D]).
+				The [OpenXRFbSpatialEntity] object will be returned immediately, but anchor creation is asynchronous, and so the anchor won't really exist until after [signal openxr_fb_spatial_entity_created] is emitted with arguments indicating success.
+				[b]Rather than using this method directly, it's recommended to use an [OpenXRFbSpatialAnchorManager] node instead! It can help with many of the follow-up steps necessary for using spatial anchors in practice.[/b]
+			</description>
+		</method>
+		<method name="destroy">
+			<return type="void" />
+			<description>
+				Untracks and destroys a spatial entity, such that it will no longer be tracked by [XRServer] or the headset.
+				This [i]does not[/i] remove the entity from storage, which must be done via [method erase_from_storage].
+			</description>
+		</method>
+		<method name="erase_from_storage">
+			<return type="void" />
+			<param index="0" name="location" type="int" enum="OpenXRFbSpatialEntity.StorageLocation" default="0" />
+			<description>
+				Removes the spatial entity from the given storage location.
+				The component [constant COMPONENT_TYPE_STORABLE] must be enabled, which can be checked by calling [method is_component_enabled], or set by calling [method set_component_enabled].
+				This is an asynchronous operation - the [signal openxr_fb_spatial_entity_erased] signal will be emitted when completed with an argument indicating if it was successful or not.
+			</description>
+		</method>
+		<method name="get_boundary_2d" qualifiers="const">
 			<return type="PackedVector2Array" />
 			<description>
+				Gets the 2D boundary of the spatial entity as an array of [Vector2]s.
+				The component [constant COMPONENT_TYPE_BOUNDED_2D] must be enabled, which can be checked by calling [method is_component_enabled].
+				Use [method create_mesh_instance] or [method create_collision_shape] to create a node using this data.
 			</description>
 		</method>
-		<method name="get_bounding_box_2d">
+		<method name="get_bounding_box_2d" qualifiers="const">
 			<return type="Rect2" />
 			<description>
+				Gets the 2D boundary of the spatial entity as a [Rect2].
+				The component [constant COMPONENT_TYPE_BOUNDED_2D] must be enabled, which can be checked by calling [method is_component_enabled].
+				Use [method create_mesh_instance] or [method create_collision_shape] to create a node using this data.
 			</description>
 		</method>
-		<method name="get_bounding_box_3d">
+		<method name="get_bounding_box_3d" qualifiers="const">
 			<return type="AABB" />
 			<description>
+				Gets the 3D boundary of the spatial entity as an [AABB].
+				The component [constant COMPONENT_TYPE_BOUNDED_3D] must be enabled, which can be checked by calling [method is_component_enabled].
+				Use [method create_mesh_instance] or [method create_collision_shape] to create a node using this data.
 			</description>
 		</method>
-		<method name="get_contained_uuids">
+		<method name="get_contained_uuids" qualifiers="const">
 			<return type="Array" />
 			<description>
+				Gets an array of the UUIDs of the spatial entities that are contained in this spatial entity.
+				The component [constant COMPONENT_TYPE_CONTAINER] must be enabled, which can be checked by calling [method is_component_enabled].
+				The actual [OpenXRFbSpatialEntity] objects can be obtained using [OpenXRFbSpatialEntityQuery].
 			</description>
 		</method>
-		<method name="get_room_layout">
+		<method name="get_room_layout" qualifiers="const">
 			<return type="Dictionary" />
 			<description>
+				Gets a [Dictionary] containing the following keys:
+				- [code]floor[/code] ([StringName]): the UUID of the spatial entity representing the floor.
+				- [code]ceiling[/code] ([StringName]): the UUID of the spatial entity representing the ceiling.
+				- [code]walls[/code] ([Array] of [StringName]s): the UUIDs of the spatial entities representing the walls.
+				The component [constant COMPONENT_TYPE_ROOM_LAYOUT] must be enabled, which can be checked by calling [method is_component_enabled].
+				The actual [OpenXRFbSpatialEntity] objects can be obtained using [OpenXRFbSpatialEntityQuery].
 			</description>
 		</method>
-		<method name="get_semantic_labels">
+		<method name="get_semantic_labels" qualifiers="const">
 			<return type="PackedStringArray" />
 			<description>
+				Gets an array of the semantic labels used by this spatial entity.
+				The component [constant COMPONENT_TYPE_SEMANTIC_LABELS] must be enabled, which can be checked by calling [method is_component_enabled].
 			</description>
 		</method>
-		<method name="get_supported_components">
+		<method name="get_supported_components" qualifiers="const">
 			<return type="Array" />
 			<description>
+				Gets an array of [enum ComponentType]s where are supported by this spatial entity.
 			</description>
 		</method>
-		<method name="get_triangle_mesh">
+		<method name="get_triangle_mesh" qualifiers="const">
 			<return type="Array" />
 			<description>
+				Gets an array in the same format as used by [ArrayMesh], representing a triangle mesh covering the spatial entity.
+				The component [constant COMPONENT_TYPE_TRIANGLE_MESH] must be enabled, which can be checked by calling [method is_component_enabled].
+				Use [method create_mesh_instance] or [method create_collision_shape] to create a node using this data.
 			</description>
 		</method>
-		<method name="is_component_enabled">
+		<method name="is_component_enabled" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="component" type="int" enum="OpenXRFbSpatialEntity.ComponentType" />
 			<description>
+				Checks if the given component is enabled on this spatial entity.
 			</description>
 		</method>
-		<method name="is_component_supported">
+		<method name="is_component_supported" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="component" type="int" enum="OpenXRFbSpatialEntity.ComponentType" />
 			<description>
+				Checks if the given component is supported by this spatial entity.
 			</description>
 		</method>
-		<method name="is_tracked">
+		<method name="is_tracked" qualifiers="const">
 			<return type="bool" />
 			<description>
+				Checks if this spatial entity is being tracked by [XRServer].
+				See [method track] for more information.
+			</description>
+		</method>
+		<method name="save_to_storage">
+			<return type="void" />
+			<param index="0" name="location" type="int" enum="OpenXRFbSpatialEntity.StorageLocation" default="0" />
+			<description>
+				Saves the spatial entity in the given storage location.
+				The component [constant COMPONENT_TYPE_STORABLE] must be enabled, which can be checked by calling [method is_component_enabled], or set by calling [method set_component_enabled].
+				This is an asynchronous operation - the [signal openxr_fb_spatial_entity_saved] signal will be emitted when completed with an argument indicating if it was successful or not.
+				Note: [OpenXRFbSpatialEntityBatch] can be used to save multiple spatial entities in a single operation.
 			</description>
 		</method>
 		<method name="set_component_enabled">
@@ -79,54 +151,116 @@
 			<param index="0" name="component" type="int" enum="OpenXRFbSpatialEntity.ComponentType" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
+				Sets a particular component as enabled or disabled on this spatial entity.
+				You can check if the given component is supported by calling [method is_component_supported], however, not all component types can be enabled or disabled even if supported.
+				This is an asynchronous operation - the [signal openxr_fb_spatial_entity_set_component_enabled_completed] signal will be emitted when completed with an argument indicating if it was successful or not.
+			</description>
+		</method>
+		<method name="share_with_users">
+			<return type="void" />
+			<param index="0" name="users" type="OpenXRFbSpatialEntityUser[]" />
+			<description>
+				Shares this spatial entity with the given users.
+				The component [constant COMPONENT_TYPE_SHARABLE] must be enabled, which can be checked by calling [method is_component_enabled], or set by calling [method set_component_enabled].
+				The spatial entity must have already been saved to the cloud, using [method save_to_storage].
+				This is an asynchronous operation - the [signal openxr_fb_spatial_entity_shared] signal will be emitted when completed with an argument indicating if it was successful or not.
+				Note: [OpenXRFbSpatialEntityBatch] can be used to share multiple spatial entities in a single operation.
 			</description>
 		</method>
 		<method name="track">
 			<return type="void" />
 			<description>
+				Starts tracking this spatial entity on [XRServer].
+				The component [constant COMPONENT_TYPE_LOCATABLE] must be enabled, which can be checked by calling [method is_component_enabled], or set by calling [method set_component_enabled].
+				Once a spatial entity is being tracked, an [XRAnchor3D] node can be created with its [member XRAnchor3D.tracker] property set to the [member uuid] of this spatial entity, and it will be moved to the correct position based on the headset's tracking.
+				Use [method untrack] to stop tracking a spatial anchor on [XRServer].
 			</description>
 		</method>
 		<method name="untrack">
 			<return type="void" />
 			<description>
+				Stops tracking this spatial entity on [XRServer].
+				See [method track] for more information.
 			</description>
 		</method>
 	</methods>
 	<members>
+		<member name="custom_data" type="Dictionary" setter="set_custom_data" getter="get_custom_data" default="{}">
+			Game or application-specific data about the spatial entity.
+		</member>
 		<member name="uuid" type="StringName" setter="" getter="get_uuid" default="&amp;&quot;&quot;">
+			The UUID of the spatial entity.
 		</member>
 	</members>
 	<signals>
+		<signal name="openxr_fb_spatial_entity_created">
+			<param index="0" name="succeeded" type="bool" />
+			<description>
+				Emitted when the operation to create a spatial entity is completed. See [method create_spatial_anchor].
+			</description>
+		</signal>
+		<signal name="openxr_fb_spatial_entity_erased">
+			<param index="0" name="succeeded" type="bool" />
+			<param index="1" name="location" type="int" />
+			<description>
+				Emitted when the operation to erase a spatial entity from storage is completed. See [method erase_from_storage].
+			</description>
+		</signal>
+		<signal name="openxr_fb_spatial_entity_saved">
+			<param index="0" name="succeeded" type="bool" />
+			<param index="1" name="location" type="int" />
+			<description>
+				Emitted when the operation to save a spatial entity to storage is completed. See [method save_to_storage].
+			</description>
+		</signal>
 		<signal name="openxr_fb_spatial_entity_set_component_enabled_completed">
 			<param index="0" name="succeeded" type="bool" />
 			<param index="1" name="component" type="int" />
 			<param index="2" name="enabled" type="bool" />
 			<description>
+				Emitted when the operation to enable or disable a component on the spatial entity is completed. See [method set_component_enabled].
+			</description>
+		</signal>
+		<signal name="openxr_fb_spatial_entity_shared">
+			<param index="0" name="succeeded" type="bool" />
+			<description>
+				Emitted when the operation to share a spatial entity is completed. See [method share_with_users].
 			</description>
 		</signal>
 	</signals>
 	<constants>
 		<constant name="STORAGE_LOCAL" value="0" enum="StorageLocation">
+			Storage on the local headset.
 		</constant>
 		<constant name="STORAGE_CLOUD" value="1" enum="StorageLocation">
+			Storage in the cloud.
 		</constant>
 		<constant name="COMPONENT_TYPE_LOCATABLE" value="0" enum="ComponentType">
+			The spatial entity's location can be tracked. See [method track].
 		</constant>
 		<constant name="COMPONENT_TYPE_STORABLE" value="1" enum="ComponentType">
+			The spatial entity can be stored. See [method save_to_storage] and [method erase_from_storage].
 		</constant>
 		<constant name="COMPONENT_TYPE_SHARABLE" value="2" enum="ComponentType">
+			The spatial entity can be shared with other users. See [method share_with_users].
 		</constant>
 		<constant name="COMPONENT_TYPE_BOUNDED_2D" value="3" enum="ComponentType">
+			The spatial entity has 2D boundary data. See [method get_bounding_box_2d] and [method get_boundary_2d].
 		</constant>
 		<constant name="COMPONENT_TYPE_BOUNDED_3D" value="4" enum="ComponentType">
+			The spatial entity has 3D boundary data. See [method get_bounding_box_3d].
 		</constant>
 		<constant name="COMPONENT_TYPE_SEMANTIC_LABELS" value="5" enum="ComponentType">
+			The spatial entity has semantic labels. See [method get_semantic_labels].
 		</constant>
 		<constant name="COMPONENT_TYPE_ROOM_LAYOUT" value="6" enum="ComponentType">
+			The spatial entity has room layout data. See [method get_room_layout].
 		</constant>
 		<constant name="COMPONENT_TYPE_CONTAINER" value="7" enum="ComponentType">
+			The spatial entity contains other spatial entities. See [method get_contained_uuids].
 		</constant>
 		<constant name="COMPONENT_TYPE_TRIANGLE_MESH" value="8" enum="ComponentType">
+			The spatial entity has triangle mesh data. See [method get_triangle_mesh].
 		</constant>
 	</constants>
 </class>

--- a/doc_classes/OpenXRFbSpatialEntityBatch.xml
+++ b/doc_classes/OpenXRFbSpatialEntityBatch.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OpenXRFbSpatialEntityBatch" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Used to batch save or share spatial entities.
+	</brief_description>
+	<description>
+		Used to batch save or share a collection of [OpenXRFbSpatialEntity]s in a single operation.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="create_batch" qualifiers="static">
+			<return type="OpenXRFbSpatialEntityBatch" />
+			<param index="0" name="entities" type="OpenXRFbSpatialEntity[]" />
+			<description>
+				Create a batch of [OpenXRFbSpatialEntity] objects.
+			</description>
+		</method>
+		<method name="save_to_storage">
+			<return type="void" />
+			<param index="0" name="location" type="int" enum="OpenXRFbSpatialEntity.StorageLocation" />
+			<description>
+				Saves all the spatial entities in this batch to the given storage location as a single operation.
+				This is an asynchronous operation - the [signal openxr_fb_spatial_entity_batch_saved] signal will be emitted when completed with an argument indicating if it was successful or not.
+			</description>
+		</method>
+		<method name="share_with_users">
+			<return type="void" />
+			<param index="0" name="users" type="OpenXRFbSpatialEntityUser[]" />
+			<description>
+				Shares all the spatial entities in this batch with the given users in a single operation.
+				This is an asynchronous operation - the [signal openxr_fb_spatial_entity_batch_shared] signal will be emitted when completed with an argument indicating if it was successful or not.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="entities" type="OpenXRFbSpatialEntity[]" setter="" getter="get_entities" default="[]">
+			The spatial entities in this batch.
+		</member>
+	</members>
+	<signals>
+		<signal name="openxr_fb_spatial_entity_batch_saved">
+			<param index="0" name="succeeded" type="bool" />
+			<param index="1" name="location" type="int" />
+			<description>
+				Emitted when the save operation has completed. See [method save_to_storage].
+			</description>
+		</signal>
+		<signal name="openxr_fb_spatial_entity_batch_shared">
+			<param index="0" name="succeeded" type="bool" />
+			<description>
+				Emitted when the share operation has completed. See [method share_with_users].
+			</description>
+		</signal>
+	</signals>
+</class>

--- a/doc_classes/OpenXRFbSpatialEntityContainerExtensionWrapper.xml
+++ b/doc_classes/OpenXRFbSpatialEntityContainerExtensionWrapper.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="OpenXRFbSpatialEntityContainerExtensionWrapper" inherits="OpenXRExtensionWrapperExtension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
+		Wraps the [code]XR_FB_spatial_entity_container[/code] extension.
 	</brief_description>
 	<description>
+		Wraps the [code]XR_FB_spatial_entity_container[/code] extension.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,6 +12,7 @@
 		<method name="is_spatial_entity_container_supported">
 			<return type="bool" />
 			<description>
+				Checks if this extension is enabled.
 			</description>
 		</method>
 	</methods>

--- a/doc_classes/OpenXRFbSpatialEntityExtensionWrapper.xml
+++ b/doc_classes/OpenXRFbSpatialEntityExtensionWrapper.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="OpenXRFbSpatialEntityExtensionWrapper" inherits="OpenXRExtensionWrapperExtension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
+		Wraps the [code]XR_FB_spatial_entity[/code] extension.
 	</brief_description>
 	<description>
+		Wraps the [code]XR_FB_spatial_entity[/code] extension.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,6 +12,7 @@
 		<method name="is_spatial_entity_supported">
 			<return type="bool" />
 			<description>
+				Checks if this extension is enabled.
 			</description>
 		</method>
 	</methods>

--- a/doc_classes/OpenXRFbSpatialEntityQuery.xml
+++ b/doc_classes/OpenXRFbSpatialEntityQuery.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="OpenXRFbSpatialEntityQuery" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
+		Used to query spatial entities stored on the headset or in the cloud.
 	</brief_description>
 	<description>
+		Used to query [OpenXRFbSpatialEntity] objects stored on the headset or in the cloud.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,31 +12,43 @@
 		<method name="execute">
 			<return type="int" enum="Error" />
 			<description>
+				Executes the query. Returns [constant Error.OK] if the query can be executed; otherwise, it returns [constant Error.ERR_ALREADY_IN_USE] or [constant Error.ERR_INVALID_DATA].
+				This is an asynchronous operation - the [signal openxr_fb_spatial_entity_query_completed] signal will be emitted when the query is completed.
+				Each query object can only be executed once. To perform multiple queries, create a new [OpenXRFbSpatialEntityQuery] for each one.
 			</description>
 		</method>
-		<method name="get_component_type">
+		<method name="get_component_type" qualifiers="const">
 			<return type="int" enum="OpenXRFbSpatialEntity.ComponentType" />
 			<description>
+				Gets the component type being searched for when querying by component.
+				See [method query_by_component].
 			</description>
 		</method>
-		<method name="get_query_type">
+		<method name="get_query_type" qualifiers="const">
 			<return type="int" enum="OpenXRFbSpatialEntityQuery.QueryType" />
 			<description>
+				Gets the type of query that will be performed.
+				Set by using [method query_all], [method query_by_component] or [method query_by_uuid].
 			</description>
 		</method>
-		<method name="get_storage_location">
+		<method name="get_storage_location" qualifiers="const">
 			<return type="int" enum="OpenXRFbSpatialEntity.StorageLocation" />
 			<description>
+				The storage location that is being queried.
 			</description>
 		</method>
-		<method name="get_uuids">
+		<method name="get_uuids" qualifiers="const">
 			<return type="Array" />
 			<description>
+				Gets the UUIDs being searched for when querying by UUID.
+				See [method query_by_uuid].
 			</description>
 		</method>
 		<method name="query_all">
 			<return type="void" />
 			<description>
+				Sets up the query to get all spatial entities in local storage (up to the limit of [member max_results]).
+				Note: It's not possible to query all spatial entities stored in the cloud.
 			</description>
 		</method>
 		<method name="query_by_component">
@@ -42,6 +56,7 @@
 			<param index="0" name="component" type="int" enum="OpenXRFbSpatialEntity.ComponentType" />
 			<param index="1" name="location" type="int" enum="OpenXRFbSpatialEntity.StorageLocation" default="0" />
 			<description>
+				Sets up the query to get all spatial entities with the given component in the given storage location (up to the limit of [member max_results]).
 			</description>
 		</method>
 		<method name="query_by_uuid">
@@ -49,28 +64,36 @@
 			<param index="0" name="uuids" type="Array" />
 			<param index="1" name="location" type="int" enum="OpenXRFbSpatialEntity.StorageLocation" default="0" />
 			<description>
+				Sets up the query to get all spatial entities with the given UUIDs from the given storage location.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="max_results" type="int" setter="set_max_results" getter="get_max_results" default="25">
+			The maximum number of results to return as the result of executing the query.
 		</member>
 		<member name="timeout" type="float" setter="set_timeout" getter="get_timeout" default="0.0">
+			The maximum amount of time (in seconds) to wait for the query to return before giving up.
+			If set to [code]0.0[/code], the query won't timeout.
 		</member>
 	</members>
 	<signals>
 		<signal name="openxr_fb_spatial_entity_query_completed">
 			<param index="0" name="results" type="Array" />
 			<description>
+				Emitted when the query has finished executing.
 			</description>
 		</signal>
 	</signals>
 	<constants>
 		<constant name="QUERY_ALL" value="0" enum="QueryType">
+			Query all spatial entities.
 		</constant>
 		<constant name="QUERY_BY_UUID" value="1" enum="QueryType">
+			Query by UUID.
 		</constant>
 		<constant name="QUERY_BY_COMPONENT" value="2" enum="QueryType">
+			Query by component.
 		</constant>
 	</constants>
 </class>

--- a/doc_classes/OpenXRFbSpatialEntityQueryExtensionWrapper.xml
+++ b/doc_classes/OpenXRFbSpatialEntityQueryExtensionWrapper.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="OpenXRFbSpatialEntityQueryExtensionWrapper" inherits="OpenXRExtensionWrapperExtension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
+		Wraps the [code]XR_FB_spatial_entity_query[/code] extension.
 	</brief_description>
 	<description>
+		Wraps the [code]XR_FB_spatial_entity_query[/code] extension.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,6 +12,7 @@
 		<method name="is_spatial_entity_query_supported">
 			<return type="bool" />
 			<description>
+				Checks if this extension is enabled.
 			</description>
 		</method>
 	</methods>

--- a/doc_classes/OpenXRFbSpatialEntitySharingExtensionWrapper.xml
+++ b/doc_classes/OpenXRFbSpatialEntitySharingExtensionWrapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OpenXRFbSpatialEntitySharingExtensionWrapper" inherits="OpenXRExtensionWrapperExtension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Wraps the [code]XR_FB_spatial_entity_sharing[/code] extension.
+	</brief_description>
+	<description>
+		Wraps the [code]XR_FB_spatial_entity_sharing[/code] extension.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="is_spatial_entity_sharing_supported">
+			<return type="bool" />
+			<description>
+				Checks if this extension is enabled.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc_classes/OpenXRFbSpatialEntityStorageBatchExtensionWrapper.xml
+++ b/doc_classes/OpenXRFbSpatialEntityStorageBatchExtensionWrapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OpenXRFbSpatialEntityStorageBatchExtensionWrapper" inherits="OpenXRExtensionWrapperExtension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Wraps the [code]XR_FB_spatial_entity_storage_batch[/code] extension.
+	</brief_description>
+	<description>
+		Wraps the [code]XR_FB_spatial_entity_storage_batch[/code] extension.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="is_spatial_entity_storage_batch_supported">
+			<return type="bool" />
+			<description>
+				Checks if this extension is enabled.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc_classes/OpenXRFbSpatialEntityStorageExtensionWrapper.xml
+++ b/doc_classes/OpenXRFbSpatialEntityStorageExtensionWrapper.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="OpenXRFbSpatialEntityStorageExtensionWrapper" inherits="OpenXRExtensionWrapperExtension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
+		Wraps the [code]XR_FB_spatial_entity_storage[/code] extension.
 	</brief_description>
 	<description>
+		Wraps the [code]XR_FB_spatial_entity_storage[/code] extension.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,6 +12,7 @@
 		<method name="is_spatial_entity_query_supported">
 			<return type="bool" />
 			<description>
+				Checks if this extension is enabled.
 			</description>
 		</method>
 	</methods>

--- a/doc_classes/OpenXRFbSpatialEntityUser.xml
+++ b/doc_classes/OpenXRFbSpatialEntityUser.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OpenXRFbSpatialEntityUser" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Represents a remote user registered with Meta's platform.
+	</brief_description>
+	<description>
+		Represents a remote user registered with Meta's platform.
+		[OpenXRFbSpatialEntity] objects which have been stored in the cloud can be shared with remote users in order to create multiplayer co-located experiences, where multiple users with headsets in the same physical space can interact with the same virtual objects.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="create_user" qualifiers="static">
+			<return type="OpenXRFbSpatialEntityUser" />
+			<param index="0" name="user_id" type="int" />
+			<description>
+				Creates an [OpenXRFbSpatialEntityUser] from the given user ID.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="user_id" type="int" setter="" getter="get_user_id" default="0">
+			The user ID.
+		</member>
+	</members>
+</class>

--- a/doc_classes/OpenXRFbSpatialEntityUserExtensionWrapper.xml
+++ b/doc_classes/OpenXRFbSpatialEntityUserExtensionWrapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OpenXRFbSpatialEntityUserExtensionWrapper" inherits="OpenXRExtensionWrapperExtension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Wraps the [code]XR_FB_spatial_entity_user[/code] extension.
+	</brief_description>
+	<description>
+		Wraps the [code]XR_FB_spatial_entity_user[/code] extension.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="is_spatial_entity_user_supported">
+			<return type="bool" />
+			<description>
+				Checks if this extension is enabled.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc_classes/OpenXRHtcFacialTrackingExtensionWrapper.xml
+++ b/doc_classes/OpenXRHtcFacialTrackingExtensionWrapper.xml
@@ -7,7 +7,7 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="is_enabled">
+		<method name="is_enabled" qualifiers="const">
 			<return type="bool" />
 			<description>
 			</description>

--- a/doc_classes/OpenXRMetaSpatialEntityMeshExtensionWrapper.xml
+++ b/doc_classes/OpenXRMetaSpatialEntityMeshExtensionWrapper.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="OpenXRMetaSpatialEntityMeshExtensionWrapper" inherits="OpenXRExtensionWrapperExtension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
+		Wraps the [code]XR_META_spatial_entity_mesh[/code] extension.
 	</brief_description>
 	<description>
+		Wraps the [code]XR_META_spatial_entity_mesh[/code] extension.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,6 +12,7 @@
 		<method name="is_spatial_entity_mesh_supported">
 			<return type="bool" />
 			<description>
+				Checks if this extension is enabled.
 			</description>
 		</method>
 	</methods>

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -25,6 +25,12 @@ if errorlevel 9009 (
 
 if "%1" == "" goto help
 
+if "%1" == "api" (
+    rmdir /s /q "%SOURCEDIR%\api"
+    python "%SOURCEDIR%\make_rst.py" "%SOURCEDIR%\..\doc_classes" --output "%SOURCEDIR%\api"
+    goto end
+)
+
 %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
 goto end
 


### PR DESCRIPTION
This PR updates the XML docs from the current code (so it pulls in some stuff that wasn't present when PR https://github.com/GodotVR/godot_openxr_vendors/pull/138 was made), and adds API documentation for everything associated with Meta's Scene Understanding and Spatial Anchor APIs.

I also just realized that the bits to get the XML docs compiled into the GDExtension (so they are visible in the editor) weren't added! So, I've also taken the opportunity to update godot-cpp, and add that as well.

Logan also noticed that `.\make.bat api` wasn't working on Windows. So, I've snuck in a fix for that as well :-)

This will compliment the tutorial in PR https://github.com/GodotVR/godot_openxr_vendors/pull/153