### PR TITLE
Fix hybrid app support for recent Godot Android library changes

### DIFF
--- a/plugin/src/main/java/org/godotengine/openxr/vendors/GodotOpenXRHybridAppInternal.kt
+++ b/plugin/src/main/java/org/godotengine/openxr/vendors/GodotOpenXRHybridAppInternal.kt
@@ -76,9 +76,9 @@ class GodotOpenXRHybridAppInternal(godot: Godot?) : GodotPlugin(godot) {
 	fun hybridAppSwitchTo(mode: Int, data: String = ""): Boolean {
 		if (hybridMode == mode) return false
 
-		if (!isNativeXRDevice()) return false
-
 		val context = getActivity() ?: return false
+
+		if (!isNativeXRDevice(context)) return false
 
 		val activityName = if (mode == IMMERSIVE_MODE) IMMERSIVE_ACTIVITY else PANEL_ACTIVITY
 		val newInstance = Intent()

--- a/plugin/src/main/java/org/godotengine/openxr/vendors/GodotPanelApp.kt
+++ b/plugin/src/main/java/org/godotengine/openxr/vendors/GodotPanelApp.kt
@@ -31,6 +31,7 @@ package org.godotengine.openxr.vendors
 
 import android.os.Bundle
 import android.util.Log
+import androidx.annotation.CallSuper
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import org.godotengine.godot.GodotActivity
 import org.godotengine.godot.BuildConfig
@@ -60,9 +61,10 @@ class GodotPanelApp : GodotActivity() {
 		super.onCreate(savedInstanceState)
 	}
 
-	override fun getCommandLine(): MutableList<String> {
-		// Force XR to be turned off.
-		return mutableListOf("--xr_mode_regular", "--xr-mode", "off")
+	@CallSuper
+	protected override fun updateCommandLineParams(args: Array<String>) {
+		// Force XR to be turned off and discard other params.
+		super.updateCommandLineParams(arrayOf("--xr_mode_regular", "--xr-mode", "off"))
 	}
 
 	override fun supportsFeature(featureTag: String): Boolean {


### PR DESCRIPTION
We're currently [failing CI due](https://github.com/GodotVR/godot_openxr_vendors/pull/259#issuecomment-2644064620) to recent changes to Godot Android library, that affect our hybrid app support.

This PR is attempting to fix that!

This now compiles, however, I still have to test it, so keeping as a DRAFT for now