### PR TITLE
Update switch statements to prevent build warnings

### DIFF
--- a/plugin/src/main/cpp/extensions/openxr_fb_composition_layer_settings_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_fb_composition_layer_settings_extension_wrapper.cpp
@@ -120,6 +120,9 @@ uint64_t OpenXRFbCompositionLayerSettingsExtensionWrapper::_set_viewport_composi
 		case SUPERSAMPLING_MODE_QUALITY: {
 			settings->layerFlags |= XR_COMPOSITION_LAYER_SETTINGS_QUALITY_SUPER_SAMPLING_BIT_FB;
 		} break;
+		case SUPERSAMPLING_MODE_DISABLED: {
+			// Do not enable any supersampling mode flags.
+		} break;
 	}
 
 	switch ((SharpeningMode)(int)p_property_values.get(SHARPENING_MODE_PROPERTY_NAME, SHARPENING_MODE_DISABLED)) {
@@ -128,6 +131,9 @@ uint64_t OpenXRFbCompositionLayerSettingsExtensionWrapper::_set_viewport_composi
 		} break;
 		case SHARPENING_MODE_QUALITY: {
 			settings->layerFlags |= XR_COMPOSITION_LAYER_SETTINGS_QUALITY_SHARPENING_BIT_FB;
+		} break;
+		case SHARPENING_MODE_DISABLED: {
+			// Do not enable any sharpening mode flags.
 		} break;
 	}
 

--- a/plugin/src/main/cpp/extensions/openxr_fb_passthrough_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_fb_passthrough_extension_wrapper.cpp
@@ -309,7 +309,8 @@ void OpenXRFbPassthroughExtensionWrapper::start_passthrough_layer(LayerPurpose p
 		case LAYER_PURPOSE_PROJECTED:
 			xr_layer_purpose = XR_PASSTHROUGH_LAYER_PURPOSE_PROJECTED_FB;
 			break;
-		default:
+		case LAYER_PURPOSE_NONE:
+		case LAYER_PURPOSE_MAX:
 			UtilityFunctions::print("Corresponding XrPassthroughLayerPurposeFB not found for LayerPurpose: ", p_layer_purpose);
 			return;
 	}


### PR DESCRIPTION
These switch statements throw a lot of warnings every time I build the plugin because not every enum value is explicitly handled. Changing them to if statements fixes that.