### PR TITLE
Passthrough extensions should override real alpha blend mode, if enabled

### DIFF
--- a/plugin/src/main/cpp/extensions/openxr_fb_passthrough_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_fb_passthrough_extension_wrapper.cpp
@@ -182,8 +182,10 @@ void OpenXRFbPassthroughExtensionWrapper::_on_instance_created(uint64_t p_instan
 void OpenXRFbPassthroughExtensionWrapper::_on_session_created(uint64_t p_session) {
 	XrSession session = (XrSession)p_session;
 	if (fb_passthrough_ext) {
-		// If it's already supported, then we don't want to emulate it.
-		if (get_openxr_api()->is_environment_blend_mode_alpha_supported() != OpenXRAPIExtension::OPENXR_ALPHA_BLEND_MODE_SUPPORT_NONE) {
+		// If another extension is already emulating alpha blend mode, then we don't attempt to.
+		if (get_openxr_api()->is_environment_blend_mode_alpha_supported() == OpenXRAPIExtension::OPENXR_ALPHA_BLEND_MODE_SUPPORT_EMULATING) {
+			// Act as if the extension is not enabled.
+			fb_passthrough_ext = false;
 			return;
 		}
 

--- a/plugin/src/main/cpp/extensions/openxr_htc_passthrough_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_htc_passthrough_extension_wrapper.cpp
@@ -93,8 +93,10 @@ void OpenXRHtcPassthroughExtensionWrapper::_on_instance_destroyed() {
 
 void OpenXRHtcPassthroughExtensionWrapper::_on_session_created(uint64_t p_session) {
 	if (htc_passthrough_ext) {
-		// If it's already supported, then we don't want to emulate it.
-		if (get_openxr_api()->is_environment_blend_mode_alpha_supported() != OpenXRAPIExtension::OPENXR_ALPHA_BLEND_MODE_SUPPORT_NONE) {
+		// If another extension is already emulating alpha blend mode, then we don't attempt to.
+		if (get_openxr_api()->is_environment_blend_mode_alpha_supported() == OpenXRAPIExtension::OPENXR_ALPHA_BLEND_MODE_SUPPORT_EMULATING) {
+			// Act as if the extension is not enabled.
+			htc_passthrough_ext = false;
 			return;
 		}
 


### PR DESCRIPTION
~~This (partially) depends on Godot PR https://github.com/godotengine/godot/pull/103338 and also shouldn't be merged until we merge one of the PRs that allow enabling/disabling OpenXR extension via project settings (like https://github.com/GodotVR/godot_openxr_vendors/pull/272 or https://github.com/GodotVR/godot_openxr_vendors/pull/234), which is why it's marked as a DRAFT.~~

This PR is to fix issues with headsets that support both a real alpha blend mode, and one of the passthrough extensions that can emulate it.

Because the passthrough extensions can provide additional functionality beyond just turning passthrough mode on and off (which is all the alpha blend mode can do), the idea is that if the developer has enabled a passthrough extension, it should be used rather than the real alpha blend mode.

That's what this PR does! Rather than the FB and HTC extensions only doing the emulation if there is no support for alpha blend mode (either from emulation or the real thing), it will do the emulation even if there is a real alpha blend mode (but not if some other extension has already decided to do emulation).

This works in my testing on Pico 4 Ultra