### PR TITLE
Remove deprecated "Contexual" boundary mode on Meta Quest

### DIFF
--- a/plugin/src/main/cpp/export/meta_export_plugin.cpp
+++ b/plugin/src/main/cpp/export/meta_export_plugin.cpp
@@ -156,7 +156,7 @@ MetaEditorExportPlugin::MetaEditorExportPlugin() {
 			"",
 			Variant::Type::INT,
 			PROPERTY_HINT_ENUM,
-			"Enabled,Disabled,Contextual",
+			"Enabled,Disabled",
 			PROPERTY_USAGE_DEFAULT,
 			BOUNDARY_ENABLED_VALUE,
 			false);
@@ -428,8 +428,6 @@ String MetaEditorExportPlugin::_get_android_manifest_element_contents(const Ref<
 	int boundary_mode = _get_int_option("meta_xr_features/boundary_mode", BOUNDARY_ENABLED_VALUE);
 	if (boundary_mode == BOUNDARY_DISABLED_VALUE) {
 		contents += "    <uses-feature tools:node=\"replace\" android:name=\"com.oculus.feature.BOUNDARYLESS_APP\" android:required=\"true\" />\n";
-	} else if (boundary_mode == BOUNDARY_CONTEXTUAL_VALUE) {
-		contents += "    <uses-feature tools:node=\"replace\" android:name=\"com.oculus.feature.CONTEXTUAL_BOUNDARYLESS_APP\" android:required=\"true\" />\n";
 	}
 
 	return contents;

--- a/plugin/src/main/cpp/include/export/meta_export_plugin.h
+++ b/plugin/src/main/cpp/include/export/meta_export_plugin.h
@@ -65,7 +65,6 @@ static const int HAND_TRACKING_FREQUENCY_HIGH_VALUE = 1;
 
 static const int BOUNDARY_ENABLED_VALUE = 0;
 static const int BOUNDARY_DISABLED_VALUE = 1;
-static const int BOUNDARY_CONTEXTUAL_VALUE = 2;
 } // namespace
 
 class MetaEditorExportPlugin : public OpenXREditorExportPlugin {


### PR DESCRIPTION
Fixes https://github.com/GodotVR/godot_openxr_vendors/issues/210

This only removes the now deprecated option. If a project used it previously, then a subsequent export would treat it as if the boundary mode was "Enabled".

Ideally, we'd also add support for the `XR_META_boundary_visibility` extension, but we still need to figure out our internal policy around using OpenXR extensions that haven't been added to the spec yet.