### PR TITLE
Fix `OpenXRFbHandTrackingMesh` changes after startup and detecting when it's not supported

### DIFF
--- a/doc_classes/OpenXRFbHandTrackingMesh.xml
+++ b/doc_classes/OpenXRFbHandTrackingMesh.xml
@@ -35,11 +35,24 @@
 			[b]Note: This is a global value that applies to all [OpenXRFbHandTrackingMesh] nodes, which is only provided here for convenience.[/b]
 		</member>
 	</members>
+	<signals>
+		<signal name="openxr_fb_hand_tracking_mesh_ready">
+			<description>
+				Emitted when the hand tracking mesh is successfully loaded.
+			</description>
+		</signal>
+		<signal name="openxr_fb_hand_tracking_mesh_unavailable">
+			<description>
+				Emitted if the hand tracking mesh is unavailable, due to missing support or permissions.
+				You can use this signal to provide a fallback hand mesh.
+			</description>
+		</signal>
+	</signals>
 	<constants>
-		<constant name="Hand::HAND_LEFT" value="0" enum="Hand">
+		<constant name="HAND_LEFT" value="0" enum="Hand">
 			Left hand.
 		</constant>
-		<constant name="Hand::HAND_RIGHT" value="1" enum="Hand">
+		<constant name="HAND_RIGHT" value="1" enum="Hand">
 			Right hand.
 		</constant>
 	</constants>

--- a/doc_classes/OpenXRFbHandTrackingMeshExtensionWrapper.xml
+++ b/doc_classes/OpenXRFbHandTrackingMeshExtensionWrapper.xml
@@ -8,12 +8,4 @@
 	</description>
 	<tutorials>
 	</tutorials>
-	<signals>
-		<signal name="openxr_fb_hand_tracking_mesh_data_fetched">
-			<param index="0" name="hand_index" type="int" />
-			<description>
-				Emitted when the mesh data has been fetched for the given hand ([code]0[/code] is left, and [code]1[/code] is right).
-			</description>
-		</signal>
-	</signals>
 </class>

--- a/plugin/src/main/cpp/include/classes/openxr_fb_hand_tracking_mesh.h
+++ b/plugin/src/main/cpp/include/classes/openxr_fb_hand_tracking_mesh.h
@@ -50,7 +50,7 @@ private:
 
 	MeshInstance3D *mesh_instance = nullptr;
 
-	void setup_hand_mesh(Hand p_hand);
+	void setup_hand_mesh(const Ref<Mesh> &p_hand_mesh);
 
 protected:
 	void _notification(int p_what);

--- a/plugin/src/main/cpp/include/extensions/openxr_fb_hand_tracking_mesh_extension_wrapper.h
+++ b/plugin/src/main/cpp/include/extensions/openxr_fb_hand_tracking_mesh_extension_wrapper.h
@@ -75,9 +75,7 @@ public:
 	void set_scale_override(Hand p_hand, float p_scale);
 	float get_scale_override(Hand p_hand) const;
 
-	void enable_fetch_hand_mesh_data();
-	bool fetch_hand_mesh_data(Hand p_hand);
-	Ref<ArrayMesh> get_mesh(Hand p_hand);
+	void request_hand_mesh_data(Hand p_hand, const Callable &p_callback);
 	void construct_skeleton(Skeleton3D *r_skeleton);
 	void reset_skeleton_pose(Hand p_hand, Skeleton3D *r_skeleton);
 
@@ -102,10 +100,18 @@ private:
 
 	bool fb_hand_tracking_mesh_ext = false;
 
+	struct FetchCallback {
+		Hand hand;
+		Callable callable;
+	};
+	LocalVector<FetchCallback> fetch_callbacks;
+
 	bool should_fetch_hand_mesh_data = false;
 	Ref<ArrayMesh> hand_mesh[Hand::HAND_MAX];
 	BoneData bone_data[Hand::HAND_MAX];
 	XrHandTrackingScaleFB hand_tracking_scale[Hand::HAND_MAX];
+
+	bool fetch_hand_mesh_data(Hand p_hand);
 };
 
 #endif // OPENXR_FB_HAND_TRACKING_MESH_EXTENSION_WRAPPER_H


### PR DESCRIPTION
This aims to fix some issues I found with using `OpenXRFbHandTrackingMesh` in my recent [jam game](https://dsnopek.itch.io/rock-paper-infinity):

- If you have some `OpenXRFbHandTrackingMesh`s added at startup, but then add another `OpenXRFbHandTrackingMesh` later on, it'll never get its mesh populated
- If you change the `hand` property after its mesh has already been loaded, it won't switch to the other hand mesh
- There's no _good_ way to detect if this extension is enabled and loading the hash mesh has succeeded. This makes it hard to automatically use a fallback hand mesh when run on platforms that don't support the extension (it is possible to do in a hacky way, but there should be an "official" way)

Fixes https://github.com/GodotVR/godot_openxr_vendors/issues/352