### PR TITLE
Fix crash when attempting to create a spatial anchor too early

### DIFF
--- a/plugin/src/main/cpp/classes/openxr_fb_spatial_anchor_manager.cpp
+++ b/plugin/src/main/cpp/classes/openxr_fb_spatial_anchor_manager.cpp
@@ -179,8 +179,12 @@ void OpenXRFbSpatialAnchorManager::create_anchor(const Transform3D &p_transform,
 	Transform3D local_transform = xr_origin->get_global_transform().inverse() * p_transform;
 
 	Ref<OpenXRFbSpatialEntity> spatial_entity = OpenXRFbSpatialEntity::create_spatial_anchor(local_transform);
-	spatial_entity->set_custom_data(p_custom_data);
-	spatial_entity->connect("openxr_fb_spatial_entity_created", callable_mp(this, &OpenXRFbSpatialAnchorManager::_on_anchor_created).bind(p_transform, spatial_entity));
+	if (spatial_entity.is_valid()) {
+		spatial_entity->set_custom_data(p_custom_data);
+		spatial_entity->connect("openxr_fb_spatial_entity_created", callable_mp(this, &OpenXRFbSpatialAnchorManager::_on_anchor_created).bind(p_transform, spatial_entity));
+	} else {
+		emit_signal("openxr_fb_spatial_anchor_create_failed", p_transform, p_custom_data);
+	}
 }
 
 void OpenXRFbSpatialAnchorManager::_on_anchor_created(bool p_success, const Transform3D &p_transform, const Ref<OpenXRFbSpatialEntity> &p_spatial_entity) {

--- a/plugin/src/main/cpp/classes/openxr_fb_spatial_entity.cpp
+++ b/plugin/src/main/cpp/classes/openxr_fb_spatial_entity.cpp
@@ -375,7 +375,11 @@ Node3D *OpenXRFbSpatialEntity::create_collision_shape() const {
 Ref<OpenXRFbSpatialEntity> OpenXRFbSpatialEntity::create_spatial_anchor(const Transform3D &p_transform) {
 	Ref<OpenXRFbSpatialEntity> *userdata = memnew(Ref<OpenXRFbSpatialEntity>());
 	(*userdata).instantiate();
-	OpenXRFbSpatialEntityExtensionWrapper::get_singleton()->create_spatial_anchor(p_transform, &OpenXRFbSpatialEntity::_on_spatial_anchor_created, userdata);
+	if (!OpenXRFbSpatialEntityExtensionWrapper::get_singleton()->create_spatial_anchor(p_transform, &OpenXRFbSpatialEntity::_on_spatial_anchor_created, userdata)) {
+		// If it fails to create, then _on_spatial_anchor_created() would have been called immediately,
+		// which will have already done memdelete(userdata), so we need to return a new null value.
+		return Ref<OpenXRFbSpatialEntity>();
+	}
 	return *userdata;
 }
 


### PR DESCRIPTION
This fixes a crash that happens if you attempt to create a spatial anchor too early (like before the OpenXR session has begun).

This happens because there's two different ways an anchor can fail to create:

1. If the function call to initiate creation of the anchor (which completes asynchronously) fails immediately, or
2. The function call to initiate create works, but we're notified asynchronously that the creation of the anchor failed

We're correctly handling case nr 2, but not case nr 1!

In case nr 1, we clean up everything earlier than expected, and get some null pointer exceptions when attempting to use the anchor object when setting up our asynchronous handling.