### PR TITLE
Implement XR_FB_color_space extension

### DIFF
--- a/doc_classes/OpenXRFbColorSpaceExtensionWrapper.xml
+++ b/doc_classes/OpenXRFbColorSpaceExtensionWrapper.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OpenXRFbColorSpaceExtensionWrapper" inherits="OpenXRExtensionWrapperExtension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Wraps the [code]XR_FB_color_space[/code] extension.
+	</brief_description>
+	<description>
+		Wraps the [code]XR_FB_color_space[/code] extension.
+		A color space defines how digital color values are translated into actual visible colors. Specific displays have a native color space that they are capable of producing.
+		This extension allows applications to tell the OpenXR runtime what color space we are rendering in, so that it can potentially translate from that into the native color space of the headset's display.
+		For more information on color management, see: [url=https://developers.meta.com/horizon/resources/color-management-guide/]Color Management in Meta Quest Headsets[/url]
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_color_space">
+			<return type="int" enum="OpenXRFbColorSpaceExtensionWrapper.ColorSpace" />
+			<description>
+				Returns the currently active color space.
+			</description>
+		</method>
+		<method name="get_native_color_space">
+			<return type="int" enum="OpenXRFbColorSpaceExtensionWrapper.ColorSpace" />
+			<description>
+				Returns the native color space of the XR device.
+			</description>
+		</method>
+		<method name="get_supported_color_spaces">
+			<return type="Array" />
+			<description>
+				Returns an array of supported color spaces that we can pass to [method set_color_space].
+			</description>
+		</method>
+		<method name="is_enabled">
+			<return type="bool" />
+			<description>
+				Checks if the extension is enabled or not.
+			</description>
+		</method>
+		<method name="set_color_space">
+			<return type="void" />
+			<param index="0" name="color_space" type="int" enum="OpenXRFbColorSpaceExtensionWrapper.ColorSpace" />
+			<description>
+				Sets the color space that the app is rendering in.
+			</description>
+		</method>
+	</methods>
+	<constants>
+		<constant name="COLOR_SPACE_RUNTIME_DEFAULT" value="0" enum="ColorSpace">
+			The color space the OpenXR runtime selects by default, this may vary depending on the XR device.
+			This is not a valid option for [method set_color_space].
+		</constant>
+		<constant name="COLOR_SPACE_UNMANAGED" value="1" enum="ColorSpace">
+			Unmanaged color space. Using this will disable color correction.
+		</constant>
+		<constant name="COLOR_SPACE_REC2020" value="2" enum="ColorSpace">
+			Rec. 2020 color space.
+		</constant>
+		<constant name="COLOR_SPACE_REC709" value="3" enum="ColorSpace">
+			Rec. 709 color space.
+		</constant>
+		<constant name="COLOR_SPACE_RIFT_CV1" value="4" enum="ColorSpace">
+			Rift CV1 color space.
+		</constant>
+		<constant name="COLOR_SPACE_RIFT_S" value="5" enum="ColorSpace">
+			Rift S color space.
+		</constant>
+		<constant name="COLOR_SPACE_QUEST" value="6" enum="ColorSpace">
+			Quest color space.
+		</constant>
+		<constant name="COLOR_SPACE_P3" value="7" enum="ColorSpace">
+			P3 color space.
+		</constant>
+		<constant name="COLOR_SPACE_ADOBE_RGB" value="8" enum="ColorSpace">
+			Adobe RGB color space.
+		</constant>
+	</constants>
+</class>

--- a/plugin/src/main/cpp/export/meta_export_plugin.cpp
+++ b/plugin/src/main/cpp/export/meta_export_plugin.cpp
@@ -304,6 +304,12 @@ String MetaEditorExportPlugin::_get_export_option_warning(const Ref<EditorExport
 		if (!openxr_enabled && _get_bool_option(option)) {
 			return "\"Instant splash screen\" is only valid when \"XR Mode\" is \"OpenXR\".\n";
 		}
+	} else if (option == "xr_features/enable_meta_plugin") {
+		if ((bool)project_settings->get_setting_with_override("xr/openxr/extensions/meta/color_space")) {
+			if ((int)project_settings->get_setting_with_override("xr/openxr/extensions/meta/color_space/starting_color_space") != 3) {
+				return "\"Recommended color space is REC709, this can be updated in OpenXR project settings.\"";
+			}
+		}
 	}
 
 	return OpenXREditorExportPlugin::_get_export_option_warning(platform, option);

--- a/plugin/src/main/cpp/extensions/openxr_fb_color_space_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_fb_color_space_extension_wrapper.cpp
@@ -1,0 +1,275 @@
+/**************************************************************************/
+/*  openxr_fb_color_space_extension_wrapper.cpp                           */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "extensions/openxr_fb_color_space_extension_wrapper.h"
+
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
+#include <godot_cpp/classes/project_settings.hpp>
+
+using namespace godot;
+
+OpenXRFbColorSpaceExtensionWrapper *OpenXRFbColorSpaceExtensionWrapper::singleton = nullptr;
+
+OpenXRFbColorSpaceExtensionWrapper *OpenXRFbColorSpaceExtensionWrapper::get_singleton() {
+	if (singleton == nullptr) {
+		singleton = memnew(OpenXRFbColorSpaceExtensionWrapper());
+	}
+	return singleton;
+}
+
+OpenXRFbColorSpaceExtensionWrapper::OpenXRFbColorSpaceExtensionWrapper() :
+		OpenXRExtensionWrapperExtension() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "An OpenXRFbColorSpaceExtensionWrapper singleton already exists");
+
+	request_extensions[XR_FB_COLOR_SPACE_EXTENSION_NAME] = &fb_color_space_ext;
+	singleton = this;
+}
+
+OpenXRFbColorSpaceExtensionWrapper::~OpenXRFbColorSpaceExtensionWrapper() {
+	cleanup();
+}
+
+Array OpenXRFbColorSpaceExtensionWrapper::get_supported_color_spaces() {
+	ERR_FAIL_COND_V_MSG(!fb_color_space_ext, Array(), "XR_FB_color_space extension is not enabled");
+
+	if (!supported_color_spaces_set) {
+		populate_supported_color_spaces();
+	}
+
+	ERR_FAIL_COND_V(supported_color_spaces.size() == 0, Array());
+
+	Array ret;
+	ret.resize(supported_color_spaces.size());
+	int i = 0;
+	for (const XrColorSpaceFB &color_space : supported_color_spaces) {
+		ret[i++] = from_openxr_color_space(color_space);
+	}
+	return ret;
+}
+
+OpenXRFbColorSpaceExtensionWrapper::ColorSpace OpenXRFbColorSpaceExtensionWrapper::get_native_color_space() {
+	ERR_FAIL_COND_V_MSG(!fb_color_space_ext, COLOR_SPACE_RUNTIME_DEFAULT, "XR_FB_color_space extension is not enabled");
+	return from_openxr_color_space(system_color_space_properties.colorSpace);
+}
+
+void OpenXRFbColorSpaceExtensionWrapper::set_color_space(ColorSpace p_color_space) {
+	ERR_FAIL_COND_MSG(!fb_color_space_ext, "XR_FB_color_space extension is not enabled");
+	ERR_FAIL_COND_MSG(p_color_space == COLOR_SPACE_RUNTIME_DEFAULT, "Color space must be set to an explicit option when being set at runtime");
+
+	if (p_color_space == current_color_space) {
+		return;
+	}
+
+	if (!supported_color_spaces_set) {
+		populate_supported_color_spaces();
+	}
+
+	XrColorSpaceFB openxr_color_space = to_openxr_color_space(p_color_space);
+	ERR_FAIL_COND_MSG(!supported_color_spaces.has(openxr_color_space), vformat("Color space is not supported: %s", p_color_space));
+
+	XrResult result = xrSetColorSpaceFB(SESSION, openxr_color_space);
+	ERR_FAIL_COND_MSG(XR_FAILED(result), vformat("Failed to set color space [%s]", get_openxr_api()->get_error_string(result)));
+
+	current_color_space = p_color_space;
+}
+
+OpenXRFbColorSpaceExtensionWrapper::ColorSpace OpenXRFbColorSpaceExtensionWrapper::get_color_space() {
+	ERR_FAIL_COND_V_MSG(!fb_color_space_ext, COLOR_SPACE_RUNTIME_DEFAULT, "XR_FB_color_space extension is not enabled");
+	return current_color_space;
+}
+
+void OpenXRFbColorSpaceExtensionWrapper::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_enabled"), &OpenXRFbColorSpaceExtensionWrapper::is_enabled);
+
+	ClassDB::bind_method(D_METHOD("get_supported_color_spaces"), &OpenXRFbColorSpaceExtensionWrapper::get_supported_color_spaces);
+
+	ClassDB::bind_method(D_METHOD("get_native_color_space"), &OpenXRFbColorSpaceExtensionWrapper::get_native_color_space);
+
+	ClassDB::bind_method(D_METHOD("set_color_space", "color_space"), &OpenXRFbColorSpaceExtensionWrapper::set_color_space);
+	ClassDB::bind_method(D_METHOD("get_color_space"), &OpenXRFbColorSpaceExtensionWrapper::get_color_space);
+
+	BIND_ENUM_CONSTANT(COLOR_SPACE_RUNTIME_DEFAULT)
+	BIND_ENUM_CONSTANT(COLOR_SPACE_UNMANAGED)
+	BIND_ENUM_CONSTANT(COLOR_SPACE_REC2020)
+	BIND_ENUM_CONSTANT(COLOR_SPACE_REC709)
+	BIND_ENUM_CONSTANT(COLOR_SPACE_RIFT_CV1)
+	BIND_ENUM_CONSTANT(COLOR_SPACE_RIFT_S)
+	BIND_ENUM_CONSTANT(COLOR_SPACE_QUEST)
+	BIND_ENUM_CONSTANT(COLOR_SPACE_P3)
+	BIND_ENUM_CONSTANT(COLOR_SPACE_ADOBE_RGB)
+}
+
+void OpenXRFbColorSpaceExtensionWrapper::cleanup() {
+	fb_color_space_ext = false;
+	supported_color_spaces_set = false;
+}
+
+void OpenXRFbColorSpaceExtensionWrapper::populate_supported_color_spaces() {
+	if (supported_color_spaces_set) {
+		return;
+	}
+
+	uint32_t num_color_spaces = 0;
+	XrResult result = xrEnumerateColorSpacesFB(SESSION, 0, &num_color_spaces, nullptr);
+	ERR_FAIL_COND_MSG(XR_FAILED(result), vformat("Failed to get supported color space count [%s]", get_openxr_api()->get_error_string(result)));
+
+	supported_color_spaces.resize(num_color_spaces);
+	result = xrEnumerateColorSpacesFB(SESSION, num_color_spaces, &num_color_spaces, supported_color_spaces.ptrw());
+	if (XR_FAILED(result)) {
+		supported_color_spaces.clear();
+		ERR_FAIL_MSG(vformat("Failed to get supported color spaces [%s]", get_openxr_api()->get_error_string(result)));
+	}
+
+	supported_color_spaces_set = true;
+}
+
+OpenXRFbColorSpaceExtensionWrapper::ColorSpace OpenXRFbColorSpaceExtensionWrapper::from_openxr_color_space(XrColorSpaceFB p_color_space) {
+	switch (p_color_space) {
+		case XR_COLOR_SPACE_UNMANAGED_FB: {
+			return COLOR_SPACE_UNMANAGED;
+		} break;
+		case XR_COLOR_SPACE_REC2020_FB: {
+			return COLOR_SPACE_REC2020;
+		} break;
+		case XR_COLOR_SPACE_REC709_FB: {
+			return COLOR_SPACE_REC709;
+		} break;
+		case XR_COLOR_SPACE_RIFT_CV1_FB: {
+			return COLOR_SPACE_RIFT_CV1;
+		} break;
+		case XR_COLOR_SPACE_RIFT_S_FB: {
+			return COLOR_SPACE_RIFT_S;
+		} break;
+		case XR_COLOR_SPACE_QUEST_FB: {
+			return COLOR_SPACE_QUEST;
+		} break;
+		case XR_COLOR_SPACE_P3_FB: {
+			return COLOR_SPACE_P3;
+		} break;
+		case XR_COLOR_SPACE_ADOBE_RGB_FB: {
+			return COLOR_SPACE_ADOBE_RGB;
+		} break;
+		case XR_COLOR_SPACE_MAX_ENUM_FB:
+		default: {
+			ERR_FAIL_V_MSG(COLOR_SPACE_RUNTIME_DEFAULT, vformat("Unknown OpenXR color space: %s", p_color_space));
+		}
+	}
+}
+
+XrColorSpaceFB OpenXRFbColorSpaceExtensionWrapper::to_openxr_color_space(ColorSpace p_color_space) {
+	switch (p_color_space) {
+		case COLOR_SPACE_UNMANAGED: {
+			return XR_COLOR_SPACE_UNMANAGED_FB;
+		} break;
+		case COLOR_SPACE_REC2020: {
+			return XR_COLOR_SPACE_REC2020_FB;
+		} break;
+		case COLOR_SPACE_REC709: {
+			return XR_COLOR_SPACE_REC709_FB;
+		} break;
+		case COLOR_SPACE_RIFT_CV1: {
+			return XR_COLOR_SPACE_RIFT_CV1_FB;
+		} break;
+		case COLOR_SPACE_RIFT_S: {
+			return XR_COLOR_SPACE_RIFT_S_FB;
+		} break;
+		case COLOR_SPACE_QUEST: {
+			return XR_COLOR_SPACE_QUEST_FB;
+		} break;
+		case COLOR_SPACE_P3: {
+			return XR_COLOR_SPACE_P3_FB;
+		} break;
+		case COLOR_SPACE_ADOBE_RGB: {
+			return XR_COLOR_SPACE_ADOBE_RGB_FB;
+		} break;
+		case COLOR_SPACE_RUNTIME_DEFAULT:
+		default: {
+			ERR_FAIL_V_MSG(XR_COLOR_SPACE_MAX_ENUM_FB, vformat("Unknown color space: %s", p_color_space));
+		}
+	}
+}
+
+uint64_t OpenXRFbColorSpaceExtensionWrapper::_set_system_properties_and_get_next_pointer(void *p_next_pointer) {
+	if (fb_color_space_ext) {
+		system_color_space_properties.next = p_next_pointer;
+		p_next_pointer = &system_color_space_properties;
+	}
+
+	return reinterpret_cast<uint64_t>(p_next_pointer);
+}
+
+godot::Dictionary OpenXRFbColorSpaceExtensionWrapper::_get_requested_extensions() {
+	godot::Dictionary result;
+	for (auto ext : request_extensions) {
+		godot::String key = ext.first;
+		uint64_t value = reinterpret_cast<uint64_t>(ext.second);
+		result[key] = (godot::Variant)value;
+	}
+	return result;
+}
+
+void OpenXRFbColorSpaceExtensionWrapper::_on_instance_created(uint64_t instance) {
+	if (fb_color_space_ext) {
+		bool result = initialize_fb_color_space_extension((XrInstance)instance);
+		if (!result) {
+			ERR_PRINT("Failed to initialize XR_FB_color_space extension");
+			fb_color_space_ext = false;
+		}
+	}
+}
+
+void OpenXRFbColorSpaceExtensionWrapper::_on_instance_destroyed() {
+	cleanup();
+}
+
+void OpenXRFbColorSpaceExtensionWrapper::_on_session_destroyed() {
+	current_color_space = COLOR_SPACE_RUNTIME_DEFAULT;
+}
+
+void OpenXRFbColorSpaceExtensionWrapper::_on_state_ready() {
+	ERR_FAIL_COND_MSG(!fb_color_space_ext, "XR_FB_color_space extension is not enabled");
+
+	ProjectSettings *project_settings = ProjectSettings::get_singleton();
+	ERR_FAIL_NULL(project_settings);
+
+	ColorSpace starting_color_space = ColorSpace((int)project_settings->get_setting_with_override("xr/openxr/extensions/meta/color_space/starting_color_space"));
+	if (starting_color_space != COLOR_SPACE_REC709) {
+		WARN_PRINT("Recommended color space project setting is REC709");
+	}
+	if (starting_color_space != COLOR_SPACE_RUNTIME_DEFAULT) {
+		set_color_space(starting_color_space);
+	}
+}
+
+bool OpenXRFbColorSpaceExtensionWrapper::initialize_fb_color_space_extension(const XrInstance p_instance) {
+	GDEXTENSION_INIT_XR_FUNC_V(xrEnumerateColorSpacesFB);
+	GDEXTENSION_INIT_XR_FUNC_V(xrSetColorSpaceFB);
+
+	return true;
+}

