### PR TITLE
Implement XR_META_headset_id extension

### DIFF
--- a/doc_classes/OpenXRMetaHeadsetIDExtensionWrapper.xml
+++ b/doc_classes/OpenXRMetaHeadsetIDExtensionWrapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OpenXRMetaHeadsetIDExtensionWrapper" inherits="OpenXRExtensionWrapperExtension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Wraps the [code]XR_META_headset_id[/code] extension.
+	</brief_description>
+	<description>
+		Wraps the [code]XR_META_headset_id[/code] extension.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_headset_id">
+			<return type="String" />
+			<description>
+				Returns unique headset id string.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/plugin/src/main/cpp/extensions/openxr_meta_headset_id_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_meta_headset_id_extension_wrapper.cpp
@@ -1,0 +1,100 @@
+/**************************************************************************/
+/*  openxr_meta_headset_id_extension_wrapper.cpp                          */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "extensions/openxr_meta_headset_id_extension_wrapper.h"
+#include "godot_cpp/variant/packed_byte_array.hpp"
+#include "openxr/openxr.h"
+#include "util.h"
+
+#include <godot_cpp/classes/open_xrapi_extension.hpp>
+
+using namespace godot;
+
+OpenXRMetaHeadsetIDExtensionWrapper *OpenXRMetaHeadsetIDExtensionWrapper::singleton = nullptr;
+
+OpenXRMetaHeadsetIDExtensionWrapper *OpenXRMetaHeadsetIDExtensionWrapper::get_singleton() {
+	if (singleton == nullptr) {
+		singleton = memnew(OpenXRMetaHeadsetIDExtensionWrapper());
+	}
+	return singleton;
+}
+
+OpenXRMetaHeadsetIDExtensionWrapper::OpenXRMetaHeadsetIDExtensionWrapper() :
+		OpenXRExtensionWrapperExtension() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "An OpenXRMetaHeadsetIDExtensionWrapper singleton already exists.");
+
+	request_extensions[XR_META_HEADSET_ID_EXTENSION_NAME] = &meta_headset_id_ext;
+	singleton = this;
+}
+
+OpenXRMetaHeadsetIDExtensionWrapper::~OpenXRMetaHeadsetIDExtensionWrapper() {
+	cleanup();
+	singleton = nullptr;
+}
+
+godot::Dictionary OpenXRMetaHeadsetIDExtensionWrapper::_get_requested_extensions() {
+	godot::Dictionary result;
+	for (auto ext : request_extensions) {
+		godot::String key = ext.first;
+		uint64_t value = reinterpret_cast<uint64_t>(ext.second);
+		result[key] = (godot::Variant)value;
+	}
+	return result;
+}
+
+uint64_t OpenXRMetaHeadsetIDExtensionWrapper::_set_system_properties_and_get_next_pointer(void *p_next_pointer) {
+	if (meta_headset_id_ext) {
+		headset_id_properties.next = p_next_pointer;
+		p_next_pointer = &headset_id_properties;
+	}
+
+	return reinterpret_cast<uint64_t>(p_next_pointer);
+}
+
+void OpenXRMetaHeadsetIDExtensionWrapper::_on_instance_destroyed() {
+	cleanup();
+}
+
+String OpenXRMetaHeadsetIDExtensionWrapper::get_headset_id() {
+	ERR_FAIL_COND_V_MSG(!meta_headset_id_ext, "", "XR_META_headset_id extension is not enabled");
+
+	if (headset_id_string.is_empty()) {
+		headset_id_string = OpenXRUtilities::uuid_to_string_name(headset_id_properties.id);
+	}
+
+	return headset_id_string;
+}
+
+void OpenXRMetaHeadsetIDExtensionWrapper::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_headset_id"), &OpenXRMetaHeadsetIDExtensionWrapper::get_headset_id);
+}
+
+void OpenXRMetaHeadsetIDExtensionWrapper::cleanup() {
+	meta_headset_id_ext = false;
+}

