### PR TITLE
Fix standard manifest entries

### DIFF
--- a/plugin/src/khronos/AndroidManifest.xml
+++ b/plugin/src/khronos/AndroidManifest.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <!-- Tell the system this app works in either 3dof or 6dof mode -->
+    <!-- Tell storefronts this app works in either 3dof or 6dof mode,
+         and do not filter out devices that did not ship with VR support. -->
     <uses-feature
         android:name="android.hardware.vr.headtracking"
-        android:required="true"
+        android:required="false"
         android:version="1"/>
 
     <!-- Permissions needed by OpenXR -->

--- a/plugin/src/khronos/AndroidManifest.xml
+++ b/plugin/src/khronos/AndroidManifest.xml
@@ -13,7 +13,10 @@
 
     <queries>
         <intent>
-            <action android:name="org.khronos.openxr.OpenXRRuntimeService"/>
+            <action android:name="org.khronos.openxr.OpenXRRuntimeService" />
+        </intent>
+        <intent>
+            <action android:name="org.khronos.openxr.OpenXRApiLayerService" />
         </intent>
         <provider android:authorities="org.khronos.openxr.runtime_broker;org.khronos.openxr.system_runtime_broker" />
     </queries>


### PR DESCRIPTION
I have not tested this, but this corrects the manifest entries for the "Khronos" variant to match the entries added by the manifest in the loader AAR. This should increase compatibility of this build variant (as long as the activity is getting the right intent filter, which sadly can't be done this easily via merging manifest files)