--- a/plugin/src/main/cpp/extensions/openxr_fb_render_model_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_fb_render_model_extension_wrapper.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  openxr_fb_scene_capture_extension_wrapper.cpp                         */
+/*  openxr_fb_render_model_extension_wrapper.cpp                          */
 /**************************************************************************/
 /*                       This file is part of:                            */
 /*                              GODOT XR                                  */

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_color_space_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_color_space_extension_wrapper.h
@@ -1,0 +1,119 @@
+/**************************************************************************/
+/*  openxr_fb_color_space_extension_wrapper.h                             */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <openxr/openxr.h>
+#include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
+#include <map>
+
+#include "util.h"
+
+using namespace godot;
+
+// Wrapper for the meta color space extension.
+class OpenXRFbColorSpaceExtensionWrapper : public OpenXRExtensionWrapperExtension {
+	GDCLASS(OpenXRFbColorSpaceExtensionWrapper, OpenXRExtensionWrapperExtension);
+
+public:
+	enum ColorSpace {
+		COLOR_SPACE_RUNTIME_DEFAULT,
+		COLOR_SPACE_UNMANAGED,
+		COLOR_SPACE_REC2020,
+		COLOR_SPACE_REC709,
+		COLOR_SPACE_RIFT_CV1,
+		COLOR_SPACE_RIFT_S,
+		COLOR_SPACE_QUEST,
+		COLOR_SPACE_P3,
+		COLOR_SPACE_ADOBE_RGB,
+	};
+
+	uint64_t _set_system_properties_and_get_next_pointer(void *next_pointer) override;
+
+	godot::Dictionary _get_requested_extensions() override;
+
+	void _on_instance_created(uint64_t instance) override;
+	void _on_instance_destroyed() override;
+	void _on_session_destroyed() override;
+	void _on_state_ready() override;
+
+	static OpenXRFbColorSpaceExtensionWrapper *get_singleton();
+
+	bool is_enabled() { return fb_color_space_ext; }
+
+	OpenXRFbColorSpaceExtensionWrapper();
+	~OpenXRFbColorSpaceExtensionWrapper();
+
+	Array get_supported_color_spaces();
+
+	ColorSpace get_native_color_space();
+
+	void set_color_space(ColorSpace p_color_space);
+	ColorSpace get_color_space();
+
+protected:
+	static void _bind_methods();
+
+private:
+	EXT_PROTO_XRRESULT_FUNC4(xrEnumerateColorSpacesFB,
+			(XrSession), session,
+			(uint32_t), colorSpaceCapacityInput,
+			(uint32_t *), colorSpaceCountOutput,
+			(XrColorSpaceFB *), colorSpaces);
+
+	EXT_PROTO_XRRESULT_FUNC2(xrSetColorSpaceFB,
+			(XrSession), session,
+			(const XrColorSpaceFB), colorSpace);
+
+	bool initialize_fb_color_space_extension(const XrInstance instance);
+
+	void cleanup();
+
+	void populate_supported_color_spaces();
+
+	ColorSpace from_openxr_color_space(XrColorSpaceFB p_color_space);
+	XrColorSpaceFB to_openxr_color_space(ColorSpace p_color_space);
+
+	static OpenXRFbColorSpaceExtensionWrapper *singleton;
+
+	std::map<godot::String, bool *> request_extensions;
+
+	bool fb_color_space_ext = false;
+	bool supported_color_spaces_set = false;
+
+	XrSystemColorSpacePropertiesFB system_color_space_properties = {
+		XR_TYPE_SYSTEM_COLOR_SPACE_PROPERTIES_FB, // type
+		nullptr, // next
+	};
+
+	Vector<XrColorSpaceFB> supported_color_spaces;
+	ColorSpace current_color_space = COLOR_SPACE_RUNTIME_DEFAULT;
+};
+
+VARIANT_ENUM_CAST(OpenXRFbColorSpaceExtensionWrapper::ColorSpace)

