### PR TITLE
Implement XR_META_boundary_visibility extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ local.properties
 *.lib
 
 # Misc
+compile_commands.json
 .DS_Store
 /plugin/src/gen/
 /plugin/src/main/libs

--- a/SConstruct
+++ b/SConstruct
@@ -3,8 +3,8 @@ from glob import glob
 from pathlib import Path
 
 env = SConscript("thirdparty/godot-cpp/SConstruct")
-
-opts = Variables('custom.py')
+opts = Variables('custom.py', ARGUMENTS)
+opts.Add(PathVariable("meta_headers", "Path to the directory containing Meta OpenXR preview headers", None))
 opts.Update(env)
 
 # Add common includes
@@ -12,6 +12,12 @@ env.Append(CPPPATH=[
     "#plugin/src/main/cpp/include/",
     "#thirdparty/openxr/include/",
     ])
+
+# Include Meta OpenXR preview headers if provided
+meta_headers = env.get("meta_headers")
+if meta_headers:
+    env.Append(CPPDEFINES=["META_HEADERS_ENABLED"])
+    env.Append(CPPPATH=[meta_headers])
 
 sources = []
 sources += Glob("#plugin/src/main/cpp/*.cpp")

--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,11 @@ def createSconsTasks(File sconsExecutableFile, boolean clean) {
         "build_profile=thirdparty/godot_cpp_build_profile/build_profile.json",
     ]
 
+    if (project.hasProperty("meta_headers")) {
+        def meta_headers_path = project.property("meta_headers")
+        defaultArgs << "meta_headers=${meta_headers_path}"
+    }
+
     if (clean) {
         defaultArgs << "-c"
     }

--- a/plugin/src/main/cpp/export/meta_export_plugin.cpp
+++ b/plugin/src/main/cpp/export/meta_export_plugin.cpp
@@ -433,6 +433,13 @@ String MetaEditorExportPlugin::_get_android_manifest_element_contents(const Ref<
 		contents += "    <uses-permission android:name=\"com.oculus.permission.USE_SCENE\" />\n";
 	}
 
