### PR TITLE
Miscellaneous SpaceWarp cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ local.properties
 # Misc
 compile_commands.json
 .DS_Store
+.cache
 /plugin/src/gen/
 /plugin/src/main/libs
 /zippedSamples

--- a/plugin/src/main/cpp/extensions/openxr_fb_space_warp_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_fb_space_warp_extension_wrapper.cpp
@@ -102,14 +102,6 @@ void OpenXRFbSpaceWarpExtensionWrapper::_on_session_created(uint64_t p_instance)
 	}
 
 	ProjectSettings *project_settings = ProjectSettings::get_singleton();
-	bool is_project_setting_enabled = (bool)project_settings->get_setting_with_override("xr/openxr/extensions/meta/application_space_warp");
-	if (!is_project_setting_enabled) {
-		fb_space_warp_ext = false;
-		return;
-	} else {
-		enabled = true;
-	}
-
 	String rendering_method = (String)project_settings->get_setting_with_override("rendering/renderer/rendering_method");
 	if (rendering_method == "forward_plus") {
 		UtilityFunctions::print_verbose("Disabling XR_FB_space_warp extension; this extension is not supported in the forward plus renderer");

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_space_warp_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_space_warp_extension_wrapper.h
@@ -76,7 +76,7 @@ private:
 
 	static OpenXRFbSpaceWarpExtensionWrapper *singleton;
 
-	bool enabled = false;
+	bool enabled = true;
 
 	XrSystemSpaceWarpPropertiesFB system_space_warp_properties = {
 		XR_TYPE_SYSTEM_SPACE_WARP_PROPERTIES_FB, // type

--- a/samples/meta-space-warp-sample/main.tscn
+++ b/samples/meta-space-warp-sample/main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=22 format=3 uid="uid://cqsodpswgup8w"]
+[gd_scene load_steps=25 format=3 uid="uid://cqsodpswgup8w"]
 
 [ext_resource type="Script" uid="uid://cxxy74r3njgxw" path="res://main.gd" id="1_fsva1"]
 [ext_resource type="Script" uid="uid://w3jfhbcsh0bl" path="res://multi_mesh_move.gd" id="3_h2yge"]
@@ -20,6 +20,18 @@ sky = SubResource("Sky_dqyx0")
 ambient_light_source = 2
 ambient_light_color = Color(0.270588, 0.270588, 0.270588, 1)
 tonemap_mode = 2
+
+[sub_resource type="PlaneMesh" id="PlaneMesh_lquwl"]
+size = Vector2(0.33, 0.075)
+orientation = 2
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_7mycd"]
+cull_mode = 2
+shading_mode = 0
+
+[sub_resource type="PlaneMesh" id="PlaneMesh_272bh"]
+size = Vector2(0.5, 0.3)
+orientation = 2
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_k604q"]
 
@@ -100,6 +112,11 @@ transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, -0.
 pixel_size = 0.001
 text = "[Analog Stick] Move"
 
+[node name="MeshInstance3D" type="MeshInstance3D" parent="XROrigin3D/LeftHand/Label3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -0.0012819469)
+mesh = SubResource("PlaneMesh_lquwl")
+surface_material_override/0 = SubResource("StandardMaterial3D_7mycd")
+
 [node name="RightHand" type="XRController3D" parent="XROrigin3D"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.478861, 0.468292, -0.241097)
 tracker = &"right_hand"
@@ -117,6 +134,11 @@ Space Warp: ENABLED
 [B] Toggle Turn Mode
 [A] Enable/Disable Space Warp
 [Analog Stick] Turn"
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="XROrigin3D/RightHand/Label3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -0.0012819469)
+mesh = SubResource("PlaneMesh_272bh")
+surface_material_override/0 = SubResource("StandardMaterial3D_7mycd")
 
 [node name="TurnTimer" type="Timer" parent="XROrigin3D"]
 wait_time = 0.2


### PR DESCRIPTION
Couple random things in this PR:
- Remove the unnecessary project setting check in the SpaceWarp extension wrapper's `_on_session_created()`.
- Add opaque meshes behind the `Label3D` nodes attached the player hands in the SpaceWarp sample project, when SpaceWarp is enabled these would produce a lot of artifacts because they're in the transparent pass, this just makes the sample look a little nicer.
- Add `.cache` to the gitignore