### PR TITLE
Remove outdated plugin.cfg reference from project.godot files

### DIFF
--- a/samples/meta-composition-layers-sample/project.godot
+++ b/samples/meta-composition-layers-sample/project.godot
@@ -15,10 +15,6 @@ run/main_scene="res://main.tscn"
 config/features=PackedStringArray("4.3", "GL Compatibility")
 config/icon="res://icon.svg"
 
-[editor_plugins]
-
-enabled=PackedStringArray("res://addons/godotopenxrvendors/plugin.cfg")
-
 [rendering]
 
 renderer/rendering_method="gl_compatibility"

--- a/samples/meta-passthrough-sample/project.godot
+++ b/samples/meta-passthrough-sample/project.godot
@@ -15,10 +15,6 @@ run/main_scene="res://main.tscn"
 config/features=PackedStringArray("4.3", "GL Compatibility")
 config/icon="res://icon.svg"
 
-[editor_plugins]
-
-enabled=PackedStringArray("res://addons/godotopenxrvendors/plugin.cfg")
-
 [rendering]
 
 renderer/rendering_method="gl_compatibility"


### PR DESCRIPTION
Two of the sample projects still have an outdated reference to the (now nonexistent) plugin.cfg file for the vendors plugin, this PR removes those. This would sometimes cause a popup warning on opening the project, stating that plugin.cfg could not be parsed.