### PR TITLE
Prevent "XR_FB_color_space extension is not enabled" error on session start

### DIFF
--- a/plugin/src/main/cpp/extensions/openxr_fb_color_space_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_fb_color_space_extension_wrapper.cpp
@@ -253,7 +253,9 @@ void OpenXRFbColorSpaceExtensionWrapper::_on_session_destroyed() {
 }
 
 void OpenXRFbColorSpaceExtensionWrapper::_on_state_ready() {
-	ERR_FAIL_COND_MSG(!fb_color_space_ext, "XR_FB_color_space extension is not enabled");
+	if (!fb_color_space_ext) {
+		return;
+	}
 
 	ProjectSettings *project_settings = ProjectSettings::get_singleton();
 	ERR_FAIL_NULL(project_settings);


### PR DESCRIPTION
Presently, if you enable the `XR_FB_color_space` extension in project settings, and then you run on a runtime that doesn't support that extension, you'll always get this error when the OpenXR session starts.

I don't think this should be an error in `_state_ready()` - only in functions that the developer explicitly called.

In this case, I think we should just silently return (which is what this PR does).