### PR TITLE
Copy XrUuid <-> String conversions from Godot Core

### DIFF
--- a/plugin/src/main/cpp/classes/openxr_fb_scene_manager.cpp
+++ b/plugin/src/main/cpp/classes/openxr_fb_scene_manager.cpp
@@ -376,7 +376,7 @@ Array OpenXRFbSceneManager::get_anchor_uuids() const {
 XRAnchor3D *OpenXRFbSceneManager::get_anchor_node(const StringName &p_uuid) const {
 	ERR_FAIL_COND_V(!anchors_created, nullptr);
 
-	const Anchor *anchor = anchors.getptr(p_uuid);
+	const Anchor *anchor = anchors.getptr(String(p_uuid).remove_char('-'));
 	if (anchor) {
 		return Object::cast_to<XRAnchor3D>(ObjectDB::get_instance(anchor->node));
 	}
@@ -387,7 +387,7 @@ XRAnchor3D *OpenXRFbSceneManager::get_anchor_node(const StringName &p_uuid) cons
 Ref<OpenXRFbSpatialEntity> OpenXRFbSceneManager::get_spatial_entity(const StringName &p_uuid) const {
 	ERR_FAIL_COND_V(!anchors_created, nullptr);
 
-	const Anchor *anchor = anchors.getptr(p_uuid);
+	const Anchor *anchor = anchors.getptr(String(p_uuid).remove_char('-'));
 	if (anchor) {
 		return anchor->entity;
 	}

--- a/plugin/src/main/cpp/classes/openxr_fb_spatial_anchor_manager.cpp
+++ b/plugin/src/main/cpp/classes/openxr_fb_spatial_anchor_manager.cpp
@@ -198,11 +198,13 @@ void OpenXRFbSpatialAnchorManager::_on_anchor_created(bool p_success, const Tran
 void OpenXRFbSpatialAnchorManager::load_anchor(const StringName &p_uuid, const Dictionary &p_custom_data, OpenXRFbSpatialEntity::StorageLocation p_location) {
 	ERR_FAIL_COND(!xr_origin);
 
+	StringName uuid = String(p_uuid).remove_char('-');
+
 	Array uuids;
-	uuids.push_back(p_uuid);
+	uuids.push_back(uuid);
 
 	Dictionary data;
-	data[p_uuid] = p_custom_data;
+	data[uuid] = p_custom_data;
 
 	Ref<OpenXRFbSpatialEntityQuery> query;
 	query.instantiate();
@@ -227,13 +229,17 @@ void OpenXRFbSpatialAnchorManager::load_anchors(const TypedArray<StringName> &p_
 		// In order for this to work correctly, we need to make sure that all UUIDs are present
 		// on the custom data dictionary (and no others).
 		for (int i = 0; i < p_uuids.size(); i++) {
-			all_custom_data[p_uuids[i]] = p_all_custom_data.get(p_uuids[i], Dictionary());
+			all_custom_data[String(p_uuids[i]).remove_char('-')] = p_all_custom_data.get(p_uuids[i], Dictionary());
 		}
 	} else {
 		// Otherwise, we just query the specific anchors we know about.
 		query->query_by_uuid(p_uuids, p_location);
 		query->set_max_results(p_uuids.size());
-		all_custom_data = p_all_custom_data;
+
+		Array custom_data_keys = p_all_custom_data.keys();
+		for (int i = 0; i < custom_data_keys.size(); i++) {
+			all_custom_data[String(custom_data_keys[i]).remove_char('-')] = p_all_custom_data[custom_data_keys[i]];
+		}
 	}
 
 	query->connect("openxr_fb_spatial_entity_query_completed", callable_mp(this, &OpenXRFbSpatialAnchorManager::_on_anchor_load_query_completed).bind(all_custom_data, p_location, p_erase_unknown_anchors));
@@ -332,7 +338,7 @@ void OpenXRFbSpatialAnchorManager::untrack_anchor(const Variant &p_spatial_entit
 		ERR_FAIL_COND(spatial_entity.is_null());
 		uuid = spatial_entity->get_uuid();
 	} else if (p_spatial_entity_or_uuid.get_type() == Variant::STRING || p_spatial_entity_or_uuid.get_type() == Variant::STRING_NAME) {
-		uuid = p_spatial_entity_or_uuid;
+		uuid = String(p_spatial_entity_or_uuid).remove_char('-');
 	} else {
 		ERR_FAIL_MSG("Invalid argument passed to OpenXRFbSpatialAnchorManager::untrack_anchor().");
 	}
@@ -393,7 +399,7 @@ Array OpenXRFbSpatialAnchorManager::get_anchor_uuids() const {
 }
 
 XRAnchor3D *OpenXRFbSpatialAnchorManager::get_anchor_node(const StringName &p_uuid) const {
-	const Anchor *anchor = anchors.getptr(p_uuid);
+	const Anchor *anchor = anchors.getptr(String(p_uuid).remove_char('-'));
 	if (anchor) {
 		return Object::cast_to<XRAnchor3D>(ObjectDB::get_instance(anchor->node));
 	}
@@ -402,7 +408,7 @@ XRAnchor3D *OpenXRFbSpatialAnchorManager::get_anchor_node(const StringName &p_uu
 }
 
 Ref<OpenXRFbSpatialEntity> OpenXRFbSpatialAnchorManager::get_spatial_entity(const StringName &p_uuid) const {
-	const Anchor *anchor = anchors.getptr(p_uuid);
+	const Anchor *anchor = anchors.getptr(String(p_uuid).remove_char('-'));
 	if (anchor) {
 		return anchor->entity;
 	}

--- a/plugin/src/main/cpp/classes/openxr_fb_spatial_entity_query.cpp
+++ b/plugin/src/main/cpp/classes/openxr_fb_spatial_entity_query.cpp
@@ -162,7 +162,7 @@ bool OpenXRFbSpatialEntityQuery::_execute_query_by_uuid() {
 	LocalVector<XrUuidEXT> uuid_array;
 	uuid_array.resize(uuids.size());
 	for (int i = 0; i < uuids.size(); i++) {
-		PackedByteArray uuid_data = String(uuids[i]).replace("-", "").hex_decode();
+		PackedByteArray uuid_data = String(uuids[i]).remove_char('-').hex_decode();
 		ERR_CONTINUE_MSG(uuid_data.size() != 16, vformat("Invalid UUID: %s", uuids[i]));
 		memcpy(uuid_array[i].data, uuid_data.ptr(), 16);
 	}

--- a/plugin/src/main/cpp/util.cpp
+++ b/plugin/src/main/cpp/util.cpp
@@ -31,57 +31,49 @@
 
 #include <openxr/internal/xr_linear.h>
 #include <openxr/openxr.h>
-#include <stdio.h>
 #include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/core/error_macros.hpp>
-#include <godot_cpp/variant/packed_string_array.hpp>
 #include <godot_cpp/variant/projection.hpp>
 
 using namespace godot;
 
-namespace {
-bool hexchar_to_uint8(uint8_t &out, char32_t hexchar) {
-	if (U'0' <= hexchar && hexchar <= U'9') {
-		out = hexchar - U'0';
-		return true;
-	}
-
-	if (U'a' <= hexchar && hexchar <= U'f') {
-		out = 10 + (hexchar - U'a');
-		return true;
-	}
-
-	return false;
-}
-
-bool hexchars_to_uint8(uint8_t &ret, char32_t hexchar0, char32_t hexchar1) {
-	// ab
-	// ||
-	// |hexchar1
-	// hexchar0
-	uint8_t d0;
-	uint8_t d1;
-	if (!hexchar_to_uint8(d0, hexchar0) || !hexchar_to_uint8(d1, hexchar1)) {
-		return false;
-	}
-
-	ret = (d0 * 16) + d1;
-	return true;
-}
-} //namespace
-
 StringName OpenXRUtilities::uuid_to_string_name(const XrUuid &p_uuid) {
-	const uint8_t *data = p_uuid.data;
-	char uuid_str[37];
+	// This code was originally copied from
+	// godot core's modules/openxr/openxr_util.cpp, OpenXRUtil::string_from_xruuid()
+	// to ensure identical output.
+	// It was then modified to use a char[] buffer for efficiency.
 
-	sprintf(uuid_str, "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
-			data[0], data[1], data[2], data[3],
-			data[4], data[5],
-			data[6], data[7],
-			data[8], data[9],
-			data[10], data[11], data[12], data[13], data[14], data[15]);
+	// +1 for null terminator
+	char ret[XR_UUID_SIZE * 2 + 1];
+	char *ret_ptr = &ret[0];
+	bool is_zero = true;
 
-	return StringName(uuid_str);
+	for (int i = 0; i < XR_UUID_SIZE; i++) {
+		ERR_FAIL_COND_V(XR_UUID_SIZE * 2 <= ret_ptr - &ret[0], "");
+
+		is_zero = is_zero && p_uuid.data[i] == 0;
+
+		char a = (p_uuid.data[i] & 0xF0) >> 4;
+		char b = p_uuid.data[i] & 0x0F;
+
+		if (a < 10) {
+			*ret_ptr = '0' + a;
+		} else {
+			*ret_ptr = 'a' + a - 10;
+		}
+
+		++ret_ptr;
+		if (b < 10) {
+			*ret_ptr = '0' + b;
+		} else {
+			*ret_ptr = 'a' + b - 10;
+		}
+
+		++ret_ptr;
+	}
+
+	ret[XR_UUID_SIZE * 2] = '\0';
+	return is_zero ? "" : String(ret);
 }
 
 void OpenXRUtilities::xrMatrix4x4f_to_godot_projection(XrMatrix4x4f *m, godot::Projection &p) {
@@ -110,47 +102,53 @@ Vector3 OpenXRUtilities::XrVector3f_to_godot_vector3(const XrVector3f &vector) {
 }
 
 XrUuid OpenXRUtilities::string_name_to_uuid(const StringName &p_uuid_str) {
-	// expecting p_uuid_str of the form: "ffffffff-ffff-ffff-ffff-ffffffffffff"
-	// note that we expect the uuid to be all lowercase (so A, B, C, D, E, and F are invalid)
+	// This code was copied from
+	// godot core's modules/openxr/openxr_util.cpp, OpenXRUtil::xruuid_from_string()
+	// to ensure identical output.
+	// It was then modified to handle uuids with hyphens.
+	String uuid = p_uuid_str;
+	XrUuid new_uuid = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
-	// expecting a string generated from uuid_to_string_name(), which has 36 characters
-	if (p_uuid_str.length() != 36) {
-		return XrUuid{};
+	int len = uuid.length();
+	if (len == 0) {
+		return new_uuid;
+	} else if (len != (2 * XR_UUID_SIZE)) {
+		// For compatibility, accept uuid strings that contain
+		// hyphens, like: "ffffffff-ffff-ffff-ffff-ffffffffffff"
+		uuid = uuid.remove_char('-');
+		len = uuid.length();
+		if (len != (2 * XR_UUID_SIZE)) {
+			WARN_PRINT("OpenXR: Unexpected UUID length: " + String::num_int64(len) + " != " + String::num_int64(2 * XR_UUID_SIZE));
+		}
 	}
 
-	// expecting a string generated from uuid_to_string_name(), which has 5 chunks
-	PackedStringArray strs = p_uuid_str.split("-");
-	if (strs.size() != 5 || strs[0].length() != 8 || strs[1].length() != 4 || strs[2].length() != 4 || strs[3].length() != 4 || strs[4].length() != 12) {
-		return XrUuid{};
+	int j = 0;
+	const char32_t *uuid_ptr = uuid.ptr();
+	for (int i = 0; i < XR_UUID_SIZE; i++) {
+		uint8_t val = 0;
+
+		// 2 chars per byte.
+		for (int k = 0; k < 2; k++) {
+			if (j < len) {
+				val <<= 4;
+
+				char32_t c = uuid_ptr[j++];
+				if (c >= '0' && c <= '9') {
+					val += uint8_t(c - '0');
+				} else if (c >= 'a' && c <= 'f') {
+					val += uint8_t(10 + c - 'a');
+				} else if (c >= 'A' && c <= 'F') {
+					val += uint8_t(10 + c - 'A');
+				} else {
+					WARN_PRINT("OpenXR: Unexpected character in UUID: " + String::num_int64(c));
+				}
+			}
+		}
+
+		new_uuid.data[i] = val;
 	}
 
-	XrUuid ret;
-	uint8_t *data = &ret.data[0];
-	const char32_t *chunk0{ strs[0].ptr() };
-	const char32_t *chunk1{ strs[1].ptr() };
-	const char32_t *chunk2{ strs[2].ptr() };
-	const char32_t *chunk3{ strs[3].ptr() };
-	const char32_t *chunk4{ strs[4].ptr() };
-	if (!hexchars_to_uint8(data[0], chunk0[0], chunk0[1]) ||
-			!hexchars_to_uint8(data[1], chunk0[2], chunk0[3]) ||
-			!hexchars_to_uint8(data[2], chunk0[4], chunk0[5]) ||
-			!hexchars_to_uint8(data[3], chunk0[6], chunk0[7]) ||
-			!hexchars_to_uint8(data[4], chunk1[0], chunk1[1]) ||
-			!hexchars_to_uint8(data[5], chunk1[2], chunk1[3]) ||
-			!hexchars_to_uint8(data[6], chunk2[0], chunk2[1]) ||
-			!hexchars_to_uint8(data[7], chunk2[2], chunk2[3]) ||
-			!hexchars_to_uint8(data[8], chunk3[0], chunk3[1]) ||
-			!hexchars_to_uint8(data[9], chunk3[2], chunk3[3]) ||
-			!hexchars_to_uint8(data[10], chunk4[0], chunk4[1]) ||
-			!hexchars_to_uint8(data[11], chunk4[2], chunk4[3]) ||
-			!hexchars_to_uint8(data[12], chunk4[4], chunk4[5]) ||
-			!hexchars_to_uint8(data[13], chunk4[6], chunk4[7]) ||
-			!hexchars_to_uint8(data[14], chunk4[8], chunk4[9]) ||
-			!hexchars_to_uint8(data[15], chunk4[10], chunk4[11])) {
-		return XrUuid{};
-	}
-
-	return ret;
+	return new_uuid;
 }
 
 bool OpenXRUtilities::supports_runtime_permissions() {


### PR DESCRIPTION
Copy the code used to convert strings to and from `XrUuid`, from https://github.com/godotengine/godot/blob/master/modules/openxr/openxr_util.cpp to ensure identical output.

Previously the godot_openxr_vendors version inserted and expected hyphens.  The hyphens could cause confusion when the stringified uuids from core were converted to XrUuid in godot_openxr_vendors, or when the stringified uuids from godot_openxr_vendors were given to core.

@dsnopek @m4gr3d I tested Android XR trackables and scene meshing.  I'll need help testing the Facebook and Meta samples that use uuids.  I looked through the code and it looks like the uuids are mainly user facing.  I also see them used keys in a dictionary, which should be okay.