### PR TITLE
Patch godot-cpp for SCons cache issue on CI

### DIFF
--- a/.github/workflows/build-addon-on-push.yml
+++ b/.github/workflows/build-addon-on-push.yml
@@ -95,6 +95,14 @@ jobs:
       - name: Install scons
         run: |
           python -m pip install scons==4.0.0
+      - name: Apply godot-cpp patches
+        run: |
+          cd aar/thirdparty/godot-cpp
+          for f in ../godot_cpp_patches/*.patch; do
+            patch -p1 < $f
+          done
+          cd ../..
+        if: matrix.platform != 'windows'
       - name: Create extension library
         run: |
           cd aar

--- a/thirdparty/godot_cpp_patches/001-scons-cache-fix.patch
+++ b/thirdparty/godot_cpp_patches/001-scons-cache-fix.patch
@@ -1,0 +1,18 @@
+diff --git a/tools/godotcpp.py b/tools/godotcpp.py
+index 8931e6dc..f71bd3ab 100644
+--- a/tools/godotcpp.py
++++ b/tools/godotcpp.py
+@@ -140,7 +140,12 @@ def scons_emit_files(target, source, env):
+     env.Clean(target, [env.File(f) for f in get_file_list(str(source[0]), target[0].abspath, True, True)])
+ 
+     api = generate_trimmed_api(str(source[0]), profile_filepath)
+-    files = [env.File(f) for f in _get_file_list(api, target[0].abspath, True, True)]
++    files = []
++    for f in _get_file_list(api, target[0].abspath, True, True):
++        file = env.File(f)
++        if profile_filepath:
++            env.Depends(file, profile_filepath)
++        files.append(file)
+     env["godot_cpp_gen_dir"] = target[0].abspath
+     return files, source
+ 


### PR DESCRIPTION
This applies a patch with the changes from PR https://github.com/godotengine/godot-cpp/pull/1795

This seems to fix the cache issue in my testing on PR https://github.com/GodotVR/godot_openxr_vendors/pull/308, which was experiencing the issue

We won't really know if this fixes it on `master` until we merge it there, because each branch/pr will have its own cache. And we also won't really, really know until we've tried this with a couple more PRs after it has been merged to `master`

Assuming this works, after it's merged and cherry-picked into godot-cpp, we can drop these changes

NOTE: The CI doesn't apply the patch on Windows because that would need some PowerShell to do the loop and patch, and the problem never seems to manifest there anyway. I've seen it happen on the Linux, MacOS and Android builds, though