### PR TITLE
Only add the `LAUNCHER` category if "Show in App Library" is enabled

### DIFF
--- a/plugin/src/main/cpp/export/export_plugin.cpp
+++ b/plugin/src/main/cpp/export/export_plugin.cpp
@@ -191,14 +191,24 @@ String OpenXREditorExportPlugin::_get_android_manifest_activity_element_contents
 		return "";
 	}
 
-	return R"(
+	String contents = R"(
 				<intent-filter>
 					<action android:name="android.intent.action.MAIN" />
-					<category android:name="android.intent.category.LAUNCHER" />
 
 					<!-- OpenXR category tag to indicate the activity starts in an immersive OpenXR mode.
 					See https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#android-runtime-category. -->
 					<category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
-				</intent-filter>
 )";
+
+	if (_get_bool_option("package/show_in_app_library")) {
+		contents += R"(
+						<category android:name="android.intent.category.LAUNCHER" />
+)";
+	}
+
+	contents += R"(
+				</intent-filter>"
+)";
+
+	return contents;
 }

--- a/plugin/src/main/cpp/export/khronos_export_plugin.cpp
+++ b/plugin/src/main/cpp/export/khronos_export_plugin.cpp
@@ -191,13 +191,18 @@ String KhronosEditorExportPlugin::_get_android_manifest_activity_element_content
 	contents += R"(
 				<intent-filter>
 					<action android:name="android.intent.action.MAIN" />
-					<category android:name="android.intent.category.LAUNCHER" />
 
 					<!-- OpenXR category tag to indicate the activity starts in an immersive OpenXR mode.
 					See https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#android-runtime-category. -->
 					<category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
 
 )";
+
+	if (_get_bool_option("package/show_in_app_library")) {
+		contents += R"(
+						<category android:name="android.intent.category.LAUNCHER" />
+)";
+	}
 
 	if (_is_khronos_htc_enabled()) {
 		contents += R"(

--- a/plugin/src/main/cpp/export/magicleap_export_plugin.cpp
+++ b/plugin/src/main/cpp/export/magicleap_export_plugin.cpp
@@ -112,29 +112,6 @@ String MagicleapEditorExportPlugin::_get_export_option_warning(const Ref<EditorE
 	return OpenXREditorExportPlugin::_get_export_option_warning(platform, option);
 }
 
-String MagicleapEditorExportPlugin::_get_android_manifest_activity_element_contents(const Ref<EditorExportPlatform> &platform, bool debug) const {
-	String contents;
-	if (!_supports_platform(platform) || !_is_vendor_plugin_enabled()) {
-		return contents;
-	}
-
-	contents += R"(
-				<intent-filter>
-					<action android:name="android.intent.action.MAIN" />
-					<category android:name="android.intent.category.LAUNCHER" />
-
-					<!-- OpenXR category tag to indicate the activity starts in an immersive OpenXR mode.
-					See https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#android-runtime-category. -->
-					<category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
-
-)";
-
-	contents += R"(
-				</intent-filter>
-)";
-	return contents;
-}
-
 String MagicleapEditorExportPlugin::_get_android_manifest_element_contents(const Ref<EditorExportPlatform> &platform, bool debug) const {
 	String contents;
 	if (!_supports_platform(platform) || !_is_vendor_plugin_enabled()) {

--- a/plugin/src/main/cpp/export/meta_export_plugin.cpp
+++ b/plugin/src/main/cpp/export/meta_export_plugin.cpp
@@ -483,10 +483,9 @@ String MetaEditorExportPlugin::_get_android_manifest_activity_element_contents(c
 		return "";
 	}
 
-	return R"(
+	String contents = R"(
 				<intent-filter>
 					<action android:name="android.intent.action.MAIN" />
-					<category android:name="android.intent.category.LAUNCHER" />
 
 					<!-- Enable access to OpenXR on Oculus mobile devices, no-op on other Android
 					platforms. -->
@@ -495,6 +494,17 @@ String MetaEditorExportPlugin::_get_android_manifest_activity_element_contents(c
 					<!-- OpenXR category tag to indicate the activity starts in an immersive OpenXR mode.
 					See https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#android-runtime-category. -->
 					<category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
-				</intent-filter>
 )";
+
+	if (_get_bool_option("package/show_in_app_library")) {
+		contents += R"(
+						<category android:name="android.intent.category.LAUNCHER" />
+)";
+	}
+
+	contents += R"(
+				</intent-filter>"
+)";
+
+	return contents;
 }

--- a/plugin/src/main/cpp/include/export/magicleap_export_plugin.h
+++ b/plugin/src/main/cpp/include/export/magicleap_export_plugin.h
@@ -49,7 +49,6 @@ public:
 
 	String _get_export_option_warning(const Ref<EditorExportPlatform> &platform, const String &option) const override;
 
-	String _get_android_manifest_activity_element_contents(const Ref<EditorExportPlatform> &platform, bool debug) const override;
 	String _get_android_manifest_element_contents(const Ref<EditorExportPlatform> &platform, bool debug) const override;
 
 protected:


### PR DESCRIPTION
Presently, we are forcibly adding this Android intent for when using any OpenXR loader:

```
<category android:name="android.intent.category.LAUNCHER" />
```

... however:

- Godot already has an export option ("Show In App Library") to add this intent, and it's already enabled by default. So, we don't really even need to add this
- Always adding it makes it impossible for an Android plugin to add a second Activity which will launch by default, which is necessary for making a hybrid app on Meta's platform, that starts as a panel app (and later switches to immersive)
