### PR TITLE
Improve hand tracking related code in demo project

### DIFF
--- a/demo/hand_controller.gd
+++ b/demo/hand_controller.gd
@@ -1,0 +1,36 @@
+extends XRController3D
+
+@onready var hand_cube: MeshInstance3D = $HandCube
+@onready var render_model: OpenXRFbRenderModel = $ControllerFbRenderModel
+
+func _process(_delta: float) -> void:
+	var hand_tracker_name = "/user/hand_tracker/left" if tracker == "left_hand" \
+			else "/user/hand_tracker/right"
+	var hand_tracker_hand: OpenXRInterface.Hand = OpenXRInterface.HAND_LEFT if tracker == "left_hand" \
+		else OpenXRInterface.HAND_RIGHT
+
+	var interface: OpenXRInterface = XRServer.find_interface("OpenXR")
+
+	var hand_tracker: XRHandTracker = XRServer.get_tracker(hand_tracker_name)
+	if hand_tracker and hand_tracker.has_tracking_data:
+		# If hand tracking data is provided by controller,
+		# and controller model is available, show it with hand mesh.
+		if hand_tracker.hand_tracking_source == XRHandTracker.HAND_TRACKING_SOURCE_CONTROLLER \
+				and render_model.has_render_model_node():
+			render_model.show()
+			interface.set_motion_range(hand_tracker_hand, OpenXRInterface.HAND_MOTION_RANGE_CONFORM_TO_CONTROLLER)
+		# If hand tracking data is not provided by controller,
+		# and controller model is available, hide it.
+		elif render_model.has_render_model_node():
+			render_model.hide()
+			interface.set_motion_range(hand_tracker_hand, OpenXRInterface.HAND_MOTION_RANGE_UNOBSTRUCTED)
+
+		# Always hide placeholder hand cubes if we have hand tracking data.
+		hand_cube.hide()
+	else:
+		# Show render model if availabe, otherwise show hand cubes.
+		if render_model.has_render_model_node():
+			render_model.show()
+			hand_cube.hide()
+		else:
+			hand_cube.show()

--- a/demo/hand_controller.gd.uid
+++ b/demo/hand_controller.gd.uid
@@ -1,0 +1,1 @@
+uid://tu2v2kg8lrh1

--- a/demo/hand_mesh.gd
+++ b/demo/hand_mesh.gd
@@ -1,0 +1,8 @@
+extends XRNode3D
+
+func _process(_delta: float) -> void:
+	var hand_tracker: XRHandTracker = XRServer.get_tracker(tracker)
+	if hand_tracker and hand_tracker.has_tracking_data:
+		show()
+	else:
+		hide()

--- a/demo/hand_mesh.gd.uid
+++ b/demo/hand_mesh.gd.uid
@@ -1,0 +1,1 @@
+uid://174ia6ge6xmi

--- a/demo/main.gd
+++ b/demo/main.gd
@@ -1,14 +1,6 @@
 extends Node3D
 
 var xr_interface: XRInterface = null
-var hand_tracking_source: Array[OpenXRInterface.HandTrackedSource]
-
-@onready var left_hand: XRController3D = $XROrigin3D/LeftHand
-@onready var right_hand: XRController3D = $XROrigin3D/RightHand
-@onready var left_hand_mesh: MeshInstance3D = $XROrigin3D/LeftHand/LeftHandMesh
-@onready var right_hand_mesh: MeshInstance3D = $XROrigin3D/RightHand/RightHandMesh
-@onready var left_controller_model: OpenXRFbRenderModel = $XROrigin3D/LeftHand/LeftControllerFbRenderModel
-@onready var right_controller_model: OpenXRFbRenderModel = $XROrigin3D/RightHand/RightControllerFbRenderModel
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
@@ -18,48 +10,9 @@ func _ready():
 		var vp: Viewport = get_viewport()
 		vp.use_xr = true
 
-	hand_tracking_source.resize(OpenXRInterface.HAND_MAX)
-	for hand in OpenXRInterface.HAND_MAX:
-		hand_tracking_source[hand] = xr_interface.get_hand_tracking_source(hand)
-
 
 func _on_session_stopping() -> void:
 	if "--xrsim-automated-tests" in OS.get_cmdline_user_args():
 		# When we're running tests via the XR Simulator, it will end the OpenXR
 		# session automatically, and in that case, we want to quit.
 		get_tree().quit()
