### PR TITLE
Add request permissions on start project setting

### DIFF
--- a/plugin/src/main/cpp/include/register_types.h
+++ b/plugin/src/main/cpp/include/register_types.h
@@ -35,3 +35,5 @@ using namespace godot;
 
 void initialize_plugin_module(ModuleInitializationLevel p_level);
 void terminate_plugin_module(ModuleInitializationLevel p_level);
+
+void add_plugin_project_settings();

--- a/plugin/src/main/cpp/register_types.cpp
+++ b/plugin/src/main/cpp/register_types.cpp
@@ -32,6 +32,7 @@
 #include <gdextension_interface.h>
 
 #include <godot_cpp/classes/engine.hpp>
+#include <godot_cpp/classes/project_settings.hpp>
 #include <godot_cpp/core/class_db.hpp>
 #include <godot_cpp/core/defs.hpp>
 #include <godot_cpp/godot.hpp>
@@ -155,6 +156,8 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			break;
 
 		case MODULE_INITIALIZATION_LEVEL_SCENE: {
+			add_plugin_project_settings();
+
 			Engine::get_singleton()->register_singleton("OpenXRFbPassthroughExtensionWrapper", OpenXRFbPassthroughExtensionWrapper::get_singleton());
 			Engine::get_singleton()->register_singleton("OpenXRFbRenderModelExtensionWrapper", OpenXRFbRenderModelExtensionWrapper::get_singleton());
 			Engine::get_singleton()->register_singleton("OpenXRFbSceneCaptureExtensionWrapper", OpenXRFbSceneCaptureExtensionWrapper::get_singleton());
@@ -212,6 +215,30 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 }
 
 void terminate_plugin_module(ModuleInitializationLevel p_level) {
+}
+
+void add_plugin_project_settings() {
+	ProjectSettings* project_settings = ProjectSettings::get_singleton();
+	if (project_settings == nullptr) {
+		return;
+	}
+
+	{
+		// Add the 'automatically_request_runtime_permissions' project setting
+		String request_permissions_setting = "xr/openxr/extensions/automatically_request_runtime_permissions";
+		if (!project_settings->has_setting(request_permissions_setting)) {
+			// Default value is `true` to match prior plugin behavior
+			project_settings->set_setting(request_permissions_setting, true);
+		}
+
+		project_settings->set_initial_value(request_permissions_setting, true);
+		project_settings->set_as_basic(request_permissions_setting, false);
+		Dictionary property_info;
+		property_info["name"] = request_permissions_setting;
+		property_info["type"] = Variant::Type::BOOL;
+		property_info["hint"] = PROPERTY_HINT_NONE;
+		project_settings->add_property_info(property_info);
+	}
 }
 
 extern "C" {

--- a/plugin/src/main/java/org/godotengine/openxr/vendors/GodotOpenXR.kt
+++ b/plugin/src/main/java/org/godotengine/openxr/vendors/GodotOpenXR.kt
@@ -31,6 +31,7 @@ package org.godotengine.openxr.vendors
 
 import android.util.Log
 import org.godotengine.godot.Godot
+import org.godotengine.godot.GodotLib
 import org.godotengine.godot.plugin.GodotPlugin
 import org.godotengine.godot.utils.PermissionsUtil
 
@@ -56,10 +57,19 @@ abstract class GodotOpenXR(godot: Godot?) : GodotPlugin(godot) {
 	override fun onGodotSetupCompleted() {
 		super.onGodotSetupCompleted()
 
-		// Request plugin permissions if needed
-		val permissionsToRequest = getPluginPermissionsToEnable()
-		if (permissionsToRequest.isNotEmpty()) {
-			PermissionsUtil.requestPermissions(activity, permissionsToRequest)
+		// Check if automatic permissions request is enabled.
+		val automaticallyRequestPermissionsSetting = GodotLib.getGlobal("xr/openxr/extensions/automatically_request_runtime_permissions")
+		// We only request permissions when the project setting is enabled.
+		// If the project setting is not defined, we fall-back to the default behavior which is
+		// to automatically request permissions.
+		val requestPermissionsEnabled = automaticallyRequestPermissionsSetting.isNullOrEmpty() ||
+				automaticallyRequestPermissionsSetting.toBoolean()
+		if (requestPermissionsEnabled) {
+			val permissionsToRequest = getPluginPermissionsToEnable()
+			if (permissionsToRequest.isNotEmpty()) {
+				Log.v(TAG, "Performing automatic request of runtime permissions")
+				PermissionsUtil.requestPermissions(activity, permissionsToRequest)
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR is a follow-up from a discussion with @dsnopek; it introduces the `xr/openxr/extensions/automatically_request_runtime_permissions` project setting which allows users the ability to enable / disable the automatic request of runtime permissions that's done at start. This is done so that the app / game logic can itself request the permissions in a context-specific manner.

The project setting is enabled (set to `true`) by default to keep consistency with the current behavior.

Note that this PR builds on top of https://github.com/GodotVR/godot_openxr_vendors/pull/202 to avoid duplicating the same logic across all the vendors modules.