### PR TITLE
Update the export plugin version to match the maven central release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change history for the Godot OpenXR loaders asset
 
+## 4.1.1
+
+- Update the export plugin version to match the maven central release
+
 ## 4.1.0
 
 - Implement `XR_META_boundary_visibility` extension

--- a/config.gradle
+++ b/config.gradle
@@ -21,7 +21,7 @@ ext {
 
     // Parse the release version from the gradle project properties (e.g: -Prelease_version=<version>)
     getReleaseVersion = { ->
-        final String defaultVersion = "4.1.0-dev" // Also update 'plugin/src/main/cpp/include/export/export_plugin.h#PLUGIN_VERSION'
+        final String defaultVersion = "4.1.1-stable" // Also update 'plugin/src/main/cpp/include/export/export_plugin.h#PLUGIN_VERSION'
 
         String releaseVersion = project.hasProperty("release_version") ? project.property("release_version") : defaultVersion
         if (releaseVersion == null || releaseVersion.isEmpty()) {

--- a/plugin/src/main/cpp/include/export/export_plugin.h
+++ b/plugin/src/main/cpp/include/export/export_plugin.h
@@ -40,7 +40,7 @@
 
 using namespace godot;
 
-static const char *PLUGIN_VERSION = "4.1.0-dev"; // Also update 'config.gradle#defaultVersion'
+static const char *PLUGIN_VERSION = "4.1.1-stable"; // Also update 'config.gradle#defaultVersion'
 
 // Set of supported vendors
 static const char *META_VENDOR_NAME = "meta";


### PR DESCRIPTION
Supersede https://github.com/GodotVR/godot_openxr_vendors/pull/327