### PR TITLE
Apply reference frame transform to `OpenXRFbPassthroughGeometry`

### DIFF
--- a/common/src/main/cpp/classes/openxr_fb_passthrough_geometry.cpp
+++ b/common/src/main/cpp/classes/openxr_fb_passthrough_geometry.cpp
@@ -35,6 +35,7 @@
 #include <godot_cpp/classes/shader.hpp>
 #include <godot_cpp/classes/shader_material.hpp>
 #include <godot_cpp/classes/standard_material3d.hpp>
+#include <godot_cpp/classes/xr_server.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 
 using namespace godot;
@@ -104,6 +105,10 @@ bool OpenXRFbPassthroughGeometry::get_enable_hole_punch() const {
 	return enable_hole_punch;
 }
 
+OpenXRFbPassthroughGeometry::OpenXRFbPassthroughGeometry() {
+	XRServer::get_singleton()->connect("reference_frame_changed", callable_mp(this, &OpenXRFbPassthroughGeometry::update_passthrough_geometry_transform));
+}
+
 void OpenXRFbPassthroughGeometry::create_passthrough_geometry() {
 	geometry_instance = OpenXRFbPassthroughExtensionWrapper::get_singleton()->create_geometry_instance(mesh, get_transform());
 
@@ -122,6 +127,12 @@ void OpenXRFbPassthroughGeometry::destroy_passthrough_geometry() {
 
 	if (opaque_mesh != nullptr) {
 		delete_opaque_mesh();
+	}
+}
+
+void OpenXRFbPassthroughGeometry::update_passthrough_geometry_transform() {
+	if (geometry_instance) {
+		OpenXRFbPassthroughExtensionWrapper::get_singleton()->set_geometry_instance_transform(geometry_instance, get_transform());
 	}
 }
 
@@ -187,9 +198,7 @@ void OpenXRFbPassthroughGeometry::_notification(int p_what) {
 			}
 		} break;
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
-			if (geometry_instance) {
-				OpenXRFbPassthroughExtensionWrapper::get_singleton()->set_geometry_instance_transform(geometry_instance, get_transform());
-			}
+			update_passthrough_geometry_transform();
 		} break;
 	}
 }

--- a/common/src/main/cpp/extensions/openxr_fb_passthrough_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_fb_passthrough_extension_wrapper.cpp
@@ -447,11 +447,14 @@ XrGeometryInstanceFB OpenXRFbPassthroughExtensionWrapper::create_geometry_instan
 		return XR_NULL_HANDLE;
 	}
 
-	Quaternion quat = p_transform.basis.get_rotation_quaternion();
-	Vector3 scale = p_transform.basis.get_scale();
+	Transform3D reference_frame = XRServer::get_singleton()->get_reference_frame();
+	Transform3D transform = reference_frame.inverse() * p_transform;
+
+	Quaternion quat = transform.basis.get_rotation_quaternion();
+	Vector3 scale = transform.basis.get_scale();
 
 	XrQuaternionf xr_orientation = { quat.x, quat.y, quat.z, quat.w };
-	XrVector3f xr_position = { p_transform.origin.x, p_transform.origin.y, p_transform.origin.z };
+	XrVector3f xr_position = { transform.origin.x, transform.origin.y, transform.origin.z };
 	XrPosef xr_pose = { xr_orientation, xr_position };
 	XrVector3f xr_scale = { scale.x, scale.y, scale.z };
 
@@ -476,11 +479,14 @@ XrGeometryInstanceFB OpenXRFbPassthroughExtensionWrapper::create_geometry_instan
 }
 
 void OpenXRFbPassthroughExtensionWrapper::set_geometry_instance_transform(XrGeometryInstanceFB p_geometry_instance, const Transform3D &p_transform) {
-	Quaternion quat = p_transform.basis.get_rotation_quaternion();
-	Vector3 scale = p_transform.basis.get_scale();
+	Transform3D reference_frame = XRServer::get_singleton()->get_reference_frame();
+	Transform3D transform = reference_frame.inverse() * p_transform;
+
+	Quaternion quat = transform.basis.get_rotation_quaternion();
+	Vector3 scale = transform.basis.get_scale();
 
 	XrQuaternionf xr_orientation = { quat.x, quat.y, quat.z, quat.w };
-	XrVector3f xr_position = { p_transform.origin.x, p_transform.origin.y, p_transform.origin.z };
+	XrVector3f xr_position = { transform.origin.x, transform.origin.y, transform.origin.z };
 	XrPosef xr_pose = { xr_orientation, xr_position };
 	XrVector3f xr_scale = { scale.x, scale.y, scale.z };
 

--- a/common/src/main/cpp/include/classes/openxr_fb_passthrough_geometry.h
+++ b/common/src/main/cpp/include/classes/openxr_fb_passthrough_geometry.h
@@ -41,8 +41,11 @@ class OpenXRFbPassthroughGeometry : public Node3D {
 	GDCLASS(OpenXRFbPassthroughGeometry, Node3D)
 
 private:
+	OpenXRFbPassthroughGeometry();
+
 	void create_passthrough_geometry();
 	void destroy_passthrough_geometry();
+	void update_passthrough_geometry_transform();
 
 	void instatiate_opaque_mesh();
 	void delete_opaque_mesh();


### PR DESCRIPTION
This PR is the `OpenXRFbPassthroughGeometry` version of https://github.com/godotengine/godot/pull/92339

`XRServer.center_on_hmd()` currently doesn't impact the transform of passthrough geometry, this fixes that.