### PR TITLE
Always build docs on GitHub Actions; only deploy on `master`

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,10 +5,7 @@ permissions:
   pages: write
   id-token: write
 
-on:
-  push:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
   build:
@@ -40,6 +37,7 @@ jobs:
           path: docs/_build/html
 
   deploy:
+    if: github.ref == 'refs/heads/master'
     needs: build
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
This is response to the issue fixed on PR https://github.com/GodotVR/godot_openxr_vendors/pull/159

We didn't notice the issue on the PR that introduced it, because the documentation workflow only runs on the `master` branch, meaning the CI won't try to build the docs until merging.

In order to prevent this sort of issue happening again, this PR will cause the documentation workflow to always run, but only deploy it on the `master` branch.