### PR TITLE
Fix `OpenXRFbPassthroughExtensionWrapper` from wiping out the next pointer chain for system properties

### DIFF
--- a/plugin/src/main/cpp/extensions/openxr_fb_passthrough_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_fb_passthrough_extension_wrapper.cpp
@@ -133,8 +133,15 @@ void OpenXRFbPassthroughExtensionWrapper::cleanup() {
 }
 
 uint64_t OpenXRFbPassthroughExtensionWrapper::_set_system_properties_and_get_next_pointer(void *p_next_pointer) {
-	system_passthrough_properties.next = &system_passthrough_color_lut_properties;
-	return reinterpret_cast<uint64_t>(&system_passthrough_properties);
+	if (fb_passthrough_ext) {
+		system_passthrough_properties.next = p_next_pointer;
+		p_next_pointer = &system_passthrough_properties;
+	}
+	if (meta_passthrough_color_lut_ext) {
+		system_passthrough_color_lut_properties.next = p_next_pointer;
+		p_next_pointer = &system_passthrough_color_lut_properties;
+	}
+	return reinterpret_cast<uint64_t>(p_next_pointer);
 }
 
 void OpenXRFbPassthroughExtensionWrapper::_on_instance_created(uint64_t p_instance) {


### PR DESCRIPTION
This code in `OpenXRFbPassthroughExtensionWrapper::_set_system_properties_and_get_next_pointer()` will wipe out the next pointer chain for system properties:

```c++
uint64_t OpenXRFbPassthroughExtensionWrapper::_set_system_properties_and_get_next_pointer(void *p_next_pointer) {
	system_passthrough_properties.next = &system_passthrough_color_lut_properties;
	return reinterpret_cast<uint64_t>(&system_passthrough_properties);
}
```

Notice how it doesn't do anything with `p_next_pointer`. If there was already anything pointed to by `p_next_pointer`, it would be lost.

This PR makes sure that `p_next_pointer` is included, and it also makes sure the required extensions are enabled before adding each system properties struct.
