### PR TITLE
Update GitHub Actions to create a "draft" release, so publishing triggers MavenCentral Publish

### DIFF
--- a/.github/workflows/build-addon-on-push.yml
+++ b/.github/workflows/build-addon-on-push.yml
@@ -194,6 +194,7 @@ jobs:
         with:
           allowUpdates: true
           artifacts: "godotopenxrvendorsaddon.zip"
+          draft: true
           omitNameDuringUpdate: true
           omitBodyDuringUpdate: true
           omitDraftDuringUpdate: true


### PR DESCRIPTION
We have a GitHub workflow that will automatically create a release when we push tags.

And we have a "MavenCentral Publish" workflow that will run when a release is published.

However, on the last release, the the "MavenCentral Publish" workflow didn't run. The theory is that it didn't run because the release was created by GitHub Actions, and one workflow isn't allowed to trigger another workflow (as a protection against GitHub Actions getting into an infinite loop).

So, this PR changes it so that a "draft" release is created, which would have to be published by a human, after which (in theory) the "MavenCentral Publish" workflow will get run.

I don't actually know if this will work, because the only way to test is to make a release, but I feel like the theory is sound :-)