### PR TITLE
Remove stray double quote from `AndroidManifest.xml`

### DIFF
--- a/plugin/src/main/cpp/export/export_plugin.cpp
+++ b/plugin/src/main/cpp/export/export_plugin.cpp
@@ -207,7 +207,7 @@ String OpenXREditorExportPlugin::_get_android_manifest_activity_element_contents
 	}
 
 	contents += R"(
-				</intent-filter>"
+				</intent-filter>
 )";
 
 	return contents;

--- a/plugin/src/main/cpp/export/meta_export_plugin.cpp
+++ b/plugin/src/main/cpp/export/meta_export_plugin.cpp
@@ -503,7 +503,7 @@ String MetaEditorExportPlugin::_get_android_manifest_activity_element_contents(c
 	}
 
 	contents += R"(
-				</intent-filter>"
+				</intent-filter>
 )";
 
 	return contents;


### PR DESCRIPTION
On PR https://github.com/GodotVR/godot_openxr_vendors/pull/231, I accidentally left some stray double quotes that end up in the `AndroidManifest.xml` file. (I was converting between different ways of doing the quoted strings, originally using double quotes before going to `R"(...)"`)

It doesn't cause any harm, the built apps still function perfectly fine with the stray double quote!

But this PR cleans up my dumb mistake.