### PR TITLE
Add two modes of pico hand tracking to selectable export features

### DIFF
--- a/plugin/src/main/cpp/include/export/pico_export_plugin.h
+++ b/plugin/src/main/cpp/include/export/pico_export_plugin.h
@@ -43,6 +43,10 @@ static const int FACE_TRACKING_NONE_VALUE = 0;
 static const int FACE_TRACKING_FACEONLY_VALUE = 1;
 static const int FACE_TRACKING_LIPSYNCONLY_VALUE = 2;
 static const int FACE_TRACKING_HYBRID_VALUE = 3;
+
+static const int HAND_TRACKING_NONE_VALUE = 0;
+static const int HAND_TRACKING_LOWFREQUENCY_VALUE = 1;
+static const int HAND_TRACKING_HIGHFREQUENCY_VALUE = 2;
 } //namespace pico
 
 class PicoEditorExportPlugin : public OpenXREditorExportPlugin {
@@ -65,6 +69,7 @@ protected:
 
 	Dictionary _eye_tracking_option;
 	Dictionary _face_tracking_option;
+	Dictionary _hand_tracking_option;
 
 private:
 	bool _is_eye_tracking_enabled() const;


### PR DESCRIPTION
This should resolve part of #162.

With this, hand tracking for PICO can be explicitly enabled using `<meta-data android:name="handtracking" android:value="1"/>`
I also added the high frequency mode with `<meta-data android:name="Hand_Tracking_HighFrequency" android:value="1"/>`

Both options I found in the official PICO SDK for Unity, oddly enough no other documentation anywhere: https://github.com/Pico-Developer/PICO-Unity-Integration-SDK/blob/f07f05f433a9671344c722a13ccc6f259e7e390d/Editor/PXR_BuildProcessor.cs#L229

![image](https://github.com/user-attachments/assets/728070b2-a12b-4918-9076-b1e31e79e148)
