### PR TITLE
Reworked geometric algebra. Accesses Basis via get_column.

### DIFF
--- a/plugin/src/main/cpp/extensions/openxr_fb_body_tracking_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_fb_body_tracking_extension_wrapper.cpp
@@ -348,7 +348,6 @@ void OpenXRFbBodyTrackingExtensionWrapper::_on_process() {
 		Transform3D right_shoulder = xr_body_tracker->get_joint_transform(XRBodyTracker::JOINT_RIGHT_SHOULDER);
 		right_shoulder.origin += shoulder_offset;
 		xr_body_tracker->set_joint_transform(XRBodyTracker::JOINT_RIGHT_SHOULDER, right_shoulder);
-
 	}
 
 	// Register the XRBodyTracker if necessary


### PR DESCRIPTION
… to 'correct' root and shoulder-tracking bugs respectively.

Root tracker does now point 'forward'. IE +z aligns with hips & user's real-world 'forward' (whilst remaining along, and on, the XRorigin / Global XZ plane). Shoulder trackers also properly pulled back (the previously indicated 7cm) towards upper chest, more aligned with T-pose modelling.

Having now delved a bit deeper into GDE wrappers, variants exposure, etc, I'm going to speculate that basis' unit vectors are, indeed, intended to be accessed via get_column out here - as we're firmly in C++ land still - and *that's* what initially tripped @m4gr3d up way back when? I've done a quick search of the files in GodotVR repo and couldn't find any others which access 'basis[]' beyond this file which would need addressing.

Primarily fixes #205, & fixes #218, though leaves open discussion still re:
* the approach of omitting / dropping XR_BODY_JOINT_<#####>SCAPULA_FB data, then correction of XR_BODY_JOINT<#####>_SHOULDER_FB, and techniques employed therein.
* modifying root at all!