### PR TITLE
[DRAFT] Add support for the Android XR OpenXR vendor

### DIFF
--- a/docs/make_rst.py
+++ b/docs/make_rst.py
@@ -66,6 +66,8 @@ strings_l10n: Dict[str, str] = {}
 STYLES: Dict[str, str] = {}
 
 SKIP_CLASSES: List[str] = [
+    "AndroidEditorExportPlugin",
+    "AndroidEditorPlugin",
     "KhronosEditorExportPlugin",
     "KhronosEditorPlugin",
     "LynxEditorPlugin",

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -36,6 +36,18 @@ android {
 
     flavorDimensions = ["vendor"]
     productFlavors {
+        android {
+            dimension "vendor"
+            ndk {
+                //noinspection ChromeOsAbiSupport
+                abiFilters 'arm64-v8a', 'x86_64'
+            }
+            externalNativeBuild {
+                cmake {
+                    arguments "-DFLAVOR=android"
+                }
+            }
+        }
         khronos {
             dimension "vendor"
             ndk {
@@ -100,6 +112,11 @@ android {
     }
 
     publishing {
+        singleVariant("androidRelease") {
+            withSourcesJar()
+            withJavadocJar()
+        }
+
         singleVariant("khronosRelease") {
             withSourcesJar()
             withJavadocJar()
@@ -140,6 +157,9 @@ android {
 
 dependencies {
     compileOnly libraries.godotAndroidLib
+
+    // AndroidXR dependencies
+    androidImplementation "org.khronos.openxr:openxr_loader_for_android:$versions.openxrVersion"
 
     // Khronos dependencies
     khronosImplementation "org.khronos.openxr:openxr_loader_for_android:$versions.openxrVersion"

--- a/plugin/src/android/AndroidManifest.xml
+++ b/plugin/src/android/AndroidManifest.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- Permissions needed by OpenXR -->
+    <uses-permission android:name="org.khronos.openxr.permission.OPENXR" />
+    <uses-permission android:name="org.khronos.openxr.permission.OPENXR_SYSTEM" />
+
+    <queries>
+        <intent>
+            <action android:name="org.khronos.openxr.OpenXRRuntimeService"/>
+        </intent>
+        <provider android:authorities="org.khronos.openxr.runtime_broker;org.khronos.openxr.system_runtime_broker" />
+    </queries>
+
+    <application>
+        <meta-data
+            android:name="org.godotengine.plugin.v2.GodotOpenXRAndroid"
+            android:value="org.godotengine.openxr.vendors.android.GodotOpenXRAndroid" />
+    </application>
+
+</manifest>

--- a/plugin/src/android/android.cmake
+++ b/plugin/src/android/android.cmake
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22.1)
+
+## Android OpenXR loader library
+find_package(OpenXR REQUIRED CONFIG)
+
+set(VENDOR_HEADERS_DIR "")
+set(OPENXR_LOADER "OpenXR::openxr_loader")
+
+## Setup the project sources
+file(GLOB_RECURSE ANDROID_SOURCES ${CMAKE_CURRENT_LIST_DIR}/cpp/*.c**)
+file(GLOB_RECURSE ANDROID_HEADERS ${CMAKE_CURRENT_LIST_DIR}/cpp/*.h**)
+
+add_definitions(-DANDROID_VENDOR_ENABLED)

--- a/plugin/src/android/java/org/godotengine/openxr/vendors/android/GodotOpenXRAndroid.kt
+++ b/plugin/src/android/java/org/godotengine/openxr/vendors/android/GodotOpenXRAndroid.kt
@@ -1,0 +1,108 @@
+/**************************************************************************/
+/*  GodotOpenXRAndroid.kt                                                 */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+package org.godotengine.openxr.vendors.android
+
+import org.godotengine.godot.Godot
+import org.godotengine.godot.utils.PermissionsUtil
+import org.godotengine.openxr.vendors.GodotOpenXR
+
+/**
+ * Godot OpenXR plugin for the Android XR platform.
+ */
+class GodotOpenXRAndroid(godot: Godot?) : GodotOpenXR(godot) {
+    companion object {
+        /**
+         * Representing the user's eye pose and orientation, for the purposes of avatars
+         */
+        private const val EYE_TRACKING_PERMISSION = "android.permission.EYE_TRACKING"
+
+        /**
+         * Eye gaze input and interactions
+         */
+        private const val EYE_TRACKING_FINE_PERMISSION = "android.permission.EYE_TRACKING_FINE"
+
+        /**
+         * Tracking and rendering facial expressions
+         */
+        private const val FACE_TRACKING_PERMISSION = "android.permission.FACE_TRACKING"
+
+        /**
+         * Tracking hand joint poses and angular and linear velocities; Using a mesh representation of the user's hands
+         */
+        private const val HAND_TRACKING_PERMISSION = "android.permission.HAND_TRACKING"
+
+        /**
+         * - Light estimation
+         * - projecting passthrough onto mesh surfaces
+         * - performing raycasts against trackables in the environment
+         * - plane tracking
+         * - object tracking
+         * - working with depth for occlusion and hit testing
+         * - persistent anchors
+         */
+        private const val SCENE_UNDERSTANDING_PERMISSION = "android.permission.SCENE_UNDERSTANDING"
+
+        private val ANDROID_XR_PERMISSIONS_LIST = listOf(
+            EYE_TRACKING_PERMISSION,
+            EYE_TRACKING_FINE_PERMISSION,
+            FACE_TRACKING_PERMISSION,
+            HAND_TRACKING_PERMISSION,
+            SCENE_UNDERSTANDING_PERMISSION,
+        )
+    }
+    override fun getPluginName() = "GodotOpenXRAndroid"
+
+    override fun getPluginPermissionsToEnable(): MutableList<String> {
+        val permissionsToEnable = super.getPluginPermissionsToEnable()
+
+        // Go through the list of permissions, and request the ones that are included in the
+        // manifest.
+        for (permission in ANDROID_XR_PERMISSIONS_LIST) {
+            if (PermissionsUtil.hasManifestPermission(activity, permission)) {
+                permissionsToEnable.add(permission)
+            }
+        }
+        return permissionsToEnable
+    }
+
+    override fun supportsFeature(featureTag: String): Boolean {
+        if ("PERMISSION_XR_EXT_eye_gaze_interaction" == featureTag) {
+            val grantedPermissions = godot?.getGrantedPermissions()
+            if (grantedPermissions != null) {
+                for (permission in grantedPermissions) {
+                    if (EYE_TRACKING_FINE_PERMISSION == permission) {
+                        return true
+                    }
+                }
+            }
+        }
+        return false
+    }
+}

--- a/plugin/src/main/cpp/export/android_export_plugin.cpp
+++ b/plugin/src/main/cpp/export/android_export_plugin.cpp
@@ -1,0 +1,205 @@
+/**************************************************************************/
+/*  android_export_plugin.cpp                                             */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "export/android_export_plugin.h"
+
+#include <godot_cpp/classes/project_settings.hpp>
+
+using namespace godot;
+using namespace android;
+
+void AndroidEditorPlugin::_bind_methods() {}
+
+void AndroidEditorPlugin::_enter_tree() {
+	// Initialize the editor export plugin
+	android_export_plugin.instantiate();
+	add_export_plugin(android_export_plugin);
+}
+
+void AndroidEditorPlugin::_exit_tree() {
+	// Clean up the editor export plugin
+	remove_export_plugin(android_export_plugin);
+	android_export_plugin.unref();
+}
+
+AndroidEditorExportPlugin::AndroidEditorExportPlugin() {
+	set_vendor_name(ANDROID_VENDOR_NAME);
+
+	_eye_tracking_option = _generate_export_option(
+			"android_xr_features/eye_tracking",
+			"",
+			Variant::Type::INT,
+			PROPERTY_HINT_ENUM,
+			"None,Optional,Required",
+			PROPERTY_USAGE_DEFAULT,
+			EYE_TRACKING_NONE_VALUE,
+			false);
+	_hand_tracking_option = _generate_export_option(
+			"android_xr_features/hand_tracking",
+			"",
+			Variant::Type::INT,
+			PROPERTY_HINT_ENUM,
+			"None,Optional,Required",
+			PROPERTY_USAGE_DEFAULT,
+			HAND_TRACKING_NONE_VALUE,
+			false);
+}
+
+void AndroidEditorExportPlugin::_bind_methods() {}
+
+TypedArray<Dictionary> AndroidEditorExportPlugin::_get_export_options(const Ref<godot::EditorExportPlatform> &platform) const {
+	TypedArray<Dictionary> export_options;
+	if (!_supports_platform(platform)) {
+		return export_options;
+	}
+
+	export_options.append(_get_vendor_toggle_option());
+	export_options.append(_eye_tracking_option);
+	export_options.append(_hand_tracking_option);
+
+	return export_options;
+}
+
+Dictionary AndroidEditorExportPlugin::_get_export_options_overrides(const Ref<godot::EditorExportPlatform> &p_platform) const {
+	Dictionary overrides;
+	if (!_supports_platform(p_platform)) {
+		return overrides;
+	}
+
+	if (!_is_vendor_plugin_enabled()) {
+		overrides["android_xr_features/eye_tracking"] = EYE_TRACKING_NONE_VALUE;
+		overrides["android_xr_features/hand_tracking"] = HAND_TRACKING_NONE_VALUE;
+	}
+
+	return overrides;
+}
+
+bool AndroidEditorExportPlugin::_is_eye_tracking_enabled() const {
+	bool eye_tracking_project_setting_enabled = ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/eye_gaze_interaction");
+	if (!eye_tracking_project_setting_enabled) {
+		return false;
+	}
+
+	int eye_tracking_option_value = _get_int_option("android_xr_features/eye_tracking", EYE_TRACKING_NONE_VALUE);
+	return eye_tracking_option_value > EYE_TRACKING_NONE_VALUE;
+}
+
+PackedStringArray AndroidEditorExportPlugin::_get_export_features(const Ref<EditorExportPlatform> &platform, bool debug) const {
+	PackedStringArray features;
+	if (!_supports_platform(platform) || !_is_vendor_plugin_enabled()) {
+		return features;
+	}
+
+	// Add the eye tracking feature if necessary
+	if (_is_eye_tracking_enabled()) {
+		features.append(EYE_GAZE_INTERACTION_FEATURE);
+	}
+
+	return features;
+}
+
+String AndroidEditorExportPlugin::_get_export_option_warning(const Ref<EditorExportPlatform> &platform, const String &option) const {
+	if (!_supports_platform(platform) || !_is_vendor_plugin_enabled()) {
+		return "";
+	}
+
+	bool openxr_enabled = _is_openxr_enabled();
+	if (option == "android_xr_features/eye_tracking") {
+		bool eye_tracking_project_setting_enabled = ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/extensions/eye_gaze_interaction");
+		int eye_tracking_option_value = _get_int_option("android_xr_features/eye_tracking", EYE_TRACKING_NONE_VALUE);
+		if (eye_tracking_option_value > EYE_TRACKING_NONE_VALUE && !eye_tracking_project_setting_enabled) {
+			return "\"Eye Tracking\" project setting must be enabled!\n";
+		}
+	} else if (option == "android_xr_features/hand_tracking") {
+		if (!openxr_enabled && _get_int_option(option, HAND_TRACKING_NONE_VALUE) > HAND_TRACKING_NONE_VALUE) {
+			return "\"Hand Tracking\" requires \"XR Mode\" to be \"OpenXR\".\n";
+		}
+	}
+
+	return OpenXREditorExportPlugin::_get_export_option_warning(platform, option);
+}
+
+String AndroidEditorExportPlugin::_get_android_manifest_activity_element_contents(const Ref<EditorExportPlatform> &platform, bool debug) const {
+	if (!_supports_platform(platform) || !_is_vendor_plugin_enabled()) {
+		return "";
+	}
+
+	return R"(
+				<intent-filter>
+					<action android:name="android.intent.action.MAIN" />
+					<category android:name="android.intent.category.LAUNCHER" />
+
+					<!-- OpenXR category tag to indicate the activity starts in an immersive OpenXR mode.
+					See https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#android-runtime-category. -->
+					<category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
+				</intent-filter>
+				<property
+					android:name="android.window.PROPERTY_XR_ACTIVITY_START_MODE"
+					android:value="XR_ACTIVITY_START_MODE_FULL_SPACE_UNMANAGED" />
+)";
+}
+
+String AndroidEditorExportPlugin::_get_android_manifest_element_contents(const Ref<EditorExportPlatform> &platform, bool debug) const {
+	String contents;
+	if (!_supports_platform(platform) || !_is_vendor_plugin_enabled()) {
+		return contents;
+	}
+
+	// Android XR required
+	contents += "    <uses-feature android:name=\"android.software.xr.immersive\" android:required=\"true\" />\n";
+
+	// 6DoF motion controllers required
+	contents += "    <uses-feature android:name=\"android.hardware.xr.input.controller\" android:required=\"true\" />\n";
+
+	// Check for eye tracking
+	if (_is_eye_tracking_enabled()) {
+		contents += "    <uses-permission android:name=\"android.permission.EYE_TRACKING_FINE\" />\n";
+
+		int eye_tracking_value = _get_int_option("android_xr_features/eye_tracking", EYE_TRACKING_NONE_VALUE);
+		if (eye_tracking_value == EYE_TRACKING_OPTIONAL_VALUE) {
+			contents += "    <uses-feature android:name=\"android.hardware.xr.input.eye_tracking\" android:required=\"false\" />\n";
+		} else if (eye_tracking_value == EYE_TRACKING_REQUIRED_VALUE) {
+			contents += "    <uses-feature android:name=\"android.hardware.xr.input.eye_tracking\" android:required=\"true\" />\n";
+		}
+	}
+
+	// Check for hand tracking
+	int hand_tracking_value = _get_int_option("android_xr_features/hand_tracking", HAND_TRACKING_NONE_VALUE);
+	if (hand_tracking_value > HAND_TRACKING_NONE_VALUE) {
+		contents += "    <uses-permission android:name=\"android.permission.HAND_TRACKING\" />\n";
+
+		if (hand_tracking_value == HAND_TRACKING_OPTIONAL_VALUE) {
+			contents += "    <uses-feature android:name=\"android.hardware.xr.input.hand_tracking\" android:required=\"false\" />\n";
+		} else if (hand_tracking_value == HAND_TRACKING_REQUIRED_VALUE) {
+			contents += "    <uses-feature android:name=\"android.hardware.xr.input.hand_tracking\" android:required=\"true\" />\n";
+		}
+	}
+
+	return contents;
+}

--- a/plugin/src/main/cpp/export/export_plugin.cpp
+++ b/plugin/src/main/cpp/export/export_plugin.cpp
@@ -87,7 +87,7 @@ Dictionary OpenXREditorExportPlugin::_get_vendor_toggle_option(const String &ven
 			"",
 			PROPERTY_USAGE_DEFAULT,
 			false,
-			false);
+			true);
 }
 
 bool OpenXREditorExportPlugin::_is_openxr_enabled() const {

--- a/plugin/src/main/cpp/export/meta_export_plugin.cpp
+++ b/plugin/src/main/cpp/export/meta_export_plugin.cpp
@@ -33,6 +33,7 @@
 #include <godot_cpp/classes/xr_interface.hpp>
 
 using namespace godot;
+using namespace meta;
 
 void MetaEditorPlugin::_bind_methods() {}
 

--- a/plugin/src/main/cpp/include/export/android_export_plugin.h
+++ b/plugin/src/main/cpp/include/export/android_export_plugin.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  meta_editor_plugin.h                                                  */
+/*  android_export_plugin.h                                               */
 /**************************************************************************/
 /*                       This file is part of:                            */
 /*                              GODOT XR                                  */
@@ -35,82 +35,45 @@
 
 using namespace godot;
 
-namespace meta {
+namespace android {
 static const int EYE_TRACKING_NONE_VALUE = 0;
 static const int EYE_TRACKING_OPTIONAL_VALUE = 1;
 static const int EYE_TRACKING_REQUIRED_VALUE = 2;
 
-static const int FACE_TRACKING_NONE_VALUE = 0;
-static const int FACE_TRACKING_OPTIONAL_VALUE = 1;
-static const int FACE_TRACKING_REQUIRED_VALUE = 2;
-
-static const int BODY_TRACKING_NONE_VALUE = 0;
-static const int BODY_TRACKING_OPTIONAL_VALUE = 1;
-static const int BODY_TRACKING_REQUIRED_VALUE = 2;
-
-static const int PASSTHROUGH_NONE_VALUE = 0;
-static const int PASSTHROUGH_OPTIONAL_VALUE = 1;
-static const int PASSTHROUGH_REQUIRED_VALUE = 2;
-
-static const int RENDER_MODEL_NONE_VALUE = 0;
-static const int RENDER_MODEL_OPTIONAL_VALUE = 1;
-static const int RENDER_MODEL_REQUIRED_VALUE = 2;
-
 static const int HAND_TRACKING_NONE_VALUE = 0;
 static const int HAND_TRACKING_OPTIONAL_VALUE = 1;
 static const int HAND_TRACKING_REQUIRED_VALUE = 2;
+} // namespace android
 
-static const int HAND_TRACKING_FREQUENCY_LOW_VALUE = 0;
-static const int HAND_TRACKING_FREQUENCY_HIGH_VALUE = 1;
-
-static const int BOUNDARY_ENABLED_VALUE = 0;
-static const int BOUNDARY_DISABLED_VALUE = 1;
-} // namespace meta
-
-class MetaEditorExportPlugin : public OpenXREditorExportPlugin {
-	GDCLASS(MetaEditorExportPlugin, OpenXREditorExportPlugin)
+class AndroidEditorExportPlugin : public OpenXREditorExportPlugin {
+	GDCLASS(AndroidEditorExportPlugin, OpenXREditorExportPlugin)
 
 public:
-	MetaEditorExportPlugin();
+	AndroidEditorExportPlugin();
 
 	TypedArray<Dictionary> _get_export_options(const Ref<EditorExportPlatform> &platform) const override;
+
+	Dictionary _get_export_options_overrides(const Ref<EditorExportPlatform> &p_platform) const override;
 
 	PackedStringArray _get_export_features(const Ref<EditorExportPlatform> &platform, bool debug) const override;
 
 	String _get_export_option_warning(const Ref<EditorExportPlatform> &platform, const String &option) const override;
 
 	String _get_android_manifest_activity_element_contents(const Ref<EditorExportPlatform> &platform, bool debug) const override;
-	String _get_android_manifest_application_element_contents(const Ref<EditorExportPlatform> &platform, bool debug) const override;
 	String _get_android_manifest_element_contents(const Ref<EditorExportPlatform> &platform, bool debug) const override;
 
 protected:
 	static void _bind_methods();
 
-private:
-	PackedStringArray _get_supported_devices() const;
-
-	bool _is_eye_tracking_enabled() const;
-
 	Dictionary _eye_tracking_option;
-	Dictionary _face_tracking_option;
-	Dictionary _body_tracking_option;
 	Dictionary _hand_tracking_option;
-	Dictionary _hand_tracking_frequency_option;
-	Dictionary _passthrough_option;
-	Dictionary _render_model_option;
-	Dictionary _use_anchor_api_option;
-	Dictionary _use_scene_api_option;
-	Dictionary _use_overlay_keyboard_option;
-	Dictionary _use_experimental_features_option;
-	Dictionary _boundary_mode_option;
-	Dictionary _support_quest_1_option;
-	Dictionary _support_quest_2_option;
-	Dictionary _support_quest_3_option;
-	Dictionary _support_quest_pro_option;
+
+private:
+	bool _is_eye_tracking_enabled() const;
 };
 
-class MetaEditorPlugin : public EditorPlugin {
-	GDCLASS(MetaEditorPlugin, EditorPlugin)
+class AndroidEditorPlugin : public EditorPlugin {
+	GDCLASS(AndroidEditorPlugin, EditorPlugin)
 
 public:
 	void _enter_tree() override;
@@ -120,5 +83,5 @@ protected:
 	static void _bind_methods();
 
 private:
-	Ref<MetaEditorExportPlugin> meta_export_plugin;
+	Ref<AndroidEditorExportPlugin> android_export_plugin;
 };

--- a/plugin/src/main/cpp/include/export/export_plugin.h
+++ b/plugin/src/main/cpp/include/export/export_plugin.h
@@ -45,6 +45,7 @@ static const char *PICO_VENDOR_NAME = "pico";
 static const char *LYNX_VENDOR_NAME = "lynx";
 static const char *KHRONOS_VENDOR_NAME = "khronos";
 static const char *MAGICLEAP_VENDOR_NAME = "magicleap";
+static const char *ANDROID_VENDOR_NAME = "android";
 
 static const char *VENDORS_LIST[] = {
 	META_VENDOR_NAME,
@@ -52,6 +53,7 @@ static const char *VENDORS_LIST[] = {
 	LYNX_VENDOR_NAME,
 	KHRONOS_VENDOR_NAME,
 	MAGICLEAP_VENDOR_NAME,
+	ANDROID_VENDOR_NAME,
 };
 
 // Set of custom feature tags supported by the plugin

--- a/plugin/src/main/cpp/register_types.cpp
+++ b/plugin/src/main/cpp/register_types.cpp
@@ -38,6 +38,7 @@
 #include <godot_cpp/godot.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 
+#include "export/android_export_plugin.h"
 #include "export/export_plugin.h"
 #include "export/khronos_export_plugin.h"
 #include "export/lynx_export_plugin.h"
@@ -188,6 +189,10 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 
 		case MODULE_INITIALIZATION_LEVEL_EDITOR: {
 			ClassDB::register_class<OpenXREditorExportPlugin>();
+
+			ClassDB::register_class<AndroidEditorExportPlugin>();
+			ClassDB::register_class<AndroidEditorPlugin>();
+			EditorPlugins::add_by_type<AndroidEditorPlugin>();
 
 			ClassDB::register_class<KhronosEditorExportPlugin>();
 			ClassDB::register_class<KhronosEditorPlugin>();


### PR DESCRIPTION
This PR adds support for the Android XR OpenXR vendor, which will provide the ability to run Godot XR apps on Android XR devices via the vendor plugin.
- This is a draft PR as the Android XR emulator doesn't support OpenXR apps, and no Android XR devices is yet available for testing, so no testing / validation is feasible at the moment. The PR will remain in this state until we're able to test and validate the functionality.
- While Android XR uses the Khronos loader, the platform introduces its own set of permissions and manifest entries which prevents us from using the Khronos vendor logic, and requires us to create and use a separate `Android` vendor.
- This PR limits itself to the OpenXR extensions already supported in Godot core and the vendors plugin. Android XR [introduces a new set of OpenXR extensions](https://developer.android.com/develop/xr/openxr/extensions#android-xr) which we may add support for in future PRs.