### PR TITLE
Emit correct signal from `OpenXRFbSpatialEntity.erase_from_storage()`

### DIFF
--- a/plugin/src/main/cpp/classes/openxr_fb_spatial_entity.cpp
+++ b/plugin/src/main/cpp/classes/openxr_fb_spatial_entity.cpp
@@ -432,7 +432,7 @@ void OpenXRFbSpatialEntity::erase_from_storage(StorageLocation p_location) {
 	};
 
 	Ref<OpenXRFbSpatialEntity> *userdata = memnew(Ref<OpenXRFbSpatialEntity>(this));
-	OpenXRFbSpatialEntityStorageExtensionWrapper::get_singleton()->erase_space(&erase_info, OpenXRFbSpatialEntity::_on_save_to_storage, userdata);
+	OpenXRFbSpatialEntityStorageExtensionWrapper::get_singleton()->erase_space(&erase_info, OpenXRFbSpatialEntity::_on_erase_from_storage, userdata);
 }
 
 void OpenXRFbSpatialEntity::_on_erase_from_storage(XrResult p_result, XrSpaceStorageLocationFB p_location, void *p_userdata) {


### PR DESCRIPTION
Calling `OpenXRFbSpatialEntity.erase_from_storage()` leads to the saved signal emitting, rather than the erased signal.

Looks like a copy-paste error, using the `_on_save_to_storage()` callback rather than the correct `_on_erase_from_storage()` callback.