### PR TITLE
Automatically check version numbers before release

### DIFF
--- a/.github/workflows/build-addon-on-push.yml
+++ b/.github/workflows/build-addon-on-push.yml
@@ -11,9 +11,33 @@ env:
   META_OPENXR_HEADERS_URL: 'https://securecdn-ord5-3.oculus.com/binaries/download/?id=23875289988749597'
 
 jobs:
+  release-guard:
+    name: Release guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Validate release
+        run: |
+          if [[ "${{ github.ref }}" =~ ^refs/tags/ ]]; then
+            if scripts/validate_release.py . "${{ github.ref_name }}"; then
+              echo " ** Ready for release!"
+            else
+              echo " ** Not ready for release! Fix the above errors, reset the Git tag, and try again..."
+              exit 1
+            fi
+          else
+            echo " ** Not doing a release - carry on..."
+          fi
+
   build:
     name: Building for ${{ matrix.name }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    needs: release-guard
     strategy:
       fail-fast: true
       matrix:

--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import sys, os, re
+
+
+FILES_AND_PATTERNS = {
+    'config.gradle': r'defaultVersion = "([^"]*)"',
+    'plugin/src/main/cpp/include/export/export_plugin.h': r'PLUGIN_VERSION = "([^"]*)"',
+}
+
+
+def get_version(path, pattern):
+    with open(path, 'rt') as fd:
+        data = fd.read()
+
+    m = re.search(pattern, data, re.MULTILINE | re.DOTALL)
+    if not m:
+        raise Exception(f"Unable to find pattern {pattern} in {path}")
+
+    return m[1]
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(f"USAGE: {sys.argv[0]} SOURCE_DIR RELEASE_VERSION", file=sys.stderr)
+        sys.exit(1)
+
+    source_dir = sys.argv[1]
+    release_version = sys.argv[2]
+
+    valid = True
+    for file, pattern in FILES_AND_PATTERNS.items():
+        file_parts = file.split('/')
+        file_version = get_version(os.path.join(*[source_dir]+file_parts), pattern)
+        if file_version != release_version:
+            valid = False
+            print(f"ERROR: Version from file '{file}' ({file_version}) doesn't match release version ({release_version})", file=sys.stderr)
+
+    if not valid:
+        sys.exit(1)
+
+
+if __name__ == '__main__': main()


### PR DESCRIPTION
This PR aims to prevent issues like https://github.com/GodotVR/godot_openxr_vendors/pull/327 and https://github.com/GodotVR/godot_openxr_vendors/pull/329 were created to fix

It adds a job before everything else in `build-addon-on-push.yml` that will check that the version numbers in the code are updated for release before making the release. I put it here, rather than `mavencentral-publish.yml`, because this workflow comes first and will actually create the release on GitHub. I suppose we could put it in both? I'm happy to make that change if other folks think it makes sense

I tested this a bunch on my fork, covering all branches, so it _should_ work when used in a real release, but we'll see :-)

NOTE: I couldn't use `if` on the new job together with having the "build" job have a dependency on it (via `needs`), because it would cause the "build" job to get skipped when the "release-guard" job was skipped. That's why it's running always, and checking if its running on a tag within the shell code