### PR TITLE
Cherry-picks for the godot_openxr_vendors 3.x branch - 1st batch

### DIFF
--- a/.github/workflows/mavencentral-publish.yml
+++ b/.github/workflows/mavencentral-publish.yml
@@ -48,7 +48,7 @@ jobs:
 
         # Runs upload, and then closes & releases the repository
       - name: Publish to MavenCentral
-        run: ./gradlew -Prelease_version=${{ github.ref_name }} publishReleasePublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository
+        run: ./gradlew -Prelease_version=${{ github.ref_name }} publishAllPublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository
         env:
           OSSRH_GROUP_ID: ${{ secrets.OSSRH_GROUP_ID }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/samples/meta-passthrough-sample/main.gd
+++ b/samples/meta-passthrough-sample/main.gd
@@ -43,7 +43,9 @@ func _ready() -> void:
 	fb_passthrough.set_passthrough_filter(OpenXRFbPassthroughExtensionWrapper.PASSTHROUGH_FILTER_DISABLED)
 
 	var color_map_mat := color_map_mesh.get_surface_override_material(0)
-	color_map_mat.albedo_texture = color_map
+	var color_map_gradient_texture = GradientTexture2D.new()
+	color_map_gradient_texture.gradient = color_map
+	color_map_mat.albedo_texture = color_map_gradient_texture
 
 	var curve_texture := CurveTexture.new()
 	curve_texture.curve = mono_map


### PR DESCRIPTION
As discussed at the last XR team meeting, here's a cherry-pick PR that pulls https://github.com/GodotVR/godot_openxr_vendors/pull/251 into 3.x.

I added PR https://github.com/GodotVR/godot_openxr_vendors/pull/252 also, just so that this PR would cherry-pick more than one thing :-)