-
-
-func _physics_process(_delta: float) -> void:
-	for hand in OpenXRInterface.HAND_MAX:
-		var source = xr_interface.get_hand_tracking_source(hand)
-		if hand_tracking_source[hand] == source:
-			continue
-
-		var controller = left_controller_model if (hand == OpenXRInterface.HAND_LEFT) else right_controller_model
-		controller.visible = (source == OpenXRInterface.HAND_TRACKED_SOURCE_CONTROLLER)
-
-		if source == OpenXRInterface.HAND_TRACKED_SOURCE_UNOBSTRUCTED:
-			match hand:
-				OpenXRInterface.HAND_LEFT:
-					left_hand.tracker = "/user/fbhandaim/left"
-				OpenXRInterface.HAND_RIGHT:
-					right_hand.tracker = "/user/fbhandaim/right"
-		else:
-			match hand:
-				OpenXRInterface.HAND_LEFT:
-					left_hand.tracker = "left_hand"
-					left_hand.pose = "grip"
-				OpenXRInterface.HAND_RIGHT:
-					right_hand.tracker = "right_hand"
-					right_hand.pose = "grip"
-
-		hand_tracking_source[hand] = source
-
-
-func _on_left_controller_fb_render_model_render_model_loaded() -> void:
-	left_hand_mesh.hide()
-
-
-func _on_right_controller_fb_render_model_render_model_loaded() -> void:
-	right_hand_mesh.hide()

--- a/demo/main.tscn
+++ b/demo/main.tscn
@@ -1,6 +1,8 @@
-[gd_scene load_steps=10 format=3 uid="uid://cqsodpswgup8w"]
+[gd_scene load_steps=12 format=3 uid="uid://cqsodpswgup8w"]
 
 [ext_resource type="Script" uid="uid://rkp4t7eqnc0o" path="res://main.gd" id="1_fsva1"]
+[ext_resource type="Script" uid="uid://tu2v2kg8lrh1" path="res://hand_controller.gd" id="2_1bvp3"]
+[ext_resource type="Script" uid="uid://174ia6ge6xmi" path="res://hand_mesh.gd" id="2_h2yge"]
 [ext_resource type="Material" uid="uid://bdwh0vc86hsdb" path="res://assets/hand_silhouette_outline_mat.tres" id="7_tpkib"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_0x6cv"]
@@ -48,27 +50,30 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.352791, 0)
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.460909, 0.388594, -0.241118)
 tracker = &"left_hand"
 pose = &"grip"
+script = ExtResource("2_1bvp3")
 
-[node name="LeftHandMesh" type="MeshInstance3D" parent="XROrigin3D/LeftHand"]
+[node name="HandCube" type="MeshInstance3D" parent="XROrigin3D/LeftHand"]
 visible = false
 mesh = SubResource("BoxMesh_3kt6b")
 
-[node name="LeftControllerFbRenderModel" type="OpenXRFbRenderModel" parent="XROrigin3D/LeftHand"]
+[node name="ControllerFbRenderModel" type="OpenXRFbRenderModel" parent="XROrigin3D/LeftHand"]
 
 [node name="RightHand" type="XRController3D" parent="XROrigin3D"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.478861, 0.468292, -0.241097)
 tracker = &"right_hand"
 pose = &"grip"
+script = ExtResource("2_1bvp3")
 
-[node name="RightHandMesh" type="MeshInstance3D" parent="XROrigin3D/RightHand"]
+[node name="HandCube" type="MeshInstance3D" parent="XROrigin3D/RightHand"]
 visible = false
 mesh = SubResource("BoxMesh_ey3x4")
 
-[node name="RightControllerFbRenderModel" type="OpenXRFbRenderModel" parent="XROrigin3D/RightHand"]
+[node name="ControllerFbRenderModel" type="OpenXRFbRenderModel" parent="XROrigin3D/RightHand"]
 render_model_type = 1
 
 [node name="LeftHandTracker" type="XRNode3D" parent="XROrigin3D"]
 tracker = &"/user/hand_tracker/left"
+script = ExtResource("2_h2yge")
 
 [node name="LeftHandModel" type="OpenXRFbHandTrackingMesh" parent="XROrigin3D/LeftHandTracker"]
 material = ExtResource("7_tpkib")
@@ -77,6 +82,7 @@ material = ExtResource("7_tpkib")
 
 [node name="RightHandTracker" type="XRNode3D" parent="XROrigin3D"]
 tracker = &"/user/hand_tracker/right"
+script = ExtResource("2_h2yge")
 
 [node name="RightHandModel" type="OpenXRFbHandTrackingMesh" parent="XROrigin3D/RightHandTracker"]
 hand = 1
@@ -113,6 +119,3 @@ hand_tracker = &"/user/hand_tracker/right"
 
 [node name="Floor" type="MeshInstance3D" parent="."]
 mesh = SubResource("PlaneMesh_mjcgt")
-
-[connection signal="openxr_fb_render_model_loaded" from="XROrigin3D/LeftHand/LeftControllerFbRenderModel" to="." method="_on_left_controller_fb_render_model_render_model_loaded"]
-[connection signal="openxr_fb_render_model_loaded" from="XROrigin3D/RightHand/RightControllerFbRenderModel" to="." method="_on_right_controller_fb_render_model_render_model_loaded"]


### PR DESCRIPTION
I use the demo project for testing stuff pretty often and I've wanted to update the code that hides/displays controller and hand models based on hand tracking for a while now, since going off of hand tracking source for everything seems incorrect. Now this should be the case:

- If there is hand tracking data:
  - Hand meshes will display
  - Fb render model will display if loaded and the hand tracking data is inferred from controller data, otherwise controller models are hidden
- If there is no hand tracking data:
  - Hand meshes are hidden
  - Controller models are shown