### PR TITLE
Allow passing `-PdoNotStrip=true` to prevent stripping libraries

### DIFF
--- a/config.gradle
+++ b/config.gradle
@@ -34,4 +34,8 @@ ext {
 
         return releaseVersion
     }
+
+    shouldNotStrip = { ->
+        return project.hasProperty("doNotStrip")
+    }
 }

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -138,6 +138,12 @@ android {
         pico.jniLibs.srcDirs += ["${khronosOpenxrLoaderTargetDir}/arm64-v8a"]
     }
 
+    packagingOptions {
+        if (shouldNotStrip()) {
+            doNotStrip '**/*.so'
+        }
+    }
+
     compileOptions {
         sourceCompatibility versions.javaVersion
         targetCompatibility versions.javaVersion


### PR DESCRIPTION
This is a follow-up to https://github.com/GodotVR/godot_openxr_vendors/pull/362

I had (incorrectly) thought that `-PdoNotStrip=true` was something Gradle supported automatically, but I guess it's something we have explicit support for in Godot's configuration. This basically brings that over into this extension as well.

I've tested this PR with my normal local development workflow using debug symbols, and that the .so's are properly stripped in the .aar's when this parameter is omitted.