### PR TITLE
Use the Meta OpenXR preview headers in CI builds

### DIFF
--- a/.github/workflows/build-addon-on-push.yml
+++ b/.github/workflows/build-addon-on-push.yml
@@ -7,6 +7,8 @@ env:
   # Only used for the cache key. Increment version to force clean build.
   GODOT_BASE_BRANCH: master
   SCONS_CACHE: ${{ github.workspace }}/.scons-cache/
+  # This is ovr_openxr_mobile_sdk v77.
+  META_OPENXR_HEADERS_URL: 'https://securecdn-ord5-3.oculus.com/binaries/download/?id=23875289988749597'
 
 jobs:
   build:
@@ -19,34 +21,22 @@ jobs:
           - name: 🐧 Linux (x86_64, GCC)
             os: ubuntu-22.04
             platform: linux
+            preview-headers: true
             flags: arch=x86_64
             artifact_name: build-files-linux-x86_64
             artifact_path: aar/demo/addons/godotopenxrvendors/.bin/linux/*/*/*.so
             cache-name: linux-x86_64
-          # Not sure how to cross compile these
-          # - name: Linux (arm64)
-          #   os: ubuntu-22.04
-          #   platform: linux
-          #   flags: arch=arm64
-          #   artifact_name: build-files-linux-arm64
-          #   artifact_path: aar/demo/addons/godotopenxrvendors/.bin/linux/*/*/*.so
-          #   cache-name: linux-arm64
-          # - name: Linux (rv64)
-          #  os: ubuntu-22.04
-          #  platform: linux
-          #  flags: arch=rv64
-          #  artifact_name: build-files-linux-rv64
-          #  artifact_path: aar/demo/addons/godotopenxrvendors/.bin/linux/*/*/*.so
-          #  cache-name: linux-rv64
           - name: 🏁 Windows (x86_64, MSVC)
             os: windows-latest
             platform: windows
+            preview-headers: true
             artifact_name: build-files-windows
             artifact_path: aar/demo/addons/godotopenxrvendors/.bin/windows/*/*/*.dll
             cache-name: windows-x86_64-msvc
           - name: 🍎 MacOS (universal)
             os: macos-latest
             platform: macos
