### PR TITLE
Add gradle tasks related to zipping sample projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ local.properties
 # Misc
 .DS_Store
 /plugin/src/gen/
+/zippedSamples

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ task clean(type: Delete) {
 
     dependsOn 'cleanAddon'
     dependsOn 'cleanBuildFromSamples'
+    dependsOn 'cleanZippedSamples'
 
     dependsOn ':plugin:clean'
 }
@@ -148,4 +149,38 @@ task cleanBuildFromSamples {
             }
         }
     }
+}
+
+task zipSamples {
+    def samplesDir = file 'samples'
+    def directoriesToZip = samplesDir.listFiles().findAll { it.isDirectory() && it.name != 'builds' }
+
+    def destinationDir = file 'zippedSamples'
+    destinationDir.mkdirs()
+
+    directoriesToZip.each { dir ->
+        def godotFolder = new File(dir, '.godot')
+        if (godotFolder.exists()) {
+            godotFolder.deleteDir()
+        }
+
+        def androidFolder = new File(dir, 'android')
+        if (androidFolder.exists()) {
+            androidFolder.deleteDir()
+        }
+
+        def zipTask = tasks.create(name: "zip${dir.name.capitalize()}", type: Zip) {
+            from(dir.parentFile) {
+                include "${dir.name}/**"
+            }
+            archiveFileName = "${dir.name}.zip"
+            destinationDirectory = destinationDir
+        }
+
+        dependsOn zipTask
+    }
+}
+
+task cleanZippedSamples {
+    delete 'zippedSamples'
 }


### PR DESCRIPTION
@m4gr3d mentioned that having the vendor repo's sample projects available on the asset library would be super handy for users of the XR Editor. I think it makes most sense to host the zips of these in the vendor repo releases. This PR adds some gradle tasks to generate/clean those.

I'll add the zipped projects to the 3.0.1 release if we agree on this approach.