### PR TITLE
Statically link with libgcc and libstdc++ for more Linux compatibility.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -26,6 +26,16 @@ if env["target"] in ["editor", "template_debug"]:
 binary_path = '#demo/addons/godotopenxrvendors/.bin'
 project_name = 'godotopenxrvendors'
 
+# Statically link with libgcc and libstdc++ for more Linux compatibility.
+if env["platform"] == "linux":
+    env.Append(
+        LINKFLAGS=[
+            "-Wl,--no-undefined",
+            "-static-libgcc",
+            "-static-libstdc++",
+        ]
+    )
+
 # Create the library target
 if env["platform"] == "macos":
     library = env.SharedLibrary(


### PR DESCRIPTION
Fixes https://github.com/GodotVR/godot_openxr_vendors/issues/163

This will make the binary larger, but it'll allow the extension to be compatible with more Linux distros