--- a/plugin/src/main/cpp/include/extensions/openxr_meta_headset_id_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_meta_headset_id_extension_wrapper.h
@@ -1,0 +1,72 @@
+/**************************************************************************/
+/*  openxr_meta_headset_id_extension_wrapper.h                            */
+/**************************************************************************/
+/*                       This file is part of:                            */
+/*                              GODOT XR                                  */
+/*                      https://godotengine.org                           */
+/**************************************************************************/
+/* Copyright (c) 2022-present Godot XR contributors (see CONTRIBUTORS.md) */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <openxr/openxr.h>
+#include <godot_cpp/classes/open_xr_extension_wrapper_extension.hpp>
+#include <map>
+
+using namespace godot;
+
+class OpenXRMetaHeadsetIDExtensionWrapper : public OpenXRExtensionWrapperExtension {
+	GDCLASS(OpenXRMetaHeadsetIDExtensionWrapper, OpenXRExtensionWrapperExtension);
+
+public:
+	static OpenXRMetaHeadsetIDExtensionWrapper *get_singleton();
+
+	OpenXRMetaHeadsetIDExtensionWrapper();
+	~OpenXRMetaHeadsetIDExtensionWrapper();
+
+	godot::Dictionary _get_requested_extensions() override;
+
+	uint64_t _set_system_properties_and_get_next_pointer(void *p_next_pointer) override;
+	void _on_instance_destroyed() override;
+
+	String get_headset_id();
+
+protected:
+	static void _bind_methods();
+
+private:
+	void cleanup();
+
+	static OpenXRMetaHeadsetIDExtensionWrapper *singleton;
+
+	std::map<godot::String, bool *> request_extensions;
+	bool meta_headset_id_ext = false;
+
+	String headset_id_string;
+
+	XrSystemHeadsetIdPropertiesMETA headset_id_properties = {
+		XR_TYPE_SYSTEM_HEADSET_ID_PROPERTIES_META, // type
+		nullptr, // next
+		{} // id
+	};
+};

--- a/plugin/src/main/cpp/register_types.cpp
+++ b/plugin/src/main/cpp/register_types.cpp
@@ -74,6 +74,7 @@
 #include "extensions/openxr_htc_passthrough_extension_wrapper.h"
 #include "extensions/openxr_meta_boundary_visibility_extension_wrapper.h"
 #include "extensions/openxr_meta_environment_depth_extension_wrapper.h"
+#include "extensions/openxr_meta_headset_id_extension_wrapper.h"
 #include "extensions/openxr_meta_recommended_layer_resolution_extension_wrapper.h"
 #include "extensions/openxr_meta_simultaneous_hands_and_controllers_extension_wrapper.h"
 #include "extensions/openxr_meta_spatial_entity_mesh_extension_wrapper.h"
@@ -148,6 +149,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			GDREGISTER_CLASS(OpenXRFbSpatialEntityUserExtensionWrapper);
 			GDREGISTER_CLASS(OpenXRMetaRecommendedLayerResolutionExtensionWrapper);
 			GDREGISTER_CLASS(OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper);
+			GDREGISTER_CLASS(OpenXRMetaHeadsetIDExtensionWrapper);
 			GDREGISTER_CLASS(OpenXRMetaSpatialEntityMeshExtensionWrapper);
 			GDREGISTER_CLASS(OpenXRFbSceneExtensionWrapper);
 			GDREGISTER_CLASS(OpenXRFbFaceTrackingExtensionWrapper);
@@ -215,6 +217,10 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 
 			if (_get_bool_project_setting("xr/openxr/extensions/meta/body_tracking")) {
 				_register_extension_with_openxr(OpenXRFbBodyTrackingExtensionWrapper::get_singleton());
+			}
+
+			if (_get_bool_project_setting("xr/openxr/extensions/meta/headset_id")) {
+				_register_extension_with_openxr(OpenXRMetaHeadsetIDExtensionWrapper::get_singleton());
 			}
 
 			// All of the hand tracking extensions depend on the Godot hand tracking setting being set first.
@@ -291,6 +297,7 @@ void initialize_plugin_module(ModuleInitializationLevel p_level) {
 			_register_extension_as_singleton(OpenXRFbHandTrackingAimExtensionWrapper::get_singleton());
 			_register_extension_as_singleton(OpenXRFbHandTrackingCapsulesExtensionWrapper::get_singleton());
 			_register_extension_as_singleton(OpenXRMetaSimultaneousHandsAndControllersExtensionWrapper::get_singleton());
+			_register_extension_as_singleton(OpenXRMetaHeadsetIDExtensionWrapper::get_singleton());
 			_register_extension_as_singleton(OpenXRFbBodyTrackingExtensionWrapper::get_singleton());
 			_register_extension_as_singleton(OpenXRHtcFacialTrackingExtensionWrapper::get_singleton());
 			_register_extension_as_singleton(OpenXRHtcPassthroughExtensionWrapper::get_singleton());
@@ -433,6 +440,7 @@ void add_plugin_project_settings() {
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/color_space", true);
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/composition_layer_settings", true);
 	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/dynamic_resolution", true);
+	_add_bool_project_setting(project_settings, "xr/openxr/extensions/meta/headset_id", false);
 
 	// Only works with Godot 4.5 or later.
 	if (godot::internal::godot_version.minor >= 5) {


### PR DESCRIPTION
Implements the [`XR_META_headset_id`](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_META_headset_id) extension. Perhaps the simplest extension wrapper this repo will ever see! It just exposes a `get_headset_id()` function.