### PR TITLE
Misc cleanup

### DIFF
--- a/plugin/src/main/cpp/export/export_plugin.cpp
+++ b/plugin/src/main/cpp/export/export_plugin.cpp
@@ -88,11 +88,30 @@ Dictionary OpenXREditorExportPlugin::_get_vendor_toggle_option(const String &ven
 			"",
 			PROPERTY_USAGE_DEFAULT,
 			false,
-			false);
+			true);
 }
 
 OpenXREditorExportPlugin::HybridType OpenXREditorExportPlugin::_get_hybrid_app_setting_value() const {
 	return (HybridType)(int)ProjectSettings::get_singleton()->get_setting_with_override("xr/openxr/hybrid_app");
+}
+
+String OpenXREditorExportPlugin::_get_opening_activity_tag_for_panel_app() const {
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+
+	return vformat(
+			"        <activity android:name=\"org.godotengine.openxr.vendors.GodotPanelApp\" "
+			"android:process=\":GodotPanelApp\" "
+			"android:theme=\"@style/GodotPanelAppSplashTheme\" "
+			"android:launchMode=\"singleInstancePerTask\" "
+			"android:exported=\"true\" "
+			"android:excludeFromRecents=\"%s\" "
+			"android:screenOrientation=\"%s\" "
+			"android:resizeableActivity=\"%s\" "
+			"android:configChanges=\"orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode\" "
+			"tools:ignore=\"UnusedAttribute\">\n",
+			_bool_to_string(_get_bool_option("package/exclude_from_recents")),
+			_get_android_orientation_label((DisplayServer::ScreenOrientation)(int)project_settings->get_setting_with_override("display/window/handheld/orientation")),
+			_bool_to_string(project_settings->get_setting_with_override("display/window/size/resizable")));
 }
 
 bool OpenXREditorExportPlugin::_is_openxr_enabled() const {

--- a/plugin/src/main/cpp/export/meta_export_plugin.cpp
+++ b/plugin/src/main/cpp/export/meta_export_plugin.cpp
@@ -482,22 +482,7 @@ String MetaEditorExportPlugin::_get_android_manifest_application_element_content
 
 	HybridType hybrid_type = _get_hybrid_app_setting_value();
 	if (hybrid_type != HYBRID_TYPE_DISABLED) {
-		ProjectSettings *project_settings = ProjectSettings::get_singleton();
-
-		contents += vformat(
-				"        <activity android:name=\"org.godotengine.openxr.vendors.GodotPanelApp\" "
-				"android:process=\":GodotPanelApp\" "
-				"android:theme=\"@style/GodotPanelAppSplashTheme\" "
-				"android:launchMode=\"singleInstancePerTask\" "
-				"android:exported=\"true\" "
-				"android:excludeFromRecents=\"%s\" "
-				"android:screenOrientation=\"%s\" "
-				"android:resizeableActivity=\"%s\" "
-				"android:configChanges=\"orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode\" "
-				"tools:ignore=\"UnusedAttribute\">\n",
-				_bool_to_string(_get_bool_option("package/exclude_from_recents")),
-				_get_android_orientation_label((DisplayServer::ScreenOrientation)(int)project_settings->get_setting_with_override("display/window/handheld/orientation")),
-				_bool_to_string(project_settings->get_setting_with_override("display/window/size/resizable")));
+		contents += _get_opening_activity_tag_for_panel_app();
 
 		contents +=
 				"          <intent-filter>\n"

--- a/plugin/src/main/cpp/export/pico_export_plugin.cpp
+++ b/plugin/src/main/cpp/export/pico_export_plugin.cpp
@@ -58,7 +58,7 @@ PicoEditorExportPlugin::PicoEditorExportPlugin() {
 			PROPERTY_HINT_ENUM,
 			"No,Yes",
 			PROPERTY_USAGE_DEFAULT,
-			pico::MANIFEST_FALSE_VALUE,
+			MANIFEST_FALSE_VALUE,
 			false);
 
 	_face_tracking_option = _generate_export_option(
@@ -68,7 +68,7 @@ PicoEditorExportPlugin::PicoEditorExportPlugin() {
 			PROPERTY_HINT_ENUM,
 			"No,Face only,Lipsync only,Hybrid",
 			PROPERTY_USAGE_DEFAULT,
-			pico::FACE_TRACKING_NONE_VALUE,
+			FACE_TRACKING_NONE_VALUE,
 			false);
 
 	_hand_tracking_option = _generate_export_option(
@@ -78,7 +78,7 @@ PicoEditorExportPlugin::PicoEditorExportPlugin() {
 			PROPERTY_HINT_ENUM,
 			"No,Low frequency,High frequency (60Hz)",
 			PROPERTY_USAGE_DEFAULT,
-			pico::HAND_TRACKING_NONE_VALUE,
+			HAND_TRACKING_NONE_VALUE,
 			false);
 }
 
@@ -104,8 +104,8 @@ bool PicoEditorExportPlugin::_is_eye_tracking_enabled() const {
 		return false;
 	}
 
-	int eye_tracking_option_value = _get_int_option("pico_xr_features/eye_tracking", pico::MANIFEST_FALSE_VALUE);
-	return eye_tracking_option_value == pico::MANIFEST_TRUE_VALUE;
+	int eye_tracking_option_value = _get_int_option("pico_xr_features/eye_tracking", MANIFEST_FALSE_VALUE);
+	return eye_tracking_option_value == MANIFEST_TRUE_VALUE;
 }
 
 PackedStringArray PicoEditorExportPlugin::_get_export_features(const Ref<EditorExportPlatform> &platform, bool debug) const {
@@ -129,24 +129,24 @@ String PicoEditorExportPlugin::_get_export_option_warning(const Ref<EditorExport
 
 	bool openxr_enabled = _is_openxr_enabled();
 	if (option == "pico_xr_features/eye_tracking") {
-		if (!openxr_enabled && _get_int_option(option, pico::MANIFEST_FALSE_VALUE) == pico::MANIFEST_TRUE_VALUE) {
+		if (!openxr_enabled && _get_int_option(option, MANIFEST_FALSE_VALUE) == MANIFEST_TRUE_VALUE) {
 			return "\"Eye tracking\" requires \"XR Mode\" to be \"OpenXR\".\n";
 		}
 	} else if (option == "pico_xr_features/face_tracking") {
-		int face_tracking = _get_int_option(option, pico::FACE_TRACKING_NONE_VALUE);
-		if (!openxr_enabled && face_tracking > pico::FACE_TRACKING_NONE_VALUE) {
+		int face_tracking = _get_int_option(option, FACE_TRACKING_NONE_VALUE);
+		if (!openxr_enabled && face_tracking > FACE_TRACKING_NONE_VALUE) {
 			return "\"Face tracking\" requires \"XR Mode\" to be \"OpenXR\".\n";
 		}
 		bool record_audio = _get_bool_option("permissions/record_audio");
-		if (!record_audio && face_tracking == pico::FACE_TRACKING_LIPSYNCONLY_VALUE) {
+		if (!record_audio && face_tracking == FACE_TRACKING_LIPSYNCONLY_VALUE) {
 			return "\"Lipsync face tracking\" requires \"Record Audio\" to be checked.\n";
 		}
-		if (!record_audio && face_tracking == pico::FACE_TRACKING_HYBRID_VALUE) {
+		if (!record_audio && face_tracking == FACE_TRACKING_HYBRID_VALUE) {
 			return "\"Hybrid face tracking\" requires \"Record Audio\" to be checked.\n";
 		}
 	} else if (option == "pico_xr_features/hand_tracking") {
-		int hand_tracking = _get_int_option(option, pico::HAND_TRACKING_NONE_VALUE);
-		if (!openxr_enabled && hand_tracking > pico::HAND_TRACKING_NONE_VALUE) {
+		int hand_tracking = _get_int_option(option, HAND_TRACKING_NONE_VALUE);
+		if (!openxr_enabled && hand_tracking > HAND_TRACKING_NONE_VALUE) {
 			return "\"Hand tracking\" requires \"XR Mode\" to be \"OpenXR\".\n";
 		}
 	}
@@ -166,8 +166,8 @@ String PicoEditorExportPlugin::_get_android_manifest_element_contents(const Ref<
 	}
 
 	// Face tracking
-	int face_tracking = _get_int_option("pico_xr_features/face_tracking", pico::FACE_TRACKING_NONE_VALUE);
-	if (face_tracking == pico::FACE_TRACKING_FACEONLY_VALUE || face_tracking == pico::FACE_TRACKING_HYBRID_VALUE) {
+	int face_tracking = _get_int_option("pico_xr_features/face_tracking", FACE_TRACKING_NONE_VALUE);
+	if (face_tracking == FACE_TRACKING_FACEONLY_VALUE || face_tracking == FACE_TRACKING_HYBRID_VALUE) {
 		contents += "    <uses-permission android:name=\"com.picovr.permission.FACE_TRACKING\" />\n";
 	}
 
@@ -186,17 +186,17 @@ String PicoEditorExportPlugin::_get_android_manifest_application_element_content
 	}
 
 	// Face tracking
-	int face_tracking = _get_int_option("pico_xr_features/face_tracking", pico::FACE_TRACKING_NONE_VALUE);
-	if (face_tracking > pico::FACE_TRACKING_NONE_VALUE) {
+	int face_tracking = _get_int_option("pico_xr_features/face_tracking", FACE_TRACKING_NONE_VALUE);
+	if (face_tracking > FACE_TRACKING_NONE_VALUE) {
 		contents += "        <meta-data tools:node=\"replace\" android:name=\"picovr.software.face_tracking\" android:value=\"1\" />\n";
 	}
 
 	//Hand tracking
-	int hand_tracking = _get_int_option("pico_xr_features/hand_tracking", pico::HAND_TRACKING_NONE_VALUE);
-	if (hand_tracking > pico::HAND_TRACKING_NONE_VALUE) {
+	int hand_tracking = _get_int_option("pico_xr_features/hand_tracking", HAND_TRACKING_NONE_VALUE);
+	if (hand_tracking > HAND_TRACKING_NONE_VALUE) {
 		contents += "        <meta-data tools:node=\"replace\" android:name=\"handtracking\" android:value=\"1\" />\n";
 	}
-	if (hand_tracking > pico::HAND_TRACKING_LOWFREQUENCY_VALUE) {
+	if (hand_tracking > HAND_TRACKING_LOWFREQUENCY_VALUE) {
 		contents += "        <meta-data tools:node=\"replace\" android:name=\"Hand_Tracking_HighFrequency\" android:value=\"1\" />\n";
 	}
 

--- a/plugin/src/main/cpp/include/export/export_plugin.h
+++ b/plugin/src/main/cpp/include/export/export_plugin.h
@@ -116,6 +116,8 @@ protected:
 
 	HybridType _get_hybrid_app_setting_value() const;
 
+	String _get_opening_activity_tag_for_panel_app() const;
+
 	bool _is_openxr_enabled() const;
 
 	bool _get_bool_option(const String &option) const;

--- a/plugin/src/main/cpp/include/export/meta_export_plugin.h
+++ b/plugin/src/main/cpp/include/export/meta_export_plugin.h
@@ -35,40 +35,38 @@
 
 using namespace godot;
 
-namespace {
-static const int EYE_TRACKING_NONE_VALUE = 0;
-static const int EYE_TRACKING_OPTIONAL_VALUE = 1;
-static const int EYE_TRACKING_REQUIRED_VALUE = 2;
-
-static const int FACE_TRACKING_NONE_VALUE = 0;
-static const int FACE_TRACKING_OPTIONAL_VALUE = 1;
-static const int FACE_TRACKING_REQUIRED_VALUE = 2;
-
-static const int BODY_TRACKING_NONE_VALUE = 0;
-static const int BODY_TRACKING_OPTIONAL_VALUE = 1;
-static const int BODY_TRACKING_REQUIRED_VALUE = 2;
-
-static const int PASSTHROUGH_NONE_VALUE = 0;
-static const int PASSTHROUGH_OPTIONAL_VALUE = 1;
-static const int PASSTHROUGH_REQUIRED_VALUE = 2;
-
-static const int RENDER_MODEL_NONE_VALUE = 0;
-static const int RENDER_MODEL_OPTIONAL_VALUE = 1;
-static const int RENDER_MODEL_REQUIRED_VALUE = 2;
-
-static const int HAND_TRACKING_NONE_VALUE = 0;
-static const int HAND_TRACKING_OPTIONAL_VALUE = 1;
-static const int HAND_TRACKING_REQUIRED_VALUE = 2;
-
-static const int HAND_TRACKING_FREQUENCY_LOW_VALUE = 0;
-static const int HAND_TRACKING_FREQUENCY_HIGH_VALUE = 1;
-
-static const int BOUNDARY_ENABLED_VALUE = 0;
-static const int BOUNDARY_DISABLED_VALUE = 1;
-} // namespace
-
 class MetaEditorExportPlugin : public OpenXREditorExportPlugin {
 	GDCLASS(MetaEditorExportPlugin, OpenXREditorExportPlugin)
+
+	static const int EYE_TRACKING_NONE_VALUE = 0;
+	static const int EYE_TRACKING_OPTIONAL_VALUE = 1;
+	static const int EYE_TRACKING_REQUIRED_VALUE = 2;
+
+	static const int FACE_TRACKING_NONE_VALUE = 0;
+	static const int FACE_TRACKING_OPTIONAL_VALUE = 1;
+	static const int FACE_TRACKING_REQUIRED_VALUE = 2;
+
+	static const int BODY_TRACKING_NONE_VALUE = 0;
+	static const int BODY_TRACKING_OPTIONAL_VALUE = 1;
+	static const int BODY_TRACKING_REQUIRED_VALUE = 2;
+
+	static const int PASSTHROUGH_NONE_VALUE = 0;
+	static const int PASSTHROUGH_OPTIONAL_VALUE = 1;
+	static const int PASSTHROUGH_REQUIRED_VALUE = 2;
+
+	static const int RENDER_MODEL_NONE_VALUE = 0;
+	static const int RENDER_MODEL_OPTIONAL_VALUE = 1;
+	static const int RENDER_MODEL_REQUIRED_VALUE = 2;
+
+	static const int HAND_TRACKING_NONE_VALUE = 0;
+	static const int HAND_TRACKING_OPTIONAL_VALUE = 1;
+	static const int HAND_TRACKING_REQUIRED_VALUE = 2;
+
+	static const int HAND_TRACKING_FREQUENCY_LOW_VALUE = 0;
+	static const int HAND_TRACKING_FREQUENCY_HIGH_VALUE = 1;
+
+	static const int BOUNDARY_ENABLED_VALUE = 0;
+	static const int BOUNDARY_DISABLED_VALUE = 1;
 
 public:
 	MetaEditorExportPlugin();

--- a/plugin/src/main/cpp/include/export/pico_export_plugin.h
+++ b/plugin/src/main/cpp/include/export/pico_export_plugin.h
@@ -35,22 +35,20 @@
 
 using namespace godot;
 
-namespace pico {
-static const int MANIFEST_FALSE_VALUE = 0;
-static const int MANIFEST_TRUE_VALUE = 1;
-
-static const int FACE_TRACKING_NONE_VALUE = 0;
-static const int FACE_TRACKING_FACEONLY_VALUE = 1;
-static const int FACE_TRACKING_LIPSYNCONLY_VALUE = 2;
-static const int FACE_TRACKING_HYBRID_VALUE = 3;
-
-static const int HAND_TRACKING_NONE_VALUE = 0;
-static const int HAND_TRACKING_LOWFREQUENCY_VALUE = 1;
-static const int HAND_TRACKING_HIGHFREQUENCY_VALUE = 2;
-} //namespace pico
-
 class PicoEditorExportPlugin : public OpenXREditorExportPlugin {
 	GDCLASS(PicoEditorExportPlugin, OpenXREditorExportPlugin)
+
+	static const int MANIFEST_FALSE_VALUE = 0;
+	static const int MANIFEST_TRUE_VALUE = 1;
+
+	static const int FACE_TRACKING_NONE_VALUE = 0;
+	static const int FACE_TRACKING_FACEONLY_VALUE = 1;
+	static const int FACE_TRACKING_LIPSYNCONLY_VALUE = 2;
+	static const int FACE_TRACKING_HYBRID_VALUE = 3;
+
+	static const int HAND_TRACKING_NONE_VALUE = 0;
+	static const int HAND_TRACKING_LOWFREQUENCY_VALUE = 1;
+	static const int HAND_TRACKING_HIGHFREQUENCY_VALUE = 2;
 
 public:
 	PicoEditorExportPlugin();


### PR DESCRIPTION
Misc cleanup based on feedback from https://github.com/GodotVR/godot_openxr_vendors/pull/238#discussion_r1905688266:
- Move `pico` namespace constants to class constants
- Move `meta` namespace constants to class constants
- Set the `update_visibility` field for the vendor toggle option to `true` to allow overriding the export options when their corresponding vendor is toggled on/off
- Add an helper method for generating the manifest entry for the `GodotPanelApp` from https://github.com/GodotVR/godot_openxr_vendors/pull/246 (decoupled from the PR to unblock prototyping on https://github.com/GodotVR/godot_openxr_vendors/pull/238)