### PR TITLE
Fix passthrough sample color map display bug

### DIFF
--- a/samples/meta-passthrough-sample/main.gd
+++ b/samples/meta-passthrough-sample/main.gd
@@ -43,7 +43,9 @@ func _ready() -> void:
 	fb_passthrough.set_passthrough_filter(OpenXRFbPassthroughExtensionWrapper.PASSTHROUGH_FILTER_DISABLED)
 
 	var color_map_mat := color_map_mesh.get_surface_override_material(0)
-	color_map_mat.albedo_texture = color_map
+	var color_map_gradient_texture = GradientTexture2D.new()
+	color_map_gradient_texture.gradient = color_map
+	color_map_mat.albedo_texture = color_map_gradient_texture
 
 	var curve_texture := CurveTexture.new()
 	curve_texture.curve = mono_map


### PR DESCRIPTION
In the passthrough sample, when looking at the color map passthrough mode, the used color gradient is supposed to be displayed on a mesh in front of the user. This wasn't working properly because `albedo_texture` requires a `GradientTexture2D`, not just a `Gradient` resource. This PR fixes that!