### PR TITLE
[CI] Update to actions/deploy-pages@v4

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -45,4 +45,4 @@ jobs:
       url: ${{ steps.deploy-pages.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
I don't know if this is related to the recent documentation deployment failures, but I just noticed we were using `v1` of the `actions/deploy-pages` action, when the latest is `v4`.

Unfortunately, this job will only run on the `master` branch, so the tests on this PR won't tell us if it works or not.