+#ifdef META_HEADERS_ENABLED
+	// Check for boundary visibility
+	if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/meta/boundary_visibility")) {
+		contents += "    <uses-permission android:name=\"com.oculus.permission.BOUNDARY_VISIBILITY\" />\n";
+	}
+#endif // META_HEADERS_ENABLED
+
 	// Check for overlay keyboard
 	bool use_overlay_keyboard_option = _get_bool_option("meta_xr_features/use_overlay_keyboard");
 	if (use_overlay_keyboard_option) {

--- a/plugin/src/main/cpp/extensions/openxr_meta_boundary_visibility_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_meta_boundary_visibility_extension_wrapper.cpp
@@ -1,0 +1,157 @@
+/**************************************************************************/
+/*  openxr_meta_boundary_visibility_extension_wrapper.cpp                 */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef META_HEADERS_ENABLED
+#include "extensions/openxr_meta_boundary_visibility_extension_wrapper.h"
+
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
+#include <godot_cpp/classes/project_settings.hpp>
+#include <godot_cpp/classes/xr_interface.hpp>
+#include <godot_cpp/classes/xr_server.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+using namespace godot;
+
+OpenXRMetaBoundaryVisibilityExtensionWrapper *OpenXRMetaBoundaryVisibilityExtensionWrapper::singleton = nullptr;
+
+OpenXRMetaBoundaryVisibilityExtensionWrapper *OpenXRMetaBoundaryVisibilityExtensionWrapper::get_singleton() {
+	if (singleton == nullptr) {
+		singleton = memnew(OpenXRMetaBoundaryVisibilityExtensionWrapper());
+	}
+	return singleton;
+}
+
+OpenXRMetaBoundaryVisibilityExtensionWrapper::OpenXRMetaBoundaryVisibilityExtensionWrapper() :
+		OpenXRExtensionWrapperExtension() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "An OpenXRMetaBoundaryVisibilityExtensionWrapper singleton already exists.");
+
+	request_extensions[XR_META_BOUNDARY_VISIBILITY_EXTENSION_NAME] = &meta_boundary_visibility_ext;
+	singleton = this;
+}
+
+OpenXRMetaBoundaryVisibilityExtensionWrapper::~OpenXRMetaBoundaryVisibilityExtensionWrapper() {
+	cleanup();
+	singleton = nullptr;
+}
+
+godot::Dictionary OpenXRMetaBoundaryVisibilityExtensionWrapper::_get_requested_extensions() {
+	godot::Dictionary result;
+	for (auto ext : request_extensions) {
+		godot::String key = ext.first;
+		uint64_t value = reinterpret_cast<uint64_t>(ext.second);
+		result[key] = (godot::Variant)value;
+	}
+	return result;
+}
+
+uint64_t OpenXRMetaBoundaryVisibilityExtensionWrapper::_set_system_properties_and_get_next_pointer(void *p_next_pointer) {
+	if (meta_boundary_visibility_ext) {
+		boundary_visibility_properties.next = p_next_pointer;
+		p_next_pointer = &boundary_visibility_properties;
+	}
+
+	return reinterpret_cast<uint64_t>(p_next_pointer);
+}
+
+void OpenXRMetaBoundaryVisibilityExtensionWrapper::_on_instance_created(uint64_t p_instance) {
+	if (meta_boundary_visibility_ext) {
+		bool result = initialize_meta_boundary_visibility_extension((XrInstance)p_instance);
+		if (!result) {
+			UtilityFunctions::printerr("Failed to initialize meta_boundary_visibility extension");
+			meta_boundary_visibility_ext = false;
+		}
+	}
+}
+
+void OpenXRMetaBoundaryVisibilityExtensionWrapper::_on_instance_destroyed() {
+	cleanup();
+}
+
+bool OpenXRMetaBoundaryVisibilityExtensionWrapper::_on_event_polled(const void *p_event) {
+	if (!meta_boundary_visibility_ext) {
+		return false;
+	}
+
+	if (static_cast<const XrEventDataBuffer *>(p_event)->type == XR_TYPE_EVENT_DATA_BOUNDARY_VISIBILITY_CHANGED_META) {
+		XrEventDataBoundaryVisibilityChangedMETA *boundary_visibility_event = (XrEventDataBoundaryVisibilityChangedMETA *)p_event;
+		current_boundary_visibility = boundary_visibility_event->boundaryVisibility;
+
+		return true;
+	}
+
+	return false;
+}
+
+bool OpenXRMetaBoundaryVisibilityExtensionWrapper::is_boundary_visibility_supported() {
+	return boundary_visibility_properties.supportsBoundaryVisibility;
+}
+
+void OpenXRMetaBoundaryVisibilityExtensionWrapper::set_boundary_visible(bool p_visible) {
+	if (!meta_boundary_visibility_ext) {
+		return;
+	}
+
+	const XrBoundaryVisibilityMETA boundary_visibility = p_visible ? XR_BOUNDARY_VISIBILITY_NOT_SUPPRESSED_META : XR_BOUNDARY_VISIBILITY_SUPPRESSED_META;
+	if (boundary_visibility == current_boundary_visibility) {
+		return;
+	}
+
+	Ref<XRInterface> xr_interface = XRServer::get_singleton()->find_interface("OpenXR");
+	if (xr_interface.is_null() || xr_interface->get_environment_blend_mode() != XRInterface::XR_ENV_BLEND_MODE_ALPHA_BLEND) {
+		UtilityFunctions::printerr("Boundary visibility can only be suppressed when passthrough is active");
+		return;
+	}
+
+	XrResult result = xrRequestBoundaryVisibilityMETA(SESSION, boundary_visibility);
+	if (XR_FAILED(result)) {
+		UtilityFunctions::printerr("Failed to request boundary visibility update: ", get_openxr_api()->get_error_string(result));
+	}
+}
+
+bool OpenXRMetaBoundaryVisibilityExtensionWrapper::is_boundary_visible() {
+	return (current_boundary_visibility == XR_BOUNDARY_VISIBILITY_NOT_SUPPRESSED_META);
+}
+
+void OpenXRMetaBoundaryVisibilityExtensionWrapper::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_boundary_visibility_supported"), &OpenXRMetaBoundaryVisibilityExtensionWrapper::is_boundary_visibility_supported);
+
+	ClassDB::bind_method(D_METHOD("set_boundary_visible", "visible"), &OpenXRMetaBoundaryVisibilityExtensionWrapper::set_boundary_visible);
+	ClassDB::bind_method(D_METHOD("is_boundary_visible"), &OpenXRMetaBoundaryVisibilityExtensionWrapper::is_boundary_visible);
+}
+
+void OpenXRMetaBoundaryVisibilityExtensionWrapper::cleanup() {
+	meta_boundary_visibility_ext = false;
+}
+
+bool OpenXRMetaBoundaryVisibilityExtensionWrapper::initialize_meta_boundary_visibility_extension(XrInstance p_instance) {
+	GDEXTENSION_INIT_XR_FUNC_V(xrRequestBoundaryVisibilityMETA);
+
+	return true;
+}
+#endif // META_HEADERS_ENABLED