--- a/plugin/src/main/cpp/register_types.cpp
+++ b/plugin/src/main/cpp/register_types.cpp
@@ -47,6 +47,7 @@
 
 #include "extensions/openxr_fb_android_surface_swapchain_create_extension_wrapper.h"
 #include "extensions/openxr_fb_body_tracking_extension_wrapper.h"
+#include "extensions/openxr_fb_color_space_extension_wrapper.h"
 #include "extensions/openxr_fb_composition_layer_alpha_blend_extension_wrapper.h"
 #include "extensions/openxr_fb_composition_layer_depth_test_extension_wrapper.h"
 #include "extensions/openxr_fb_composition_layer_image_layout_extension_wrapper.h"
@@ -134,6 +135,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 
 			ClassDB::register_class<OpenXRFbPassthroughExtensionWrapper>();
 			ClassDB::register_class<OpenXRFbRenderModelExtensionWrapper>();
+			ClassDB::register_class<OpenXRFbColorSpaceExtensionWrapper>();
 			ClassDB::register_class<OpenXRFbSceneCaptureExtensionWrapper>();
 			ClassDB::register_class<OpenXRFbSpatialEntityExtensionWrapper>();
 			ClassDB::register_class<OpenXRFbSpatialEntitySharingExtensionWrapper>();
