### PR TITLE
Fix static-checks CI job

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   static-checks:
     name: Formatting (clang-format, file format)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/plugin/src/main/cpp/classes/openxr_fb_hand_tracking_mesh.cpp
+++ b/plugin/src/main/cpp/classes/openxr_fb_hand_tracking_mesh.cpp
@@ -32,8 +32,8 @@
 #include "extensions/openxr_fb_hand_tracking_mesh_extension_wrapper.h"
 
 #include <godot_cpp/classes/xr_hand_modifier3d.hpp>
-#include <godot_cpp/variant/utility_functions.hpp>
 #include <godot_cpp/classes/xr_hand_tracker.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
 
 using namespace godot;
 

--- a/plugin/src/main/cpp/classes/openxr_fb_scene_manager.cpp
+++ b/plugin/src/main/cpp/classes/openxr_fb_scene_manager.cpp
@@ -30,13 +30,13 @@
 #include "classes/openxr_fb_scene_manager.h"
 
 #include <godot_cpp/classes/open_xr_interface.hpp>
-#include <godot_cpp/classes/xr_origin3d.hpp>
 #include <godot_cpp/classes/xr_anchor3d.hpp>
+#include <godot_cpp/classes/xr_origin3d.hpp>
 #include <godot_cpp/classes/xr_server.hpp>
 
+#include "classes/openxr_fb_spatial_entity_query.h"
 #include "extensions/openxr_fb_scene_capture_extension_wrapper.h"
 #include "extensions/openxr_fb_scene_extension_wrapper.h"
-#include "classes/openxr_fb_spatial_entity_query.h"
 
 using namespace godot;
 

--- a/plugin/src/main/cpp/classes/openxr_fb_spatial_anchor_manager.cpp
+++ b/plugin/src/main/cpp/classes/openxr_fb_spatial_anchor_manager.cpp
@@ -32,8 +32,8 @@
 #include <godot_cpp/classes/open_xr_interface.hpp>
 #include <godot_cpp/classes/open_xrapi_extension.hpp>
 #include <godot_cpp/classes/packed_scene.hpp>
-#include <godot_cpp/classes/xr_origin3d.hpp>
 #include <godot_cpp/classes/xr_anchor3d.hpp>
+#include <godot_cpp/classes/xr_origin3d.hpp>
 #include <godot_cpp/classes/xr_server.hpp>
 
 #include <godot_cpp/variant/utility_functions.hpp>

--- a/plugin/src/main/cpp/classes/openxr_fb_spatial_entity.cpp
+++ b/plugin/src/main/cpp/classes/openxr_fb_spatial_entity.cpp
@@ -39,11 +39,11 @@
 #include <godot_cpp/classes/surface_tool.hpp>
 #include <godot_cpp/templates/local_vector.hpp>
 
-#include "extensions/openxr_fb_spatial_entity_extension_wrapper.h"
+#include "extensions/openxr_fb_scene_extension_wrapper.h"
 #include "extensions/openxr_fb_spatial_entity_container_extension_wrapper.h"
+#include "extensions/openxr_fb_spatial_entity_extension_wrapper.h"
 #include "extensions/openxr_fb_spatial_entity_sharing_extension_wrapper.h"
 #include "extensions/openxr_fb_spatial_entity_storage_extension_wrapper.h"
-#include "extensions/openxr_fb_scene_extension_wrapper.h"
 #include "extensions/openxr_meta_spatial_entity_mesh_extension_wrapper.h"
 
 #include "classes/openxr_fb_spatial_entity_user.h"

--- a/plugin/src/main/cpp/classes/openxr_fb_spatial_entity_batch.cpp
+++ b/plugin/src/main/cpp/classes/openxr_fb_spatial_entity_batch.cpp
@@ -31,8 +31,8 @@
 
 #include <godot_cpp/templates/local_vector.hpp>
 
-#include "extensions/openxr_fb_spatial_entity_storage_batch_extension_wrapper.h"
 #include "extensions/openxr_fb_spatial_entity_sharing_extension_wrapper.h"
+#include "extensions/openxr_fb_spatial_entity_storage_batch_extension_wrapper.h"
 
 #include "classes/openxr_fb_spatial_entity_user.h"
 