--- a/plugin/src/main/cpp/include/extensions/openxr_meta_boundary_visibility_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_meta_boundary_visibility_extension_wrapper.h
@@ -1,0 +1,91 @@
+/**************************************************************************/
+/*  openxr_meta_boundary_visibility_extension_wrapper.h                   */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef META_HEADERS_ENABLED
+#ifndef OPENXR_META_BOUNDARY_VISIBILITY_EXTENSION_WRAPPER_H
+#define OPENXR_META_BOUNDARY_VISIBILITY_EXTENSION_WRAPPER_H
+
+#include <meta_boundary_visibility.h>
+#include <openxr/openxr.h>
+#include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
+#include <map>
+
+#include "util.h"
+
+using namespace godot;
+
+class OpenXRMetaBoundaryVisibilityExtensionWrapper : public OpenXRExtensionWrapperExtension {
+	GDCLASS(OpenXRMetaBoundaryVisibilityExtensionWrapper, OpenXRExtensionWrapperExtension);
+
+public:
+	static OpenXRMetaBoundaryVisibilityExtensionWrapper *get_singleton();
+
+	OpenXRMetaBoundaryVisibilityExtensionWrapper();
+	~OpenXRMetaBoundaryVisibilityExtensionWrapper();
+
+	godot::Dictionary _get_requested_extensions() override;
+
+	uint64_t _set_system_properties_and_get_next_pointer(void *p_next_pointer) override;
+	void _on_instance_created(uint64_t p_instance) override;
+	void _on_instance_destroyed() override;
+	bool _on_event_polled(const void *event) override;
+
+	bool is_boundary_visibility_supported();
+
+	void set_boundary_visible(bool p_visible);
+	bool is_boundary_visible();
+
+protected:
+	static void _bind_methods();
+
+private:
+	EXT_PROTO_XRRESULT_FUNC2(xrRequestBoundaryVisibilityMETA,
+			(XrSession), session,
+			(XrBoundaryVisibilityMETA), boundaryVisibility)
+
+	bool initialize_meta_boundary_visibility_extension(XrInstance p_instance);
+
+	void cleanup();
+
+	static OpenXRMetaBoundaryVisibilityExtensionWrapper *singleton;
+
+	std::map<godot::String, bool *> request_extensions;
+	bool meta_boundary_visibility_ext = false;
+
+	XrSystemBoundaryVisibilityPropertiesMETA boundary_visibility_properties = {
+		XR_TYPE_SYSTEM_BOUNDARY_VISIBILITY_PROPERTIES_META, // type
+		nullptr, // next
+		false // supportsBoundaryVisibility
+	};
+
+	XrBoundaryVisibilityMETA current_boundary_visibility = XR_BOUNDARY_VISIBILITY_NOT_SUPPRESSED_META;
+};
+
+#endif // OPENXR_META_BOUNDARY_VISIBILITY_EXTENSION_WRAPPER_H
+#endif // META_HEADERS_ENABLED

