### PR TITLE
Add minimal docs for a couple undocumented composition layer extensions

### DIFF
--- a/doc_classes/OpenXRFbAndroidSurfaceSwapchainCreateExtensionWrapper.xml
+++ b/doc_classes/OpenXRFbAndroidSurfaceSwapchainCreateExtensionWrapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OpenXRFbAndroidSurfaceSwapchainCreateExtensionWrapper" inherits="OpenXRExtensionWrapperExtension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Wraps the [code]XR_FB_android_surface_swapchain_create[/code] extension.
+	</brief_description>
+	<description>
+		Wraps the [code]XR_FB_android_surface_swapchain_create[/code] extension.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="is_enabled" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the extension is enabled; otherwise [code]false[/code].
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc_classes/OpenXRFbCompositionLayerDepthTestExtensionWrapper.xml
+++ b/doc_classes/OpenXRFbCompositionLayerDepthTestExtensionWrapper.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OpenXRFbCompositionLayerDepthTestExtensionWrapper" inherits="OpenXRExtensionWrapperExtension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Wraps the [code]XR_FB_composition_layer_depth_test[/code] extension.
+	</brief_description>
+	<description>
+		Wraps the [code]XR_FB_composition_layer_depth_test[/code] extension.
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/doc_classes/OpenXRFbCompositionLayerImageLayoutExtensionWrapper.xml
+++ b/doc_classes/OpenXRFbCompositionLayerImageLayoutExtensionWrapper.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OpenXRFbCompositionLayerImageLayoutExtensionWrapper" inherits="OpenXRExtensionWrapperExtension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Wraps the [code]XR_FB_composition_layer_image_layout[/code] extension.
+	</brief_description>
+	<description>
+		Wraps the [code]XR_FB_composition_layer_image_layout[/code] extension.
+	</description>
+	<tutorials>
+	</tutorials>
+</class>


### PR DESCRIPTION
I noticed that we were missing documentation for 3 random composition layer extensions:

- `XR_FB_composition_layer_image_layout`
- `XR_FB_composition_layer_depth_test`
- `XR_FB_android_surface_swapchain_create`

There really isn't anything to document on them, they all just add options to `OpenXRCompositionLayer`, which is how developers should use them.

However, it's good to have the XML documents in there for completeness, and so that folks could more easily expand on them, if they wanted.