+            preview-headers: true
             flags: arch=universal
             artifact_name: build-files-macos
             artifact_path: aar/demo/addons/godotopenxrvendors/.bin/macos/*/*.framework
@@ -54,6 +44,7 @@ jobs:
           - name: 🤖 Android (arm64)
             os: ubuntu-22.04
             platform: android
+            preview-headers: true
             flags: arch=arm64
             artifact_name: build-files-android-arm64
             artifact_path: |
@@ -62,12 +53,55 @@ jobs:
           - name: 🤖 Android (x86_64)
             os: ubuntu-22.04
             platform: android
+            preview-headers: true
             flags: arch=x86_64
             artifact_name: build-files-android-x86_64
             artifact_path: |
               aar/plugin/src/main/libs/*/*/*/*.so
             cache-name: android-x86_64
 
+          # Without the preview headers.
+          - name: 🐧 Linux (x86_64, GCC, No preview)
+            os: ubuntu-22.04
+            platform: linux
+            preview-headers: false
+            flags: arch=x86_64
+            artifact_name: build-files-linux-x86_64-nopreview
+            artifact_path: aar/demo/addons/godotopenxrvendors/.bin/linux/*/*/*.so
+            cache-name: linux-x86_64-nopreview
+          - name: 🏁 Windows (x86_64, MSVC, No preview)
+            os: windows-latest
+            platform: windows
+            preview-headers: false
+            artifact_name: build-files-windows-nopreview
+            artifact_path: aar/demo/addons/godotopenxrvendors/.bin/windows/*/*/*.dll
+            cache-name: windows-x86_64-msvc-nopreview
+          - name: 🍎 MacOS (universal, No preview)
+            os: macos-latest
+            platform: macos
+            preview-headers: false
+            cache-name: macos-universal
+            flags: arch=universal
+            artifact_name: build-files-macos-nopreview
+            artifact_path: aar/demo/addons/godotopenxrvendors/.bin/macos/*/*.framework
+          - name: 🤖 Android (arm64, No Preview)
+            os: ubuntu-22.04
+            platform: android
+            preview-headers: false
+            flags: arch=arm64
+            artifact_name: build-files-android-arm64-nopreview
+            artifact_path: |
+              aar/plugin/src/main/libs/*/*/*/*.so
+            cache-name: android-arm64-nopreview
+          - name: 🤖 Android (x86_64, No preview)
+            os: ubuntu-22.04
+            platform: android
+            preview-headers: false
+            flags: arch=x86_64
+            artifact_name: build-files-android-x86_64-nopreview
+            artifact_path: |
+              aar/plugin/src/main/libs/*/*/*/*.so
+            cache-name: android-x86_64-nopreview
 
     # Note, to satisfy the asset library we need to make sure our zip files have a root folder
     # this is why we checkout into aar and build into asset
@@ -92,6 +126,17 @@ jobs:
           ndk-version: r23c
           link-to-sdk: true
         if: matrix.platform == 'android'
+      - name: Download Meta OpenXR Preview headers
+        run: |
+          # PowerShell (ick!) works on all GitHub platforms. I don't like it, but it works.
+          Invoke-WebRequest -Uri "${{ env.META_OPENXR_HEADERS_URL }}" -OutFile "ovr_openxr_mobile_sdk.zip"
+          Expand-Archive -Path "ovr_openxr_mobile_sdk.zip" -DestinationPath "ovr_openxr_mobile_sdk"
+
+          # These variables should carry over into bash as well.
+          echo "SCONS_EXTRA=meta_headers=${{ github.workspace }}/ovr_openxr_mobile_sdk/OpenXR/meta_openxr_preview/" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "GRADLE_EXTRA=-Pmeta_headers=${{ github.workspace }}/ovr_openxr_mobile_sdk/OpenXR/meta_openxr_preview/" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        shell: pwsh
+        if: ${{ matrix.preview-headers == 'true' }}
       - name: Install scons
         run: |
           python -m pip install scons==4.0.0
@@ -106,8 +151,8 @@ jobs:
       - name: Create extension library
         run: |
           cd aar
-          scons platform=${{ matrix.platform }} target=template_debug ${{ matrix.flags }} custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json
-          scons platform=${{ matrix.platform }} target=template_release ${{ matrix.flags }} custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json
+          scons platform=${{ matrix.platform }} target=template_debug ${{ matrix.flags }} custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json $SCONS_EXTRA
+          scons platform=${{ matrix.platform }} target=template_release ${{ matrix.flags }} custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json $SCONS_EXTRA
           cd ..
       - name: Save Godot build cache
         uses: ./aar/thirdparty/godot-cpp/.github/actions/godot-cache-save
@@ -145,10 +190,20 @@ jobs:
           mkdir aar/plugin/src/main/libs
           cp -r build-files-android-arm64/* aar/plugin/src/main/libs/
           cp -r build-files-android-x86_64/* aar/plugin/src/main/libs/
+      - name: Download Meta OpenXR Preview headers
+        run: |
+          # PowerShell (ick!) works on all GitHub platforms. I don't like it, but it works.
+          Invoke-WebRequest -Uri "${{ env.META_OPENXR_HEADERS_URL }}" -OutFile "ovr_openxr_mobile_sdk.zip"
+          Expand-Archive -Path "ovr_openxr_mobile_sdk.zip" -DestinationPath "ovr_openxr_mobile_sdk"
+
+          # These variables should carry over into bash as well.
+          echo "SCONS_EXTRA=meta_headers=${{ github.workspace }}/ovr_openxr_mobile_sdk/OpenXR/meta_openxr_preview/" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "GRADLE_EXTRA=-Pmeta_headers=${{ github.workspace }}/ovr_openxr_mobile_sdk/OpenXR/meta_openxr_preview/" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        shell: pwsh
       - name: Create Godot OpenXR Vendors AARs
         run: |
           cd aar
-          ./gradlew build
+          ./gradlew build $GRADLE_EXTRA
           cd ..
       - name: Create Godot OpenXR Vendors Addon
         run: |
@@ -158,7 +213,8 @@ jobs:
       - name: Adding vendor licences
         run: |
           mkdir -p asset/addons/godotopenxrvendors/meta/
-          cp aar/thirdparty/khronos_openxr_sdk/LICENSE asset/addons/godotopenxrvendors/meta/LICENSE
+          cp ovr_openxr_mobile_sdk/LICENSE.txt asset/addons/godotopenxrvendors/meta/LICENSE-SDK
+          cp aar/thirdparty/khronos_openxr_sdk/LICENSE asset/addons/godotopenxrvendors/meta/LICENSE-LOADER
 
           mkdir -p asset/addons/godotopenxrvendors/pico/
           cp aar/thirdparty/khronos_openxr_sdk/LICENSE asset/addons/godotopenxrvendors/pico/LICENSE

--- a/.github/workflows/mavencentral-publish.yml
+++ b/.github/workflows/mavencentral-publish.yml
@@ -35,19 +35,29 @@ jobs:
           java-version: 17
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v3
+      - name: Download Meta OpenXR Preview headers
+        run: |
+          # PowerShell (ick!) works on all GitHub platforms. I don't like it, but it works.
+          Invoke-WebRequest -Uri "${{ env.META_OPENXR_HEADERS_URL }}" -OutFile "ovr_openxr_mobile_sdk.zip"
+          Expand-Archive -Path "ovr_openxr_mobile_sdk.zip" -DestinationPath "ovr_openxr_mobile_sdk"
+
+          # These variables should carry over into bash as well.
+          echo "SCONS_EXTRA=meta_headers=${{ github.workspace }}/ovr_openxr_mobile_sdk/OpenXR/meta_openxr_preview/" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "GRADLE_EXTRA=-Pmeta_headers=${{ github.workspace }}/ovr_openxr_mobile_sdk/OpenXR/meta_openxr_preview/" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        shell: pwsh
 
         # Builds the release artifacts of the library
       - name: Release build
         run: |
-          scons platform=android target=template_debug arch=arm64 custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json
-          scons platform=android target=template_release arch=arm64 custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json
-          scons platform=android target=template_debug arch=x86_64 custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json
-          scons platform=android target=template_release arch=x86_64 custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json
-          ./gradlew -Prelease_version=${{ github.ref_name }} build
+          scons platform=android target=template_debug arch=arm64 custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json $SCONS_EXTRA
+          scons platform=android target=template_release arch=arm64 custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json $SCONS_EXTRA
+          scons platform=android target=template_debug arch=x86_64 custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json $SCONS_EXTRA
+          scons platform=android target=template_release arch=x86_64 custom_api_file=thirdparty/godot_cpp_gdextension_api/extension_api.json build_profile=thirdparty/godot_cpp_build_profile/build_profile.json $SCONS_EXTRA
+          ./gradlew -Prelease_version=${{ github.ref_name }} build $GRADLE_EXTRA
 
         # Runs upload, and then closes & releases the repository
       - name: Publish to MavenCentral
-        run: ./gradlew -Prelease_version=${{ github.ref_name }} publishAllPublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository
+        run: ./gradlew -Prelease_version=${{ github.ref_name }} publishAllPublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository $GRADLE_EXTRA
         env:
           OSSRH_GROUP_ID: ${{ secrets.OSSRH_GROUP_ID }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}


### PR DESCRIPTION
This PR will download and use the Meta OpenXR preview headers in CI builds. This would also mean that our releases will include support for the features that are only available with those headers.

I am not a lawyer, but my personal interpretation of [the license](https://developers.meta.com/horizon/licenses/oculussdk/) is that this should be OK for us to do.

However, this is something we should discuss! (I'll add it to the agenda of the next XR team meeting.)

If we don't want to go this way, there are a number of possible alternative options:

- We could release _both_ Meta enabled and disabled builds
- We could build both with and without the headers (to test that both can compile), but only release the version without the headers here
- We could build and release the Meta enabled version elsewhere (maybe in a project under [godot-sdk-integrations](https://github.com/godot-sdk-integrations)?)

~~**UPDATE (2025-07-10):** The latest version builds _both_ Meta and non-Meta builds, including for release, but not for MavenCentral~~

**UPDATE (2025-07-11):** The latest version builds both Meta and non-Meta builds, but only releases the Meta ones, including to MavenCentral