### PR TITLE
Update the macos running image to the latest.

### DIFF
--- a/.github/workflows/build-addon-on-push.yml
+++ b/.github/workflows/build-addon-on-push.yml
@@ -36,7 +36,7 @@ jobs:
             artifact_name: build-files-windows
             artifact_path: aar/demo/addons/godotopenxrvendors/.bin/windows/*/*/*.dll
           - name: MacOS
-            os: macos-11
+            os: macos-latest
             platform: macos
             flags: arch=universal
             artifact_name: build-files-macos


### PR DESCRIPTION
Version 11 is being deprecated: https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/