### PR TITLE
Fix wall, floor and ceiling collision shapes with Jolt physics

### DIFF
--- a/plugin/src/main/cpp/classes/openxr_fb_spatial_entity.cpp
+++ b/plugin/src/main/cpp/classes/openxr_fb_spatial_entity.cpp
@@ -36,6 +36,7 @@
 #include <godot_cpp/classes/concave_polygon_shape3d.hpp>
 #include <godot_cpp/classes/mesh_instance3d.hpp>
 #include <godot_cpp/classes/plane_mesh.hpp>
+#include <godot_cpp/classes/project_settings.hpp>
 #include <godot_cpp/classes/surface_tool.hpp>
 #include <godot_cpp/templates/local_vector.hpp>
 
@@ -353,18 +354,23 @@ Node3D *OpenXRFbSpatialEntity::create_collision_shape() const {
 
 		return collision_shape;
 	} else if (is_component_enabled(COMPONENT_TYPE_BOUNDED_2D)) {
+		ProjectSettings *project_settings = ProjectSettings::get_singleton();
+		ERR_FAIL_NULL_V(project_settings, nullptr);
+
+		float collision_shape_2d_thickness = project_settings->get_setting_with_override("xr/openxr/extensions/meta_scene_api/collision_shape_2d_thickness");
+
 		Ref<BoxShape3D> box_shape;
 		box_shape.instantiate();
 
 		Rect2 bounding_box = get_bounding_box_2d();
-		box_shape->set_size(Vector3(bounding_box.size.x, 0, bounding_box.size.y));
+		box_shape->set_size(Vector3(bounding_box.size.x, collision_shape_2d_thickness, bounding_box.size.y));
 
 		CollisionShape3D *collision_shape = memnew(CollisionShape3D);
 		collision_shape->set_shape(box_shape);
 
 		Vector2 plane_center = bounding_box.get_center();
 		collision_shape->rotate_x(Math_PI / 2.0);
-		collision_shape->set_position(Vector3(plane_center.x, plane_center.y, 0));
+		collision_shape->set_position(Vector3(plane_center.x, plane_center.y, -(collision_shape_2d_thickness / 2.0)));
 
 		return collision_shape;
 	}

--- a/plugin/src/main/cpp/register_types.cpp
+++ b/plugin/src/main/cpp/register_types.cpp
@@ -239,6 +239,21 @@ void add_plugin_project_settings() {
 		property_info["hint"] = PROPERTY_HINT_NONE;
 		project_settings->add_property_info(property_info);
 	}
+
+	{
+		String collision_shape_2d_thickness = "xr/openxr/extensions/meta_scene_api/collision_shape_2d_thickness";
+		if (!project_settings->has_setting(collision_shape_2d_thickness)) {
+			project_settings->set_setting(collision_shape_2d_thickness, 0.1);
+		}
+
+		project_settings->set_initial_value(collision_shape_2d_thickness, 0.1);
+		project_settings->set_as_basic(collision_shape_2d_thickness, false);
+		Dictionary property_info;
+		property_info["name"] = collision_shape_2d_thickness;
+		property_info["type"] = Variant::Type::FLOAT;
+		property_info["hint"] = PROPERTY_HINT_NONE;
+		project_settings->add_property_info(property_info);
+	}
 }
 
 extern "C" {


### PR DESCRIPTION
When running the Meta Scene Sample with Jolt physics, it gets errors like this:

```
01-06 11:49:51.772 10894 11064 E godot   : ERROR: Failed to build Jolt Physics box shape with {half_extents=(2.301814, 0.000000, 1.808793) margin=0.040000}. It returned the following error: 'Invalid convex radius'. This shape belongs to 'StaticBody3D:<StaticBody3D#39040583057>' and 0 other object(s).
01-06 11:49:51.772 10894 11064 E godot   :    at: _build (modules/jolt_physics/shapes/jolt_box_shape_3d.cpp:45)
```

This is because we're using `BoxShape3D`s for the 2D spatial entities (like walls, ceiling and floor) but using a `0` for the Y size.

~~This PR fixes the issue by using `0.001` instead.~~

**UPDATE:** In order to prevent tunneling, I've decided to make the `BoxShape3D` be `0.1` thick instead, and moved the shape back, so that one side is flush with where the plane should be. Most walls are thicker than 10cm, but we can't really be sure what things will get a 2D shape, so this feels like a safe-ish default to me. I suppose we could make it configurable? Or, developers can grab the data and generate their own shapes as well, so perhaps that's not necessary