### PR TITLE
Update scene_manager.rst

### DIFF
--- a/docs/manual/meta/scene_manager.rst
+++ b/docs/manual/meta/scene_manager.rst
@@ -112,7 +112,9 @@ The complete code for requesting a scene capture could look like this:
         if success == false:
             return
 
-        # Recreate scene anchors since the user may have changed them.
+        # Delete any existing anchors, since the user may have changed them.
         if scene_manager.are_scene_anchors_created():
             scene_manager.remove_scene_anchors()
-            scene_manager.create_scene_anchors()
+
+        # Create scene_anchors for the freshly captured scene
+        scene_manager.create_scene_anchors()


### PR DESCRIPTION
Assumes the intended / preferred logic of the scene scan example snippet - post capture - to be deletion of any existing scene_anchors and creation of new anchors in any case.

This way the anchors populate without user having to restart the app. (Tested good on Q2 v67 and Q3 v68)