### PR TITLE
Configure all samples to use REC709 color space

### DIFF
--- a/demo/project.godot
+++ b/demo/project.godot
@@ -41,3 +41,4 @@ openxr/extensions/hand_tracking_controller_data_source=true
 shaders/enabled=true
 openxr/extensions/meta/hand_tracking_mesh=true
 openxr/extensions/meta/render_model=true
+openxr/extensions/meta/color_space/starting_color_space=3

--- a/samples/hybrid-app-sample/project.godot
+++ b/samples/hybrid-app-sample/project.godot
@@ -46,3 +46,4 @@ hybrid_app/enabled=true
 hybrid_app/launch_mode=1
 openxr/extensions/meta/passthrough=true
 openxr/extensions/meta/render_model=true
+openxr/extensions/meta/color_space/starting_color_space=3

--- a/samples/meta-body-tracking-sample/project.godot
+++ b/samples/meta-body-tracking-sample/project.godot
@@ -41,3 +41,4 @@ shaders/enabled=true
 openxr/extensions/meta/face_tracking=true
 openxr/extensions/meta/body_tracking=true
 openxr/extensions/meta/hand_tracking_mesh=true
+openxr/extensions/meta/color_space/starting_color_space=3

--- a/samples/meta-composition-layers-sample/project.godot
+++ b/samples/meta-composition-layers-sample/project.godot
@@ -27,3 +27,4 @@ openxr/enabled=true
 openxr/reference_space=2
 shaders/enabled=true
 openxr/extensions/meta/render_model=true
+openxr/extensions/meta/color_space/starting_color_space=3

--- a/samples/meta-hand-tracking-sample/project.godot
+++ b/samples/meta-hand-tracking-sample/project.godot
@@ -35,3 +35,4 @@ openxr/extensions/hand_tracking_aim=true
 openxr/extensions/meta/hand_tracking_aim=true
 openxr/extensions/meta/hand_tracking_mesh=true
 openxr/extensions/meta/hand_tracking_capsules=true
+openxr/extensions/meta/color_space/starting_color_space=3

--- a/samples/meta-passthrough-sample/project.godot
+++ b/samples/meta-passthrough-sample/project.godot
@@ -27,3 +27,4 @@ openxr/enabled=true
 shaders/enabled=true
 openxr/extensions/meta/render_model=true
 openxr/extensions/meta/passthrough=true
+openxr/extensions/meta/color_space/starting_color_space=3

--- a/samples/meta-scene-sample/project.godot
+++ b/samples/meta-scene-sample/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Meta Scene Sample"
 run/main_scene="res://main.tscn"
-config/features=PackedStringArray("4.5", "GL Compatibility")
+config/features=PackedStringArray("4.4", "GL Compatibility")
 config/icon="res://icon.svg"
 
 [layer_names]
@@ -80,3 +80,4 @@ openxr/extensions/meta/render_model=true
 openxr/extensions/meta/anchor_api=true
 openxr/extensions/meta/scene_api=true
 openxr/extensions/meta/environment_depth=true
+openxr/extensions/meta/color_space/starting_color_space=3

--- a/samples/meta-space-warp-sample/project.godot
+++ b/samples/meta-space-warp-sample/project.godot
@@ -31,3 +31,4 @@ openxr/reference_space=2
 shaders/enabled=true
 openxr/extensions/meta/application_space_warp=true
 openxr/extensions/meta/render_model=true
+openxr/extensions/meta/color_space/starting_color_space=3


### PR DESCRIPTION
This builds on https://github.com/GodotVR/godot_openxr_vendors/pull/305 by setting all our samples to use the recommended color space of REC709