### PR TITLE
Add individual project settings for each composition layer extension

### DIFF
--- a/plugin/src/main/cpp/register_types.cpp
+++ b/plugin/src/main/cpp/register_types.cpp
@@ -214,12 +214,27 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 				}
 			}
 
-			if (_get_bool_project_setting("xr/openxr/extensions/meta/composition_layer_settings")) {
+			if (_get_bool_project_setting("xr/openxr/extensions/meta/composition_layer_secure_content")) {
 				_register_extension_with_openxr(OpenXRFbCompositionLayerSecureContentExtensionWrapper::get_singleton());
+			}
+
+			if (_get_bool_project_setting("xr/openxr/extensions/meta/composition_layer_alpha_blend")) {
 				_register_extension_with_openxr(OpenXRFbCompositionLayerAlphaBlendExtensionWrapper::get_singleton());
+			}
+
+			if (_get_bool_project_setting("xr/openxr/extensions/meta/composition_layer_settings")) {
 				_register_extension_with_openxr(OpenXRFbCompositionLayerSettingsExtensionWrapper::get_singleton());
+			}
+
+			if (_get_bool_project_setting("xr/openxr/extensions/meta/composition_layer_android_surface_swapchain_create")) {
 				_register_extension_with_openxr(OpenXRFbAndroidSurfaceSwapchainCreateExtensionWrapper::get_singleton());
+			}
+
+			if (_get_bool_project_setting("xr/openxr/extensions/meta/composition_layer_depth_test")) {
 				_register_extension_with_openxr(OpenXRFbCompositionLayerDepthTestExtensionWrapper::get_singleton());
+			}
+
+			if (_get_bool_project_setting("xr/openxr/extensions/meta/composition_layer_image_layout")) {
 				_register_extension_with_openxr(OpenXRFbCompositionLayerImageLayoutExtensionWrapper::get_singleton());
 			}
 
@@ -376,7 +391,12 @@ void add_plugin_project_settings() {
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/anchor_api", false);
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/anchor_sharing", false);
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/scene_api", false);
+	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/composition_layer_secure_content", true);
+	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/composition_layer_alpha_blend", true);
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/composition_layer_settings", true);
+	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/composition_layer_android_surface_swapchain_create", true);
+	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/composition_layer_depth_test", true);
+	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/composition_layer_image_layout", true);
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/dynamic_resolution", true);
 
 	{


### PR DESCRIPTION
In PR https://github.com/GodotVR/godot_openxr_vendors/pull/272, I put all the Meta composition layer extensions under a single project setting.

My thinking at the time was that they are so small (they just add optional settings to `OpenXRCompositionLayer` nodes) and there's a whole bunch of them, such that it would be too much for most users.

However, I'm starting to re-think that! If any of these extensions are deprecated in favor of a new extension, or have any other unexpected interactions with other extensions, it would be nice to be able to disable them individually.

This PR adds individual project settings for each extension.

What do you folks think?