@@ -111,7 +111,6 @@ void OpenXRFbSpatialEntityBatch::_on_share_with_users(XrResult p_result, void *p
 	(*userdata)->emit_signal("openxr_fb_spatial_entity_batch_shared", XR_SUCCEEDED(p_result));
 	memdelete(userdata);
 }
-
 
 Ref<OpenXRFbSpatialEntityBatch> OpenXRFbSpatialEntityBatch::create_batch(const TypedArray<OpenXRFbSpatialEntity> &p_entities) {
 	return Ref<OpenXRFbSpatialEntityBatch>(memnew(OpenXRFbSpatialEntityBatch(p_entities)));

--- a/plugin/src/main/cpp/extensions/openxr_fb_body_tracking_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_fb_body_tracking_extension_wrapper.cpp
@@ -194,10 +194,10 @@ void OpenXRFbBodyTrackingExtensionWrapper::_on_session_created(uint64_t instance
 
 	// Create the body-tracker handle
 	XrBodyTrackerCreateInfoFB createInfo = {
-        XR_TYPE_BODY_TRACKER_CREATE_INFO_FB, // type
-        nullptr, // next
-        XR_BODY_JOINT_SET_DEFAULT_FB // bodyJointSet
-    };
+		XR_TYPE_BODY_TRACKER_CREATE_INFO_FB, // type
+		nullptr, // next
+		XR_BODY_JOINT_SET_DEFAULT_FB // bodyJointSet
+	};
 	XrResult result = xrCreateBodyTrackerFB(SESSION, &createInfo, &body_tracker);
 	if (XR_FAILED(result)) {
 		UtilityFunctions::print("Failed to create body-tracker handle: ", result);
@@ -207,7 +207,7 @@ void OpenXRFbBodyTrackingExtensionWrapper::_on_session_created(uint64_t instance
 	// Construct the XRBodyTracker if necessary
 	if (xr_body_tracker.is_null()) {
 		xr_body_tracker.instantiate();
-        xr_body_tracker->set_tracker_name("/user/body_tracker");
+		xr_body_tracker->set_tracker_name("/user/body_tracker");
 		xr_body_tracker->set_body_flags(XRBodyTracker::BODY_FLAG_UPPER_BODY_SUPPORTED | XRBodyTracker::BODY_FLAG_HANDS_SUPPORTED);
 	}
 }
@@ -249,22 +249,22 @@ void OpenXRFbBodyTrackingExtensionWrapper::_on_process() {
 
 	// Construct the expression info struct.
 	XrBodyJointsLocateInfoFB locate_info = {
-        XR_TYPE_BODY_JOINTS_LOCATE_INFO_FB, // type
-        nullptr, // next
-        (XrSpace)get_openxr_api()->get_play_space(), // baseSpace
-        display_time // time
-    };
+		XR_TYPE_BODY_JOINTS_LOCATE_INFO_FB, // type
+		nullptr, // next
+		(XrSpace)get_openxr_api()->get_play_space(), // baseSpace
+		display_time // time
+	};
 
 	// Construct the locations struct.
 	XrBodyJointLocationFB fb_locations[XR_BODY_JOINT_COUNT_FB] = {};
 	XrBodyJointLocationsFB locations = {
-        XR_TYPE_BODY_JOINT_LOCATIONS_FB, // type
-        nullptr, // next
-        XR_FALSE, // isActive
-        0.0f, // confidence
-        XR_BODY_JOINT_COUNT_FB, // jointCount
-        fb_locations // jointLocations
-    };
+		XR_TYPE_BODY_JOINT_LOCATIONS_FB, // type
+		nullptr, // next
+		XR_FALSE, // isActive
+		0.0f, // confidence
+		XR_BODY_JOINT_COUNT_FB, // jointCount
+		fb_locations // jointLocations
+	};
 
 	// Read the weights
 	XrResult result = xrLocateBodyJointsFB(body_tracker, &locate_info, &locations);
@@ -324,7 +324,7 @@ void OpenXRFbBodyTrackingExtensionWrapper::_on_process() {
 		Vector3 root_o = hips.origin.slide(Vector3(0.0, 1.0, 0.0));
 		Transform3D root = Transform3D(root_x, root_y, root_z, root_o).orthonormalized();
 		xr_body_tracker->set_joint_transform(XRBodyTracker::JOINT_ROOT, root);
-        xr_body_tracker->set_pose("default", root, Vector3(), Vector3(), XRPose::XR_TRACKING_CONFIDENCE_HIGH);
+		xr_body_tracker->set_pose("default", root, Vector3(), Vector3(), XRPose::XR_TRACKING_CONFIDENCE_HIGH);
 
 		// Distance in meters to push the shoulder joints back from the
 		// clavicle-position to be in-line with the upper arm joints as

--- a/plugin/src/main/cpp/extensions/openxr_fb_scene_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_fb_scene_extension_wrapper.cpp
@@ -191,8 +191,8 @@ Rect2 OpenXRFbSceneExtensionWrapper::get_bounding_box_2d(const XrSpace p_space) 
 	}
 
 	return Rect2(
-		Vector2(bounding_box.offset.x, bounding_box.offset.y),
-		Vector2(bounding_box.extent.width, bounding_box.extent.height));
+			Vector2(bounding_box.offset.x, bounding_box.offset.y),
+			Vector2(bounding_box.extent.width, bounding_box.extent.height));
 }
 
 AABB OpenXRFbSceneExtensionWrapper::get_bounding_box_3d(const XrSpace p_space) {
@@ -210,8 +210,8 @@ AABB OpenXRFbSceneExtensionWrapper::get_bounding_box_3d(const XrSpace p_space) {
 	}
 
 	return AABB(
-		Vector3(bounding_box.offset.x, bounding_box.offset.y, bounding_box.offset.z),
-		Vector3(bounding_box.extent.width, bounding_box.extent.height, bounding_box.extent.depth));
+			Vector3(bounding_box.offset.x, bounding_box.offset.y, bounding_box.offset.z),
+			Vector3(bounding_box.extent.width, bounding_box.extent.height, bounding_box.extent.depth));
 }
 
 PackedVector2Array OpenXRFbSceneExtensionWrapper::get_boundary_2d(const XrSpace p_space) {

--- a/plugin/src/main/cpp/extensions/openxr_fb_spatial_entity_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_fb_spatial_entity_extension_wrapper.cpp
@@ -118,12 +118,11 @@ void OpenXRFbSpatialEntityExtensionWrapper::_on_process() {
 
 		if ((location.locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) && (location.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT)) {
 			Transform3D transform(
-				Basis(Quaternion(location.pose.orientation.x, location.pose.orientation.y, location.pose.orientation.z, location.pose.orientation.w)),
-				Vector3(location.pose.position.x, location.pose.position.y, location.pose.position.z));
+					Basis(Quaternion(location.pose.orientation.x, location.pose.orientation.y, location.pose.orientation.z, location.pose.orientation.w)),
+					Vector3(location.pose.position.x, location.pose.position.y, location.pose.position.z));
 
 			E.value.tracker->set_pose("default", transform, Vector3(), Vector3(), XRPose::XR_TRACKING_CONFIDENCE_HIGH);
-		}
-		else {
+		} else {
 			Ref<XRPose> default_pose = E.value.tracker->get_pose("default");
 			if (default_pose.is_valid()) {
 				// Set the tracking confidence to none, while maintaining the existing transform.

--- a/plugin/src/main/cpp/extensions/openxr_htc_passthrough_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_htc_passthrough_extension_wrapper.cpp
@@ -157,4 +157,3 @@ int OpenXRHtcPassthroughExtensionWrapper::_get_composition_layer_order(int p_ind
 	// Ensure the passthrough layer will be behind the projection layer.
 	return -100;
 }
-

--- a/plugin/src/main/cpp/include/classes/openxr_fb_scene_manager.h
+++ b/plugin/src/main/cpp/include/classes/openxr_fb_scene_manager.h
@@ -61,7 +61,7 @@ class OpenXRFbSceneManager : public Node {
 			node = p_node->get_instance_id();
 			entity = p_entity;
 		}
-		Anchor() { }
+		Anchor() {}
 	};
 	HashMap<StringName, Anchor> anchors;
 	bool anchors_created = false;

--- a/plugin/src/main/cpp/include/classes/openxr_fb_spatial_anchor_manager.h
+++ b/plugin/src/main/cpp/include/classes/openxr_fb_spatial_anchor_manager.h
@@ -59,7 +59,7 @@ class OpenXRFbSpatialAnchorManager : public Node {
 			node = p_node->get_instance_id();
 			entity = p_entity;
 		}
-		Anchor() { }
+		Anchor() {}
 	};
 	HashMap<StringName, Anchor> anchors;
 

--- a/plugin/src/main/cpp/include/classes/openxr_fb_spatial_entity.h
+++ b/plugin/src/main/cpp/include/classes/openxr_fb_spatial_entity.h
@@ -44,7 +44,6 @@ class OpenXRFbSpatialEntity : public RefCounted {
 	GDCLASS(OpenXRFbSpatialEntity, RefCounted);
 
 public:
-
 	enum StorageLocation {
 		STORAGE_LOCAL,
 		STORAGE_CLOUD,

--- a/plugin/src/main/cpp/include/export/pico_export_plugin.h
+++ b/plugin/src/main/cpp/include/export/pico_export_plugin.h
@@ -43,7 +43,7 @@ static const int FACE_TRACKING_NONE_VALUE = 0;
 static const int FACE_TRACKING_FACEONLY_VALUE = 1;
 static const int FACE_TRACKING_LIPSYNCONLY_VALUE = 2;
 static const int FACE_TRACKING_HYBRID_VALUE = 3;
-} // namespace
+} //namespace pico
 
 class PicoEditorExportPlugin : public OpenXREditorExportPlugin {
 	GDCLASS(PicoEditorExportPlugin, OpenXREditorExportPlugin)

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_scene_capture_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_scene_capture_extension_wrapper.h
@@ -97,7 +97,7 @@ private:
 			userdata = p_userdata;
 		}
 
-		RequestInfo() { }
+		RequestInfo() {}
 	};
 
 	HashMap<XrAsyncRequestIdFB, RequestInfo> requests;

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_spatial_entity_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_spatial_entity_extension_wrapper.h
@@ -107,10 +107,10 @@ private:
 			(XrSpace), space);
 
 	EXT_PROTO_XRRESULT_FUNC4(xrLocateSpace,
-		(XrSpace), space,
-		(XrSpace), baseSpace,
-		(XrTime), time,
-		(XrSpaceLocation *), location)
+			(XrSpace), space,
+			(XrSpace), baseSpace,
+			(XrTime), time,
+			(XrSpaceLocation *), location)
 
 	bool initialize_fb_spatial_entity_extension(const XrInstance &instance);
 	void on_spatial_anchor_created(const XrEventDataSpatialAnchorCreateCompleteFB *event);
