### PR TITLE
Fix Meta passthrough when rendering with "Separate" thread model

### DIFF
--- a/plugin/src/main/cpp/classes/openxr_meta_passthrough_color_lut.cpp
+++ b/plugin/src/main/cpp/classes/openxr_meta_passthrough_color_lut.cpp
@@ -44,7 +44,9 @@ void OpenXRMetaPassthroughColorLut::_bind_methods() {
 }
 
 OpenXRMetaPassthroughColorLut::~OpenXRMetaPassthroughColorLut() {
-	OpenXRFbPassthroughExtensionWrapper::get_singleton()->destroy_color_lut(this);
+	if (color_lut_handle.is_valid()) {
+		OpenXRFbPassthroughExtensionWrapper::get_singleton()->color_lut_free(color_lut_handle);
+	}
 }
 
 Ref<OpenXRMetaPassthroughColorLut> OpenXRMetaPassthroughColorLut::create_from_image(Ref<Image> p_image, ColorLutChannels p_channels) {
@@ -124,4 +126,7 @@ void OpenXRMetaPassthroughColorLut::populate_buffer(const Ref<Image> &p_image, C
 			}
 		}
 	}
+
+	color_lut_handle = OpenXRFbPassthroughExtensionWrapper::get_singleton()->color_lut_create(channels, image_cell_resolution, buffer);
+	;
 }

--- a/plugin/src/main/cpp/include/classes/openxr_fb_passthrough_geometry.h
+++ b/plugin/src/main/cpp/include/classes/openxr_fb_passthrough_geometry.h
@@ -34,8 +34,6 @@
 #include <godot_cpp/classes/mesh_instance3d.hpp>
 #include <godot_cpp/classes/node3d.hpp>
 
-#include <openxr/openxr.h>
-
 namespace godot {
 class OpenXRFbPassthroughGeometry : public Node3D {
 	GDCLASS(OpenXRFbPassthroughGeometry, Node3D)
@@ -52,7 +50,7 @@ private:
 
 	Ref<Mesh> mesh;
 	bool enable_hole_punch = true;
-	XrGeometryInstanceFB geometry_instance = XR_NULL_HANDLE;
+	RID geometry_instance;
 	MeshInstance3D *opaque_mesh = nullptr;
 
 protected:

--- a/plugin/src/main/cpp/include/classes/openxr_meta_passthrough_color_lut.h
+++ b/plugin/src/main/cpp/include/classes/openxr_meta_passthrough_color_lut.h
@@ -30,7 +30,6 @@
 #ifndef OPENXR_FB_PASSTHROUGH_COLOR_LUT_H
 #define OPENXR_FB_PASSTHROUGH_COLOR_LUT_H
 
-#include <openxr/openxr.h>
 #include <godot_cpp/classes/image.hpp>
 #include <godot_cpp/classes/ref_counted.hpp>
 
@@ -45,7 +44,7 @@ public:
 	};
 
 private:
-	XrPassthroughColorLutMETA color_lut_handle = XR_NULL_HANDLE;
+	RID color_lut_handle;
 	int image_cell_resolution = 0;
 	ColorLutChannels channels;
 	PackedByteArray buffer;
@@ -53,19 +52,18 @@ private:
 protected:
 	static void _bind_methods();
 
-	~OpenXRMetaPassthroughColorLut();
-
 	void populate_buffer(const Ref<Image> &p_image, ColorLutChannels p_channels);
 
 public:
 	static Ref<OpenXRMetaPassthroughColorLut> create_from_image(Ref<Image> p_image, ColorLutChannels p_channels);
 
-	void set_handle(XrPassthroughColorLutMETA p_handle) { color_lut_handle = p_handle; }
-	XrPassthroughColorLutMETA get_handle() const { return color_lut_handle; }
+	RID get_handle() const { return color_lut_handle; }
 
 	int get_image_cell_resolution() const { return image_cell_resolution; }
 	PackedByteArray get_buffer() const { return buffer; }
 	ColorLutChannels get_channels() const { return channels; }
+
+	~OpenXRMetaPassthroughColorLut();
 };
 } // namespace godot
 


### PR DESCRIPTION
Similar to https://github.com/GodotVR/godot_openxr_vendors/pull/339 this moves a bunch of stuff to the render thread to make it fully safe to use with the "Separate" thread model

However, unlike that other PR, I don't have a way to reliably cause a crash without the PR.

In fact, the old code is _mostly_ safe for enabling passthrough initially. However, there's theoretically issues with changing passthrough settings mid-way, destroying `OpenXRFbPassthroughGeometry` and `OpenXRMetaPassthroughColorLut`, or when leaving passthrough or quitting the app. This PR should fix all those theoretical issues, despite not having a reliable way to trigger any crashes due to them.