### PR TITLE
Fix issues when hand-tracking is disabled in project settings

### DIFF
--- a/common/src/main/cpp/extensions/openxr_fb_hand_tracking_aim_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_fb_hand_tracking_aim_extension_wrapper.cpp
@@ -90,8 +90,14 @@ PackedStringArray OpenXRFbHandTrackingAimExtensionWrapper::_get_suggested_tracke
 }
 
 void OpenXRFbHandTrackingAimExtensionWrapper::_on_state_ready() {
-	is_project_setting_enabled = ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/hand_tracking_aim");
+	// It would be great to not even request the extension, but the ProjectSettings singleton isn't available early enough.
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+	bool is_project_setting_enabled = (bool)project_settings->get_setting_with_override("xr/openxr/extensions/hand_tracking") && (bool)project_settings->get_setting_with_override("xr/openxr/extensions/hand_tracking_aim");
 	if (!is_project_setting_enabled) {
+		fb_hand_tracking_aim_ext = false;
+	}
+
+	if (!is_enabled()) {
 		return;
 	}
 
@@ -139,7 +145,7 @@ uint64_t OpenXRFbHandTrackingAimExtensionWrapper::_set_hand_joint_locations_and_
 }
 
 void OpenXRFbHandTrackingAimExtensionWrapper::_on_process() {
-	if (!is_enabled() || !is_project_setting_enabled) {
+	if (!is_enabled()) {
 		return;
 	}
 

--- a/common/src/main/cpp/extensions/openxr_fb_hand_tracking_capsules_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_fb_hand_tracking_capsules_extension_wrapper.cpp
@@ -29,6 +29,8 @@
 
 #include "extensions/openxr_fb_hand_tracking_capsules_extension_wrapper.h"
 
+#include <godot_cpp/classes/project_settings.hpp>
+
 using namespace godot;
 
 OpenXRFbHandTrackingCapsulesExtensionWrapper *OpenXRFbHandTrackingCapsulesExtensionWrapper::singleton = nullptr;
@@ -77,6 +79,14 @@ godot::Dictionary OpenXRFbHandTrackingCapsulesExtensionWrapper::_get_requested_e
 
 void OpenXRFbHandTrackingCapsulesExtensionWrapper::_on_instance_destroyed() {
 	cleanup();
+}
+
+void OpenXRFbHandTrackingCapsulesExtensionWrapper::_on_state_ready() {
+	// It would be great to not even request the extension, but the ProjectSettings singleton isn't available early enough.
+	bool is_project_setting_enabled = (bool)ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/hand_tracking");
+	if (!is_project_setting_enabled) {
+		fb_hand_tracking_capsules_ext = false;
+	}
 }
 
 uint64_t OpenXRFbHandTrackingCapsulesExtensionWrapper::_set_hand_joint_locations_and_get_next_pointer(int32_t p_hand_index, void *p_next_pointer) {

--- a/common/src/main/cpp/extensions/openxr_fb_hand_tracking_mesh_extension_wrapper.cpp
+++ b/common/src/main/cpp/extensions/openxr_fb_hand_tracking_mesh_extension_wrapper.cpp
@@ -30,6 +30,7 @@
 #include "extensions/openxr_fb_hand_tracking_mesh_extension_wrapper.h"
 
 #include <godot_cpp/classes/open_xrapi_extension.hpp>
+#include <godot_cpp/classes/project_settings.hpp>
 #include <godot_cpp/classes/xr_hand_tracker.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 
@@ -99,6 +100,14 @@ void OpenXRFbHandTrackingMeshExtensionWrapper::_on_instance_created(uint64_t ins
 
 void OpenXRFbHandTrackingMeshExtensionWrapper::_on_instance_destroyed() {
 	cleanup();
+}
+
+void OpenXRFbHandTrackingMeshExtensionWrapper::_on_state_ready() {
+	// It would be great to not even request the extension, but the ProjectSettings singleton isn't available early enough.
+	bool is_project_setting_enabled = (bool)ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/hand_tracking");
+	if (!is_project_setting_enabled) {
+		fb_hand_tracking_mesh_ext = false;
+	}
 }
 
 uint64_t OpenXRFbHandTrackingMeshExtensionWrapper::_set_hand_joint_locations_and_get_next_pointer(int32_t p_hand_index, void *p_next_pointer) {

--- a/common/src/main/cpp/include/extensions/openxr_fb_hand_tracking_aim_extension_wrapper.h
+++ b/common/src/main/cpp/include/extensions/openxr_fb_hand_tracking_aim_extension_wrapper.h
@@ -83,7 +83,6 @@ private:
 	const String TRACKER_NAME_RIGHT = "/user/fbhandaim/right";
 
 	bool fb_hand_tracking_aim_ext = false;
-	bool is_project_setting_enabled = false;
 
 	Ref<XRPositionalTracker> trackers[Hand::HAND_MAX];
 

--- a/common/src/main/cpp/include/extensions/openxr_fb_hand_tracking_capsules_extension_wrapper.h
+++ b/common/src/main/cpp/include/extensions/openxr_fb_hand_tracking_capsules_extension_wrapper.h
@@ -47,6 +47,7 @@ public:
 	godot::Dictionary _get_requested_extensions() override;
 
 	void _on_instance_destroyed() override;
+	void _on_state_ready() override;
 
 	uint64_t _set_hand_joint_locations_and_get_next_pointer(int32_t p_hand_index, void *p_next_pointer) override;
 

--- a/common/src/main/cpp/include/extensions/openxr_fb_hand_tracking_mesh_extension_wrapper.h
+++ b/common/src/main/cpp/include/extensions/openxr_fb_hand_tracking_mesh_extension_wrapper.h
@@ -59,8 +59,9 @@ public:
 	godot::Dictionary _get_requested_extensions() override;
 
 	void _on_instance_created(uint64_t instance) override;
-
 	void _on_instance_destroyed() override;
+
+	void _on_state_ready() override;
 
 	uint64_t _set_hand_joint_locations_and_get_next_pointer(int32_t p_hand_index, void *p_next_pointer) override;
 

--- a/samples/meta-body-tracking-sample/project.godot
+++ b/samples/meta-body-tracking-sample/project.godot
@@ -35,5 +35,6 @@ textures/vram_compression/import_etc2_astc=true
 
 openxr/enabled=true
 openxr/reference_space=2
+openxr/extensions/hand_tracking=true
 openxr/extensions/eye_gaze_interaction=true
 shaders/enabled=true

--- a/samples/meta-hand-tracking-sample/project.godot
+++ b/samples/meta-hand-tracking-sample/project.godot
@@ -29,5 +29,6 @@ textures/vram_compression/import_etc2_astc=true
 
 openxr/enabled=true
 openxr/reference_space=2
+openxr/extensions/hand_tracking=true
 shaders/enabled=true
 openxr/extensions/hand_tracking_aim=true


### PR DESCRIPTION
Currently, the hand-tracking and body-tracking samples are crashing with Godot v4.3-stable, because the hand-tracking project setting isn't enabled (it was enabled, but the default was changed just before Godot v4.3-stable, causing it to become disabled).

Godot PR https://github.com/godotengine/godot/pull/95959 will fix the crash too, because it's caused by us calling `OpenXRAPI::get_hand_tracker()`.

However, we really shouldn't even be trying to call it at all if the hand-tracking project setting is disabled! So, this PR checks the project setting (unfortunately, we can't check it early enough to prevent loading the extensions - this is due to a GDExtension limitation) and prevents the hand-tracking related extension wrappers from doing much if hand-tracking is disabled.

It also enables hand-tracking in the hand-tracking and body-tracking samples so that they actually work too :-)