### PR TITLE
Update scene_manager.rst

### DIFF
--- a/docs/manual/meta/scene_manager.rst
+++ b/docs/manual/meta/scene_manager.rst
@@ -102,8 +102,8 @@ The complete code for requesting a scene capture could look like this:
     @onready var scene_manager: OpenXRFbSceneManager = $OpenXRFbSceneManager
 
     func _ready():
-        scene_manager.open_xr_fb_scene_data_missing.connect(_scene_data_missing)
-        scene_manager.open_xr_fb_scene_capture_completed.connect(_scene_capture_completed)
+        scene_manager.openxr_fb_scene_data_missing.connect(_scene_data_missing)
+        scene_manager.openxr_fb_scene_capture_completed.connect(_scene_capture_completed)
 
     func _scene_data_missing() -> void:
         scene_manager.request_scene_capture()


### PR DESCRIPTION
fixes typos referring to "open_xr_" - instead of "openxr_" signals in example snippet; now if no spacial env is found on the headset, one will be requested by this code.