### PR TITLE
Add support for overriding non-selected Khronos vendor options

### DIFF
--- a/common/src/main/cpp/export/khronos_export_plugin.cpp
+++ b/common/src/main/cpp/export/khronos_export_plugin.cpp
@@ -106,7 +106,7 @@ TypedArray<Dictionary> KhronosEditorExportPlugin::_get_export_options(const Ref<
 
 PackedStringArray KhronosEditorExportPlugin::_get_export_features(const Ref<EditorExportPlatform> &platform, bool debug) const {
 	PackedStringArray features;
-	if (!_supports_platform(platform)) {
+	if (!_supports_platform(platform) || !_is_vendor_plugin_enabled()) {
 		return features;
 	}
 
@@ -119,7 +119,7 @@ PackedStringArray KhronosEditorExportPlugin::_get_export_features(const Ref<Edit
 }
 
 String KhronosEditorExportPlugin::_get_export_option_warning(const Ref<EditorExportPlatform> &platform, const String &option) const {
-	if (!_supports_platform(platform)) {
+	if (!_supports_platform(platform) || !_is_vendor_plugin_enabled()) {
 		return "";
 	}
 

--- a/common/src/main/cpp/export/khronos_export_plugin.cpp
+++ b/common/src/main/cpp/export/khronos_export_plugin.cpp
@@ -49,6 +49,16 @@ void KhronosEditorPlugin::_exit_tree() {
 KhronosEditorExportPlugin::KhronosEditorExportPlugin() {
 	set_vendor_name(KHRONOS_VENDOR_NAME);
 
+	_khronos_vendors_option = _generate_export_option(
+			"khronos_xr_features/vendors",
+			"",
+			Variant::Type::INT,
+			PROPERTY_HINT_ENUM,
+			"Other,HTC",
+			PROPERTY_USAGE_DEFAULT,
+			KHRONOS_VENDOR_OTHER,
+			true);
+
 	_hand_tracking_option = _generate_export_option(
 			"khronos_xr_features/htc/hand_tracking",
 			"",
@@ -96,6 +106,8 @@ TypedArray<Dictionary> KhronosEditorExportPlugin::_get_export_options(const Ref<
 	}
 
 	export_options.append(_get_vendor_toggle_option());
+	export_options.append(_khronos_vendors_option);
+
 	export_options.append(_hand_tracking_option);
 	export_options.append(_tracker_option);
 	export_options.append(_eye_tracking_option);
@@ -104,15 +116,34 @@ TypedArray<Dictionary> KhronosEditorExportPlugin::_get_export_options(const Ref<
 	return export_options;
 }
 
+Dictionary KhronosEditorExportPlugin::_get_export_options_overrides(const Ref<godot::EditorExportPlatform> &p_platform) const {
+	Dictionary overrides;
+	if (!_supports_platform(p_platform)) {
+		return overrides;
+	}
+
+	if (!_is_khronos_htc_enabled()) {
+		// Overrides with the options' default values.
+		overrides["khronos_xr_features/htc/hand_tracking"] = MANIFEST_FALSE_VALUE;
+		overrides["khronos_xr_features/htc/tracker"] = MANIFEST_FALSE_VALUE;
+		overrides["khronos_xr_features/htc/eye_tracking"] = MANIFEST_FALSE_VALUE;
+		overrides["khronos_xr_features/htc/lip_expression"] = MANIFEST_FALSE_VALUE;
+	}
+
+	return overrides;
+}
+
 PackedStringArray KhronosEditorExportPlugin::_get_export_features(const Ref<EditorExportPlatform> &platform, bool debug) const {
 	PackedStringArray features;
 	if (!_supports_platform(platform) || !_is_vendor_plugin_enabled()) {
 		return features;
 	}
 
-	// Add the eye tracking feature if necessary
-	if (_get_int_option("khronos_xr_features/htc/eye_tracking", MANIFEST_FALSE_VALUE) == MANIFEST_TRUE_VALUE) {
-		features.append(EYE_GAZE_INTERACTION_FEATURE);
+	if (_is_khronos_htc_enabled()) {
+		// Add the eye tracking feature if necessary
+		if (_get_int_option("khronos_xr_features/htc/eye_tracking", MANIFEST_FALSE_VALUE) == MANIFEST_TRUE_VALUE) {
+			features.append(EYE_GAZE_INTERACTION_FEATURE);
+		}
 	}
 
 	return features;
@@ -124,21 +155,23 @@ String KhronosEditorExportPlugin::_get_export_option_warning(const Ref<EditorExp
 	}
 
 	bool openxr_enabled = _is_openxr_enabled();
-	if (option == "khronos_xr_features/htc/hand_tracking") {
-		if (!openxr_enabled && _get_int_option(option, MANIFEST_FALSE_VALUE) == MANIFEST_TRUE_VALUE) {
-			return "\"Hand Tracking\" requires \"XR Mode\" to be \"OpenXR\".\n";
-		}
-	} else if (option == "khronos_xr_features/htc/tracker") {
-		if (!openxr_enabled && _get_int_option(option, MANIFEST_FALSE_VALUE) == MANIFEST_TRUE_VALUE) {
-			return "\"Tracker\" requires \"XR Mode\" to be \"OpenXR\".\n";
-		}
-	} else if (option == "khronos_xr_features/htc/eye_tracking") {
-		if (!openxr_enabled && _get_int_option(option, MANIFEST_FALSE_VALUE) == MANIFEST_TRUE_VALUE) {
-			return "\"Eye tracking\" requires \"XR Mode\" to be \"OpenXR\".\n";
-		}
-	} else if (option == "khronos_xr_features/htc/lip_expression") {
-		if (!openxr_enabled && _get_int_option(option, MANIFEST_FALSE_VALUE) == MANIFEST_TRUE_VALUE) {
-			return "\"Lip expression\" requires \"XR Mode\" to be \"OpenXR\".\n";
+	if (_is_khronos_htc_enabled()) {
+		if (option == "khronos_xr_features/htc/hand_tracking") {
+			if (!openxr_enabled && _get_int_option(option, MANIFEST_FALSE_VALUE) == MANIFEST_TRUE_VALUE) {
+				return "\"Hand Tracking\" requires \"XR Mode\" to be \"OpenXR\".\n";
+			}
+		} else if (option == "khronos_xr_features/htc/tracker") {
+			if (!openxr_enabled && _get_int_option(option, MANIFEST_FALSE_VALUE) == MANIFEST_TRUE_VALUE) {
+				return "\"Tracker\" requires \"XR Mode\" to be \"OpenXR\".\n";
+			}
+		} else if (option == "khronos_xr_features/htc/eye_tracking") {
+			if (!openxr_enabled && _get_int_option(option, MANIFEST_FALSE_VALUE) == MANIFEST_TRUE_VALUE) {
+				return "\"Eye tracking\" requires \"XR Mode\" to be \"OpenXR\".\n";
+			}
+		} else if (option == "khronos_xr_features/htc/lip_expression") {
+			if (!openxr_enabled && _get_int_option(option, MANIFEST_FALSE_VALUE) == MANIFEST_TRUE_VALUE) {
+				return "\"Lip expression\" requires \"XR Mode\" to be \"OpenXR\".\n";
+			}
 		}
 	}
 
@@ -146,11 +179,12 @@ String KhronosEditorExportPlugin::_get_export_option_warning(const Ref<EditorExp
 }
 
 String KhronosEditorExportPlugin::_get_android_manifest_activity_element_contents(const Ref<EditorExportPlatform> &platform, bool debug) const {
+	String contents;
 	if (!_supports_platform(platform) || !_is_vendor_plugin_enabled()) {
-		return "";
+		return contents;
 	}
 
-	return R"(
+	contents += R"(
 				<intent-filter>
 					<action android:name="android.intent.action.MAIN" />
 					<category android:name="android.intent.category.LAUNCHER" />
@@ -159,10 +193,20 @@ String KhronosEditorExportPlugin::_get_android_manifest_activity_element_content
 					See https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#android-runtime-category. -->
 					<category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
 
+)";
+
+	if (_is_khronos_htc_enabled()) {
+		contents += R"(
 					<!-- Enable VR access on HTC Vive Focus devices. -->
 					<category android:name="com.htc.intent.category.VRAPP" />
+
+)";
+	}
+
+	contents += R"(
 				</intent-filter>
 )";
+	return contents;
 }
 
 String KhronosEditorExportPlugin::_get_android_manifest_element_contents(const Ref<EditorExportPlatform> &platform, bool debug) const {
@@ -171,24 +215,26 @@ String KhronosEditorExportPlugin::_get_android_manifest_element_contents(const R
 		return contents;
 	}
 
-	// Check for hand tracking
-	if (_get_int_option("khronos_xr_features/htc/hand_tracking", MANIFEST_FALSE_VALUE) == MANIFEST_TRUE_VALUE) {
-		contents += "    <uses-feature tools:node=\"replace\" android:name=\"wave.feature.handtracking\" android:required=\"true\" />\n";
-	}
+	if (_is_khronos_htc_enabled()) {
+		// Check for hand tracking
+		if (_get_int_option("khronos_xr_features/htc/hand_tracking", MANIFEST_FALSE_VALUE) == MANIFEST_TRUE_VALUE) {
+			contents += "    <uses-feature tools:node=\"replace\" android:name=\"wave.feature.handtracking\" android:required=\"true\" />\n";
+		}
 
-	// Check for tracker
-	if (_get_int_option("khronos_xr_features/htc/tracker", MANIFEST_FALSE_VALUE) == MANIFEST_TRUE_VALUE) {
-		contents += "    <uses-feature tools:node=\"replace\" android:name=\"wave.feature.tracker\" android:required=\"true\" />\n";
-	}
+		// Check for tracker
+		if (_get_int_option("khronos_xr_features/htc/tracker", MANIFEST_FALSE_VALUE) == MANIFEST_TRUE_VALUE) {
+			contents += "    <uses-feature tools:node=\"replace\" android:name=\"wave.feature.tracker\" android:required=\"true\" />\n";
+		}
 
-	// Check for eye tracking
-	if (_get_int_option("khronos_xr_features/htc/eye_tracking", MANIFEST_FALSE_VALUE) == MANIFEST_TRUE_VALUE) {
-		contents += "    <uses-feature tools:node=\"replace\" android:name=\"wave.feature.eyetracking\" android:required=\"true\" />\n";
-	}
+		// Check for eye tracking
+		if (_get_int_option("khronos_xr_features/htc/eye_tracking", MANIFEST_FALSE_VALUE) == MANIFEST_TRUE_VALUE) {
+			contents += "    <uses-feature tools:node=\"replace\" android:name=\"wave.feature.eyetracking\" android:required=\"true\" />\n";
+		}
 
-	// Check for lip expression
-	if (_get_int_option("khronos_xr_features/htc/lip_expression", MANIFEST_FALSE_VALUE) == MANIFEST_TRUE_VALUE) {
-		contents += "    <uses-feature tools:node=\"replace\" android:name=\"wave.feature.lipexpression\" android:required=\"true\" />\n";
+		// Check for lip expression
+		if (_get_int_option("khronos_xr_features/htc/lip_expression", MANIFEST_FALSE_VALUE) == MANIFEST_TRUE_VALUE) {
+			contents += "    <uses-feature tools:node=\"replace\" android:name=\"wave.feature.lipexpression\" android:required=\"true\" />\n";
+		}
 	}
 
 	return contents;

--- a/common/src/main/cpp/export/meta_export_plugin.cpp
+++ b/common/src/main/cpp/export/meta_export_plugin.cpp
@@ -260,7 +260,7 @@ bool MetaEditorExportPlugin::_is_eye_tracking_enabled() const {
 
 PackedStringArray MetaEditorExportPlugin::_get_export_features(const Ref<EditorExportPlatform> &platform, bool debug) const {
 	PackedStringArray features;
-	if (!_supports_platform(platform)) {
+	if (!_supports_platform(platform) || !_is_vendor_plugin_enabled()) {
 		return features;
 	}
 
@@ -273,7 +273,7 @@ PackedStringArray MetaEditorExportPlugin::_get_export_features(const Ref<EditorE
 }
 
 String MetaEditorExportPlugin::_get_export_option_warning(const Ref<EditorExportPlatform> &platform, const String &option) const {
-	if (!_supports_platform(platform)) {
+	if (!_supports_platform(platform) || !_is_vendor_plugin_enabled()) {
 		return "";
 	}
 

--- a/common/src/main/cpp/export/pico_export_plugin.cpp
+++ b/common/src/main/cpp/export/pico_export_plugin.cpp
@@ -99,7 +99,7 @@ bool PicoEditorExportPlugin::_is_eye_tracking_enabled() const {
 
 PackedStringArray PicoEditorExportPlugin::_get_export_features(const Ref<EditorExportPlatform> &platform, bool debug) const {
 	PackedStringArray features;
-	if (!_supports_platform(platform)) {
+	if (!_supports_platform(platform) || !_is_vendor_plugin_enabled()) {
 		return features;
 	}
 
@@ -112,7 +112,7 @@ PackedStringArray PicoEditorExportPlugin::_get_export_features(const Ref<EditorE
 }
 
 String PicoEditorExportPlugin::_get_export_option_warning(const Ref<EditorExportPlatform> &platform, const String &option) const {
-	if (!_supports_platform(platform)) {
+	if (!_supports_platform(platform) || !_is_vendor_plugin_enabled()) {
 		return "";
 	}
 

--- a/common/src/main/cpp/include/export/khronos_export_plugin.h
+++ b/common/src/main/cpp/include/export/khronos_export_plugin.h
@@ -35,6 +35,9 @@
 
 using namespace godot;
 
+static const int KHRONOS_VENDOR_OTHER = 0;
+static const int KHRONOS_VENDOR_HTC = 1;
+
 static const int MANIFEST_FALSE_VALUE = 0;
 static const int MANIFEST_TRUE_VALUE = 1;
 
@@ -46,6 +49,8 @@ public:
 
 	TypedArray<Dictionary> _get_export_options(const Ref<EditorExportPlatform> &platform) const override;
 
+	Dictionary _get_export_options_overrides(const Ref<EditorExportPlatform> &p_platform) const override;
+
 	PackedStringArray _get_export_features(const Ref<EditorExportPlatform> &platform, bool debug) const override;
 
 	String _get_export_option_warning(const Ref<EditorExportPlatform> &platform, const String &option) const override;
@@ -56,6 +61,11 @@ public:
 protected:
 	static void _bind_methods();
 
+	bool _is_khronos_htc_enabled() const {
+		return _get_int_option("khronos_xr_features/vendors", KHRONOS_VENDOR_OTHER) == KHRONOS_VENDOR_HTC;
+	}
+
+	Dictionary _khronos_vendors_option;
 	Dictionary _hand_tracking_option;
 	Dictionary _tracker_option;
 	Dictionary _eye_tracking_option;


### PR DESCRIPTION
This PR is broken into two commits:
- The first commit cleans up some of the validation logic and ensures that a vendor plugin is **enabled** prior to executing logic against it (e.g: showing warnings)
- The second commit showcases how we can support multiple vendors under the Khronos loader while keeping a clean user interface. To do so, it makes use of the `_get_export_options_overrides(...)` method introduced in Godot 4.3. An alternative would be to use `_get_export_option_visibility(...)` instead, but that method is not yet available to the `EditorExportPlugin`.
  - Note that the approach used in the second commit is up for discussion, and may not be merged in if we decide to go a different route.