### PR TITLE
Add a debug version of the maven central artifact for the OpenXR Vendors library

### DIFF
--- a/config.gradle
+++ b/config.gradle
@@ -10,7 +10,7 @@ ext {
             ndkVersion              : '23.2.8568313',
             // Note that 'plugin/src/main/AndroidManifest.xml' should be updated with content
             // from the Khronos OpenXR loader manifest.
-            openxrVersion           : '1.0.34',
+            openxrVersion           : '1.1.49',
             fragmentVersion         : '1.7.1',
             splashscreenVersion     : '1.0.1',
     ]
@@ -21,7 +21,7 @@ ext {
 
     // Parse the release version from the gradle project properties (e.g: -Prelease_version=<version>)
     getReleaseVersion = { ->
-        final String defaultVersion = "4.0.0-stable" // Also update 'plugin/src/main/cpp/include/export/export_plugin.h#PLUGIN_VERSION'
+        final String defaultVersion = "4.1.0-dev" // Also update 'plugin/src/main/cpp/include/export/export_plugin.h#PLUGIN_VERSION'
 
         String releaseVersion = project.hasProperty("release_version") ? project.property("release_version") : defaultVersion
         if (releaseVersion == null || releaseVersion.isEmpty()) {

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -152,26 +152,46 @@ android {
     }
 
     publishing {
+        singleVariant("khronosDebug") {
+            withSourcesJar()
+            withJavadocJar()
+        }
         singleVariant("khronosRelease") {
             withSourcesJar()
             withJavadocJar()
         }
 
+        singleVariant("lynxDebug") {
+            withSourcesJar()
+            withJavadocJar()
+        }
         singleVariant("lynxRelease") {
             withSourcesJar()
             withJavadocJar()
         }
 
+        singleVariant("magicleapDebug") {
+            withSourcesJar()
+            withJavadocJar()
+        }
         singleVariant("magicleapRelease") {
             withSourcesJar()
             withJavadocJar()
         }
 
+        singleVariant("metaDebug") {
+            withSourcesJar()
+            withJavadocJar()
+        }
         singleVariant("metaRelease") {
             withSourcesJar()
             withJavadocJar()
         }
 
+        singleVariant("picoDebug") {
+            withSourcesJar()
+            withJavadocJar()
+        }
         singleVariant("picoRelease") {
             withSourcesJar()
             withJavadocJar()

--- a/plugin/src/main/cpp/include/export/export_plugin.h
+++ b/plugin/src/main/cpp/include/export/export_plugin.h
@@ -40,7 +40,7 @@
 
 using namespace godot;
 
-static const char *PLUGIN_VERSION = "4.0.0-stable"; // Also update 'config.gradle#defaultVersion'
+static const char *PLUGIN_VERSION = "4.1.0-dev"; // Also update 'config.gradle#defaultVersion'
 
 // Set of supported vendors
 static const char *META_VENDOR_NAME = "meta";

--- a/scripts/publish-module.gradle
+++ b/scripts/publish-module.gradle
@@ -8,15 +8,17 @@ afterEvaluate {
     publishing {
         publications {
             android.libraryVariants.all { variant ->
-                String buildType = variant.buildType.name
-                if (buildType != "release") {
-                    return
-                }
-
                 String flavorArtifactId = PUBLISH_ARTIFACT_ID
                 String flavorName = variant.getFlavorName()
                 if (flavorName != null && !flavorName.isEmpty()) {
                     flavorArtifactId = "$flavorArtifactId-$flavorName"
+                }
+
+                String descriptionLabel = "Godot OpenXR Vendors"
+                String buildType = variant.buildType.name
+                if (buildType == "debug") {
+                    flavorArtifactId = "$flavorArtifactId-debug"
+                    descriptionLabel = "$descriptionLabel (Debug)"
                 }
 
                 String variantName = variant.name
@@ -32,7 +34,7 @@ afterEvaluate {
                     // Mostly self-explanatory metadata
                     pom {
                         name = flavorArtifactId
-                        description = 'Godot OpenXR Vendors'
+                        description = descriptionLabel
                         url = 'https://github.com/GodotVR/godot_openxr_vendors#readme'
                         licenses {
                             license {


### PR DESCRIPTION
This is a workaround to the issue described in https://github.com/godotengine/godot-cpp/issues/1820 and provide users of the Godot OpenXR Vendors library with an alternate artifact that they can use in their development process.