@@ -122,7 +122,7 @@ private:
 		SpatialAnchorCreatedCallback callback = nullptr;
 		void *userdata = nullptr;
 
-		SpatialAnchorCreationInfo() { }
+		SpatialAnchorCreationInfo() {}
 
 		SpatialAnchorCreationInfo(SpatialAnchorCreatedCallback p_callback, void *p_userdata) {
 			callback = p_callback;
@@ -135,7 +135,7 @@ private:
 		SetComponentEnabledCallback callback = nullptr;
 		void *userdata = nullptr;
 
-		SetComponentEnabledInfo() { }
+		SetComponentEnabledInfo() {}
 
 		SetComponentEnabledInfo(SetComponentEnabledCallback p_callback, void *p_userdata) {
 			callback = p_callback;
@@ -152,7 +152,7 @@ private:
 			space = p_space;
 		}
 
-		TrackedEntity() {};
+		TrackedEntity(){};
 	};
 	HashMap<StringName, TrackedEntity> tracked_entities;
 

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_spatial_entity_query_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_spatial_entity_query_extension_wrapper.h
@@ -89,7 +89,7 @@ private:
 		void *userdata = nullptr;
 		Vector<XrSpaceQueryResultFB> results;
 
-		QueryInfo() { }
+		QueryInfo() {}
 
 		QueryInfo(QueryCompleteCallback p_callback, void *p_userdata) {
 			callback = p_callback;

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_spatial_entity_sharing_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_spatial_entity_sharing_extension_wrapper.h
@@ -80,7 +80,7 @@ private:
 		ShareSpacesCompleteCallback callback = nullptr;
 		void *userdata = nullptr;
 
-		RequestInfo() { }
+		RequestInfo() {}
 
 		RequestInfo(ShareSpacesCompleteCallback p_callback, void *p_userdata) {
 			callback = p_callback;

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_spatial_entity_storage_batch_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_spatial_entity_storage_batch_extension_wrapper.h
@@ -81,7 +81,7 @@ private:
 		void *userdata = nullptr;
 		XrSpaceStorageLocationFB location = XR_SPACE_STORAGE_LOCATION_INVALID_FB;
 
-		RequestInfo() { }
+		RequestInfo() {}
 
 		RequestInfo(SaveSpacesCompleteCallback p_callback, void *p_userdata, XrSpaceStorageLocationFB p_location) {
 			callback = p_callback;

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_spatial_entity_storage_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_spatial_entity_storage_extension_wrapper.h
@@ -76,7 +76,6 @@ private:
 			(const XrSpaceEraseInfoFB *), info,
 			(XrAsyncRequestIdFB *), requestId)
 
-
 	bool initialize_fb_spatial_entity_storage_extension(const XrInstance &instance);
 	void on_space_save_complete(const XrEventDataSpaceSaveCompleteFB *event);
 	void on_space_erase_complete(const XrEventDataSpaceEraseCompleteFB *event);
@@ -87,7 +86,7 @@ private:
 		StorageRequestCompleteCallback callback = nullptr;
 		void *userdata = nullptr;
 
-		RequestInfo() { }
+		RequestInfo() {}
 
 		RequestInfo(StorageRequestCompleteCallback p_callback, void *p_userdata) {
 			callback = p_callback;

--- a/plugin/src/main/cpp/register_types.cpp
+++ b/plugin/src/main/cpp/register_types.cpp
@@ -41,9 +41,9 @@
 #include "export/export_plugin.h"
 #include "export/khronos_export_plugin.h"
 #include "export/lynx_export_plugin.h"
+#include "export/magicleap_export_plugin.h"
 #include "export/meta_export_plugin.h"
 #include "export/pico_export_plugin.h"
-#include "export/magicleap_export_plugin.h"
 
 #include "extensions/openxr_fb_body_tracking_extension_wrapper.h"
 #include "extensions/openxr_fb_composition_layer_alpha_blend_extension_wrapper.h"
@@ -61,8 +61,8 @@
 #include "extensions/openxr_fb_spatial_entity_extension_wrapper.h"
 #include "extensions/openxr_fb_spatial_entity_query_extension_wrapper.h"
 #include "extensions/openxr_fb_spatial_entity_sharing_extension_wrapper.h"
-#include "extensions/openxr_fb_spatial_entity_storage_extension_wrapper.h"
 #include "extensions/openxr_fb_spatial_entity_storage_batch_extension_wrapper.h"
+#include "extensions/openxr_fb_spatial_entity_storage_extension_wrapper.h"
 #include "extensions/openxr_fb_spatial_entity_user_extension_wrapper.h"
 #include "extensions/openxr_htc_facial_tracking_extension_wrapper.h"
 #include "extensions/openxr_htc_passthrough_extension_wrapper.h"
@@ -218,7 +218,7 @@ void terminate_plugin_module(ModuleInitializationLevel p_level) {
 }
 
 void add_plugin_project_settings() {
-	ProjectSettings* project_settings = ProjectSettings::get_singleton();
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
 	if (project_settings == nullptr) {
 		return;
 	}

--- a/plugin/src/main/cpp/util.cpp
+++ b/plugin/src/main/cpp/util.cpp
@@ -39,11 +39,11 @@ StringName OpenXRUtilities::uuid_to_string_name(const XrUuidEXT &p_uuid) {
 	char uuid_str[37];
 
 	sprintf(uuid_str, "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
-		data[0], data[1], data[2], data[3],
-		data[4], data[5],
-		data[6], data[7],
-		data[8], data[9],
-		data[10], data[11], data[12], data[13], data[14], data[15]);
+			data[0], data[1], data[2], data[3],
+			data[4], data[5],
+			data[6], data[7],
+			data[8], data[9],
+			data[10], data[11], data[12], data[13], data[14], data[15]);
 
 	return StringName(uuid_str);
 }


### PR DESCRIPTION
This PR fixes issue #212. Specifically it:
- Updates to ubuntu-22.04 (the same version as godotengine) to support the .clang-format settings
- Fixes the clang-format violations

Unfortunately while clang-format hasn't been correctly enforced we've had 21 source files committed with minor clang-format violations.