### PR TITLE
Add manifest entries for PICO

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 - Add OpenXRMetaPassthroughColorLut
 - Add feature flags to Khronos loader for HTC
 - Add XR_HTC_passthrough extension wrapper
+- Add manifest entries to Pico loader
 
 ## 2.0.3
 - Migrate the export scripts from gdscript to C++ via gdextension

--- a/common/src/main/cpp/include/export/pico_export_plugin.h
+++ b/common/src/main/cpp/include/export/pico_export_plugin.h
@@ -35,6 +35,41 @@
 
 using namespace godot;
 
+namespace pico {
+static const int MANIFEST_FALSE_VALUE = 0;
+static const int MANIFEST_TRUE_VALUE = 1;
+
+static const int FACE_TRACKING_NONE_VALUE = 0;
+static const int FACE_TRACKING_FACEONLY_VALUE = 1;
+static const int FACE_TRACKING_LIPSYNCONLY_VALUE = 2;
+static const int FACE_TRACKING_HYBRID_VALUE = 3;
+} // namespace
+
+class PicoEditorExportPlugin : public OpenXREditorExportPlugin {
+	GDCLASS(PicoEditorExportPlugin, OpenXREditorExportPlugin)
+
+public:
+	PicoEditorExportPlugin();
+
+	TypedArray<Dictionary> _get_export_options(const Ref<EditorExportPlatform> &platform) const override;
+
+	PackedStringArray _get_export_features(const Ref<EditorExportPlatform> &platform, bool debug) const override;
+
+	String _get_export_option_warning(const Ref<EditorExportPlatform> &platform, const String &option) const override;
+
+	String _get_android_manifest_element_contents(const Ref<EditorExportPlatform> &platform, bool debug) const override;
+	String _get_android_manifest_application_element_contents(const Ref<EditorExportPlatform> &platform, bool debug) const override;
+
+protected:
+	static void _bind_methods();
+
+	Dictionary _eye_tracking_option;
+	Dictionary _face_tracking_option;
+
+private:
+	bool _is_eye_tracking_enabled() const;
+};
+
 class PicoEditorPlugin : public EditorPlugin {
 	GDCLASS(PicoEditorPlugin, EditorPlugin)
 
@@ -46,5 +81,5 @@ protected:
 	static void _bind_methods();
 
 private:
-	Ref<OpenXREditorExportPlugin> pico_export_plugin;
+	Ref<PicoEditorExportPlugin> pico_export_plugin;
 };

--- a/common/src/main/cpp/register_types.cpp
+++ b/common/src/main/cpp/register_types.cpp
@@ -196,6 +196,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			ClassDB::register_class<MetaEditorPlugin>();
 			EditorPlugins::add_by_type<MetaEditorPlugin>();
 
+			ClassDB::register_class<PicoEditorExportPlugin>();
 			ClassDB::register_class<PicoEditorPlugin>();
 			EditorPlugins::add_by_type<PicoEditorPlugin>();
 		} break;

--- a/docs/make_rst.py
+++ b/docs/make_rst.py
@@ -72,6 +72,7 @@ SKIP_CLASSES: List[str] = [
     "MetaEditorExportPlugin",
     "MetaEditorPlugin",
     "OpenXREditorExportPlugin",
+    "PicoEditorExportPlugin",
     "PicoEditorPlugin",
 ]
 


### PR DESCRIPTION
Adds manifest items for Pico, these are all related to the eye tracker on the Pico 4 Pro so I can't fully test, but in theory these should work.

One thing worth checking is if the lipsync function works on the Pico 4. In theory it should do face tracking for the mouth based on audio. I do not (yet) know what face tracking API Pico is implementing, whether they are adding support for Metas one, or adding their own.