@@ -170,6 +172,10 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 
 			if (_get_bool_project_setting("xr/openxr/extensions/meta/render_model")) {
 				_register_extension_with_openxr(OpenXRFbRenderModelExtensionWrapper::get_singleton());
+			}
+
+			if (_get_bool_project_setting("xr/openxr/extensions/meta/color_space")) {
+				_register_extension_with_openxr(OpenXRFbColorSpaceExtensionWrapper::get_singleton());
 			}
 
 			// Three settings to match the three permissions for the Android manifest.
@@ -268,6 +274,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 		case MODULE_INITIALIZATION_LEVEL_SCENE: {
 			_register_extension_as_singleton(OpenXRFbPassthroughExtensionWrapper::get_singleton());
 			_register_extension_as_singleton(OpenXRFbRenderModelExtensionWrapper::get_singleton());
+			_register_extension_as_singleton(OpenXRFbColorSpaceExtensionWrapper::get_singleton());
 			_register_extension_as_singleton(OpenXRFbSceneCaptureExtensionWrapper::get_singleton());
 			_register_extension_as_singleton(OpenXRFbSpatialEntityExtensionWrapper::get_singleton());
 			_register_extension_as_singleton(OpenXRFbSpatialEntityStorageExtensionWrapper::get_singleton());
@@ -423,6 +430,7 @@ void add_plugin_project_settings() {
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/anchor_api", false);
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/anchor_sharing", false);
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/scene_api", false);
+	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/color_space", true);
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/composition_layer_settings", true);
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/dynamic_resolution", true);
 
@@ -449,6 +457,22 @@ void add_plugin_project_settings() {
 		property_info["name"] = collision_shape_2d_thickness;
 		property_info["type"] = Variant::Type::FLOAT;
 		property_info["hint"] = PROPERTY_HINT_NONE;
+		project_settings->add_property_info(property_info);
+	}
+
+	{
+		String starting_color_space = "xr/openxr/extensions/meta/color_space/starting_color_space";
+		if (!project_settings->has_setting(starting_color_space)) {
+			project_settings->set_setting(starting_color_space, 0);
+		}
+
+		project_settings->set_initial_value(starting_color_space, 0);
+		project_settings->set_as_basic(starting_color_space, false);
+		Dictionary property_info;
+		property_info["name"] = starting_color_space;
+		property_info["type"] = Variant::Type::INT;
+		property_info["hint"] = PROPERTY_HINT_ENUM;
+		property_info["hint_string"] = "Runtime Default:0,Unmanaged:1,REC2020:2,REC709:3,Rift CV1:4,Rift S:5,Quest:6,P3:7,Adobe RGB:8";
 		project_settings->add_property_info(property_info);
 	}
 


### PR DESCRIPTION
This PR adds support for the XR_FB_color_space extension.

Color space can be set in project settings or via the singleton at runtime, by default I have the color space set to Rec. 709. The reasoning (from my limited understanding of color space) is because Godot works in a sRGB / Rec. 709 color space.

~~I was torn on if this extension should be enabled by default. Setting the color space to Rec. 709 does slightly alter the color output, so those with existing projects may not want it enabled by default? I have it disabled for now, but could easily be swayed if others want it enabled.~~
2025-06-11 Edit: I've made it so that color space is enabled by default. ~~By default it looks like Quest 3 actually uses the Rec. 709 color space, so I don't think this will be problematic at all.~~
2025-06-12 Edit: Just kidding, it definitely uses a different color space than Rec. 709 enabled by default, so I've set the default color space to `Runtime Default`. This way nothing should change for any existing projects.

Also fixed a typo in `openxr_fb_render_model_extension_wrapper.cpp`.