### PR TITLE
Clear `XRServer#remove_tracker` errors when closing the Godot editor

### DIFF
--- a/plugin/src/main/cpp/extensions/openxr_fb_body_tracking_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_fb_body_tracking_extension_wrapper.cpp
@@ -318,7 +318,7 @@ void OpenXRFbBodyTrackingExtensionWrapper::_on_session_destroyed() {
 	// Unregister the body tracker.
 	if (xr_body_tracker_registered) {
 		XRServer *xr_server = XRServer::get_singleton();
-		if (xr_server) {
+		if (xr_server && xr_body_tracker.is_valid()) {
 			xr_server->remove_tracker(xr_body_tracker);
 		}
 	}

--- a/plugin/src/main/cpp/extensions/openxr_fb_face_tracking_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_fb_face_tracking_extension_wrapper.cpp
@@ -149,7 +149,7 @@ void OpenXRFbFaceTrackingExtensionWrapper::_on_session_destroyed() {
 	// Unregister the face tracker.
 	if (xr_face_tracker_registered) {
 		XRServer *xr_server = XRServer::get_singleton();
-		if (xr_server) {
+		if (xr_server && xr_face_tracker.is_valid()) {
 			xr_server->remove_tracker(xr_face_tracker);
 		}
 	}

--- a/plugin/src/main/cpp/extensions/openxr_fb_hand_tracking_aim_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_fb_hand_tracking_aim_extension_wrapper.cpp
@@ -63,10 +63,12 @@ void OpenXRFbHandTrackingAimExtensionWrapper::cleanup() {
 	XRServer *xr_server = XRServer::get_singleton();
 
 	for (int i = 0; i < Hand::HAND_MAX; i++) {
-		if (xr_server != nullptr) {
-			xr_server->remove_tracker(trackers[i]);
+		if (trackers[i].is_valid()) {
+			if (xr_server != nullptr) {
+				xr_server->remove_tracker(trackers[i]);
+			}
+			trackers[i].unref();
 		}
-		trackers[i].unref();
 	}
 
 	fb_hand_tracking_aim_ext = false;

--- a/plugin/src/main/cpp/extensions/openxr_htc_facial_tracking_extension_wrapper.cpp
+++ b/plugin/src/main/cpp/extensions/openxr_htc_facial_tracking_extension_wrapper.cpp
@@ -170,7 +170,7 @@ void OpenXRHtcFacialTrackingExtensionWrapper::_on_session_destroyed() {
 	// Unregister the face tracker.
 	if (xr_face_tracker_registered) {
 		XRServer *xr_server = XRServer::get_singleton();
-		if (xr_server) {
+		if (xr_server && xr_face_tracker.is_valid()) {
 			xr_server->remove_tracker(xr_face_tracker);
 		}
 		xr_face_tracker_registered = false;


### PR DESCRIPTION
Addresses the following errors when the Godot editor is closed

```
XR: Clearing primary interface
ERROR: Condition "p_tracker.is_null()" is true.
   at: remove_tracker (servers/xr_server.cpp:345)
ERROR: Condition "p_tracker.is_null()" is true.
   at: remove_tracker (servers/xr_server.cpp:345)

```