### PR TITLE
feat: add permission request toggles for Meta XR features

### DIFF
--- a/plugin/src/main/cpp/register_types.cpp
+++ b/plugin/src/main/cpp/register_types.cpp
@@ -239,6 +239,72 @@ void add_plugin_project_settings() {
 		property_info["hint"] = PROPERTY_HINT_NONE;
 		project_settings->add_property_info(property_info);
 	}
+
+	{
+		// Add the 'body_track_req' project setting	
+		String body_track_req_setting = "xr/openxr/meta/body_tracking_permission_request";
+		if (!project_settings->has_setting(body_track_req_setting)) {
+			// Default value is `true` to match prior plugin behavior
+			project_settings->set_setting(body_track_req_setting, true);
+		}
+
+		project_settings->set_initial_value(body_track_req_setting, true);
+		project_settings->set_as_basic(body_track_req_setting, false);
+		Dictionary property_info;
+		property_info["name"] = body_track_req_setting;
+		property_info["type"] = Variant::Type::BOOL;
+		property_info["hint"] = PROPERTY_HINT_NONE;
+		project_settings->add_property_info(property_info);
+	}
+
+	{
+		// Add the 'eye_track_req' project setting	
+		String eye_track_req_setting = "xr/openxr/meta/eye_tracking_permission_request";
+		if (!project_settings->has_setting(eye_track_req_setting)) {
+			// Default value is `true` to match prior plugin behavior
+			project_settings->set_setting(eye_track_req_setting, true);
+		}
+
+		project_settings->set_initial_value(eye_track_req_setting, true);
+		project_settings->set_as_basic(eye_track_req_setting, false);
+		Dictionary property_info;
+		property_info["name"] = eye_track_req_setting;
+		property_info["type"] = Variant::Type::BOOL;
+		property_info["hint"] = PROPERTY_HINT_NONE;
+		project_settings->add_property_info(property_info);
+	}
+
+	{
+		// Add the 'face_track_req' project setting	
+		String face_track_req_setting = "xr/openxr/meta/face_tracking_permission_request";
+		if (!project_settings->has_setting(face_track_req_setting)) {
+			project_settings->set_setting(face_track_req_setting, true);
+		}
+
+		project_settings->set_initial_value(face_track_req_setting, true);
+		project_settings->set_as_basic(face_track_req_setting, false);
+		Dictionary property_info;
+		property_info["name"] = face_track_req_setting;
+		property_info["type"] = Variant::Type::BOOL;
+		property_info["hint"] = PROPERTY_HINT_NONE;
+		project_settings->add_property_info(property_info);
+	}
+
+	{
+		// Add the 'scene_req' project setting	
+		String scene_req_setting = "xr/openxr/meta/scene_permission_request";
+		if (!project_settings->has_setting(scene_req_setting)) {
+			project_settings->set_setting(scene_req_setting, true);
+		}
+
+		project_settings->set_initial_value(scene_req_setting, true);
+		project_settings->set_as_basic(scene_req_setting, false);
+		Dictionary property_info;
+		property_info["name"] = scene_req_setting;
+		property_info["type"] = Variant::Type::BOOL;
+		property_info["hint"] = PROPERTY_HINT_NONE;
+		project_settings->add_property_info(property_info);
+	}
 }
 
 extern "C" {

--- a/plugin/src/meta/java/org/godotengine/openxr/vendors/meta/GodotOpenXRMeta.kt
+++ b/plugin/src/meta/java/org/godotengine/openxr/vendors/meta/GodotOpenXRMeta.kt
@@ -30,6 +30,8 @@
 package org.godotengine.openxr.vendors.meta
 
 import org.godotengine.godot.Godot
+import org.godotengine.godot.GodotLib
+import org.godotengine.godot.plugin.GodotPlugin
 import org.godotengine.godot.utils.PermissionsUtil
 import org.godotengine.openxr.vendors.GodotOpenXR
 
@@ -52,19 +54,23 @@ class GodotOpenXRMeta(godot: Godot?) : GodotOpenXR(godot) {
         val permissionsToEnable = super.getPluginPermissionsToEnable()
 
         // Request the body tracking permission if it's included in the manifest
-        if (PermissionsUtil.hasManifestPermission(activity, BODY_TRACKING_PERMISSION)) {
+        val body_track_req = GodotLib.getGlobal("xr/openxr/meta/body_tracking_permission_request")
+        if (body_track_req.toBoolean() && PermissionsUtil.hasManifestPermission(activity, BODY_TRACKING_PERMISSION)) {
             permissionsToEnable.add(BODY_TRACKING_PERMISSION)
         }
         // Request the eye tracking permission if it's included in the manifest
-        if (PermissionsUtil.hasManifestPermission(activity, EYE_TRACKING_PERMISSION)) {
+        val eye_track_req = GodotLib.getGlobal("xr/openxr/meta/eye_tracking_permission_request")
+        if (eye_track_req.toBoolean() && PermissionsUtil.hasManifestPermission(activity, EYE_TRACKING_PERMISSION)) {
             permissionsToEnable.add(EYE_TRACKING_PERMISSION)
         }
         // Request the face tracking permission if it's included in the manifest
-        if (PermissionsUtil.hasManifestPermission(activity, FACE_TRACKING_PERMISSION)) {
+        val face_track_req = GodotLib.getGlobal("xr/openxr/meta/face_tracking_permission_request")
+        if (face_track_req.toBoolean() && PermissionsUtil.hasManifestPermission(activity, FACE_TRACKING_PERMISSION)) {
             permissionsToEnable.add(FACE_TRACKING_PERMISSION)
         }
         // Request the scene API permission if it's included in the manifest
-        if (PermissionsUtil.hasManifestPermission(activity, SCENE_PERMISSION)) {
+        val scene_req = GodotLib.getGlobal("xr/openxr/meta/scene_permission_request")
+        if (scene_req.toBoolean() && PermissionsUtil.hasManifestPermission(activity, SCENE_PERMISSION)) {
             permissionsToEnable.add(SCENE_PERMISSION)
         }
 


### PR DESCRIPTION
Add project settings to control permission requests for Meta XR features:
- Body tracking
- Eye tracking
- Face tracking
- Scene API

Each permission can now be toggled via project settings while maintaining backwards compatibility with default true values.