### PR TITLE
Update `compatibility_minimum` to 4.4

### DIFF
--- a/demo/addons/godotopenxrvendors/plugin.gdextension
+++ b/demo/addons/godotopenxrvendors/plugin.gdextension
@@ -1,7 +1,7 @@
 [configuration]
 
 entry_symbol = "plugin_library_init"
-compatibility_minimum = "4.3"
+compatibility_minimum = "4.4"
 android_aar_plugin = true
 
 [libraries]


### PR DESCRIPTION
The current `master` requires a minimum of Godot 4.4

Note: This would be enforced by godot-cpp anyway, because of the `extension_api.json` used to build the project, but this allows the editor to present a nicer error before attempting to load the extension