### PR TITLE
Change `android.hardware.vr.headtracking` to `required="true"` when app is boundaryless

### DIFF
--- a/plugin/src/main/cpp/export/meta_export_plugin.cpp
+++ b/plugin/src/main/cpp/export/meta_export_plugin.cpp
@@ -449,6 +449,8 @@ String MetaEditorExportPlugin::_get_android_manifest_element_contents(const Ref<
 	int boundary_mode = _get_int_option("meta_xr_features/boundary_mode", BOUNDARY_ENABLED_VALUE);
 	if (boundary_mode == BOUNDARY_DISABLED_VALUE) {
 		contents += "    <uses-feature tools:node=\"replace\" android:name=\"com.oculus.feature.BOUNDARYLESS_APP\" android:required=\"true\" />\n";
+		// This overrides the default in plugin/src/main/AndroidManifest.xml, changing "required" to "true", which the Horizon store requires.
+		contents += "    <uses-feature android:name=\"android.hardware.vr.headtracking\" android:required=\"true\" android:version=\"1\" tools:node=\"replace\" />\n";
 	}
 
 	// Add camera permissions if needed.


### PR DESCRIPTION
Fixes https://github.com/GodotVR/godot_openxr_vendors/issues/363

Apparently, app uploads will be rejected by the Horizon store if they are marked as boundaryless, and don't have `android.hardware.vr.headtracking` with `required="true"`.

The original reporter tested making this change manually and it worked!

With this PR, it'll automatically make the change when an app is configured to be boundaryless