### PR TITLE
Add missing 2.0.4 changelog entries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,6 +74,10 @@
 - Add manifest entries to Pico and switch Pico to using the Khronos Loader
 - Add Meta Passthrough tutorial doc
 
+## 2.0.4
+- Fix misc crash when reloading project on Godot 4.3
+- Fix issue with only the first permission being requested
+
 ## 2.0.3
 - Migrate the export scripts from gdscript to C++ via gdextension
 - Manually request eye tracking permission if it's included in the app manifest


### PR DESCRIPTION
I noticed when bisecting an issue that we don't have the changelog entries for 2.0.4 in `master`, they are only on the `2.x` branch - probably because 2.0.4 was created after we already started work on 3.x

For completeness, let's get these into `master` as well!