--- a/plugin/src/main/cpp/register_types.cpp
+++ b/plugin/src/main/cpp/register_types.cpp
@@ -69,6 +69,7 @@
 #include "extensions/openxr_fb_spatial_entity_user_extension_wrapper.h"
 #include "extensions/openxr_htc_facial_tracking_extension_wrapper.h"
 #include "extensions/openxr_htc_passthrough_extension_wrapper.h"
+#include "extensions/openxr_meta_boundary_visibility_extension_wrapper.h"
 #include "extensions/openxr_meta_recommended_layer_resolution_extension_wrapper.h"
 #include "extensions/openxr_meta_spatial_entity_mesh_extension_wrapper.h"
 
@@ -155,6 +156,10 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			ClassDB::register_class<OpenXRHtcFacialTrackingExtensionWrapper>();
 			ClassDB::register_class<OpenXRHtcPassthroughExtensionWrapper>();
 
+#ifdef META_HEADERS_ENABLED
+			ClassDB::register_class<OpenXRMetaBoundaryVisibilityExtensionWrapper>();
+#endif // META_HEADERS_ENABLED
+
 			if (_get_bool_project_setting("xr/openxr/extensions/meta/passthrough")) {
 				_register_extension_with_openxr(OpenXRFbPassthroughExtensionWrapper::get_singleton());
 			}
@@ -223,6 +228,12 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 				_register_extension_with_openxr(OpenXRFbCompositionLayerImageLayoutExtensionWrapper::get_singleton());
 			}
 
+#ifdef META_HEADERS_ENABLED
+			if (_get_bool_project_setting("xr/openxr/extensions/meta/boundary_visibility")) {
+				_register_extension_with_openxr(OpenXRMetaBoundaryVisibilityExtensionWrapper::get_singleton());
+			}
+#endif // META_HEADERS_ENABLED
+
 			if (_get_bool_project_setting("xr/openxr/extensions/htc/face_tracking")) {
 				_register_extension_with_openxr(OpenXRHtcFacialTrackingExtensionWrapper::get_singleton());
 			}
@@ -249,6 +260,10 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			_register_extension_as_singleton(OpenXRFbHandTrackingCapsulesExtensionWrapper::get_singleton());
 			_register_extension_as_singleton(OpenXRHtcFacialTrackingExtensionWrapper::get_singleton());
 			_register_extension_as_singleton(OpenXRHtcPassthroughExtensionWrapper::get_singleton());
+
+#ifdef META_HEADERS_ENABLED
+			_register_extension_as_singleton(OpenXRMetaBoundaryVisibilityExtensionWrapper::get_singleton());
+#endif // META_HEADERS_ENABLED
 
 			ClassDB::register_class<OpenXRFbRenderModel>();
 			ClassDB::register_class<OpenXRFbHandTrackingMesh>();
@@ -378,6 +393,10 @@ void add_plugin_project_settings() {
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/scene_api", false);
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/composition_layer_settings", true);
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/dynamic_resolution", true);
+
+#ifdef META_HEADERS_ENABLED
+	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/boundary_visibility", false);
+#endif // META_HEADERS_ENABLED
 
 	{
 		String collision_shape_2d_thickness = "xr/openxr/extensions/meta/scene_api/collision_shape_2d_thickness";


### PR DESCRIPTION
This PR adds support for the XR_META_boundary_visibility extension. This extension isn't in the OpenXR spec yet, so I've added the ability to provide the path for local Meta OpenXR preview headers to scons/gradle. When provided this will include the headers in the compilation and add a `META_HEADERS_ENABLED` define.

So, if you want to build the plugin with meta headers, run a build like this:
```
./gradlew buildPlugin -Pmeta_headers=absolute/path/to/meta_openxr_preview
```

I've also added `compile_commands.json` to `.gitignore`